### PR TITLE
fix: text rendering did not work correctly with alpha

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -1078,7 +1078,9 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
         // If the buffer doesn't have an alpha, but the text color passed
         // has 4 values, assume the last value is supposed to be alpha.
         textalpha = textcolor[3];
-    }
+        alpha_channel = 3;
+    } else
+        alpha_channel = -1;
 
     // Convert the UTF to 32 bit unicode
     std::vector<uint32_t> utext;
@@ -1162,8 +1164,14 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
         float val   = t[0];
         float alpha = a[0] * textalpha;
         R.getpixel(r.x(), r.y(), pixelcolor);
-        for (int c = 0; c < nchannels; ++c)
-            pixelcolor[c] = val * textcolor[c] + (1.0f - alpha) * pixelcolor[c];
+        if (alpha == 0.0)
+            continue;
+        for (int c = 0; c < nchannels; ++c) {
+            if (c == alpha_channel)
+                pixelcolor[c] = alpha + (1.0f - alpha) * pixelcolor[c];
+            else 
+                pixelcolor[c] = (val * alpha * textcolor[c]) + (1.0f - alpha) * pixelcolor[c];
+        }
         R.setpixel(r.x(), r.y(), pixelcolor);
     }
 


### PR DESCRIPTION
As render text with shadow with channel alpha, I don't get the same result that without channel alpha.

Without channel alpha, shadow option permit to draw a dilated text in black, whereas with channel alpha, OIIO makes a gap...

Working with dev-2.2 branch, I can see the same issue on master branch.

In using this patch, shadow option works as expected on image with alpha buffer.

Ref: #3932 

[Note]: OpenImageIO is used in the [gpx2video project](https://github.com/progweb/gpx2video).