### PR TITLE
OIIO attribute "plugins_override" 

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2498,6 +2498,11 @@ OIIO_API std::string geterror(bool clear = true);
 ///    Colon-separated (or semicolon-separated) list of directories to search
 ///    for dynamically-loaded format plugins.
 ///
+/// - `int plugins_override`
+///
+///    If nonzero, plugins will have higher priority and override built-in
+///    format readers/writers for a given format.
+///
 /// - `int read_chunk`
 ///
 ///    When performing a `read_image()`, this is the number of scanlines it

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -56,6 +56,7 @@ int oiio_print_debug(oiio_debug_env ? Strutil::stoi(oiio_debug_env) : 1);
 int oiio_log_times = Strutil::from_string<int>(
     Sysutil::getenv("OPENIMAGEIO_LOG_TIMES"));
 std::vector<float> oiio_missingcolor;
+bool plugins_override = false;  // plugins override builtins
 }  // namespace pvt
 
 using namespace pvt;
@@ -354,6 +355,10 @@ attribute(string_view name, TypeDesc type, const void* val)
             *(const char**)val);
         return true;
     }
+    if (name == "plugins_override" && type == TypeDesc::TypeInt) {
+        plugins_override = *(const int*)val;
+        return true;
+    }
 
     return false;
 }
@@ -378,6 +383,10 @@ getattribute(string_view name, TypeDesc type, void* val)
     }
     if (name == "plugin_searchpath" && type == TypeString) {
         *(ustring*)val = plugin_searchpath;
+        return true;
+    }
+    if (name == "plugins_override" && type == TypeInt) {
+        *(int*)val = plugins_override;
         return true;
     }
     if (name == "format_list" && type == TypeString) {

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -27,6 +27,7 @@ extern atomic_int oiio_threads;
 extern atomic_int oiio_read_chunk;
 extern ustring font_searchpath;
 extern ustring plugin_searchpath;
+extern bool plugins_override;
 extern std::string format_list;
 extern std::string input_format_list;
 extern std::string output_format_list;


### PR DESCRIPTION
OIIO attribute "plugins_override" causes externally found plugins to override
built-in plugins with the same name (instead of the default of built-in
plugins always winning).  Also can be overridden with the
OIIO_PLUGINS_OVERRIDE environment variable.
