### PR TITLE
fix(exr): don't suppress "oiio:ColorSpace" attribute on output

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -967,7 +967,8 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
     if (Strutil::istarts_with(xname, "oiio:")) {
         if (Strutil::iequals(xname, "oiio:ConstantColor")
             || Strutil::iequals(xname, "oiio:AverageColor")
-            || Strutil::iequals(xname, "oiio:SHA-1")) {
+            || Strutil::iequals(xname, "oiio:SHA-1")
+            || Strutil::iequals(xname, "oiio:ColorSpace")) {
             // let these fall through and get stored as metadata
         } else {
             // Other than the listed exceptions, suppress any other custom


### PR DESCRIPTION
It looks like for some time setting the "oiio:ColorSpace" attribute when outputting an openexr file just got dropped on the floor. I don't think this was the original intended thing to do.

I'm adding it mainly as a short-term band-aid. I think in the long term, it is better to have a cross-project/industry consensus on how to express color space in an exr file, and to coordinate OpenEXR + OpenImageIO + OpenColorIO + DCCs about any necessary conventions. I will open a separate discussion about that. 

But in the mean time, maybe this fix helps avoid the problem of having total amnesia about the color space information when we do a "OIIO write exr -> file -> OIIO read exr" round trip.


