### PR TITLE
Use modern FindPython from CMake 3.12

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -156,8 +156,7 @@ else ()
     message (STATUS "Using internal PugiXML")
 endif()
 
-# From pythonutils.cmake
-find_python()
+find_package(Python COMPONENTS Interpreter Development)
 
 
 ###########################################################################

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -4,7 +4,6 @@
 
 # Python-related options.
 option (USE_PYTHON "Build the Python bindings" ON)
-set (PYTHON_VERSION "" CACHE STRING "Target version of python to find")
 option (PYLIB_INCLUDE_SONAME "If ON, soname/soversion will be set for Python module library" OFF)
 option (PYLIB_LIB_PREFIX "If ON, prefix the Python module with 'lib'" OFF)
 set (PYMODULE_SUFFIX "" CACHE STRING "Suffix to add to Python module init namespace")
@@ -13,49 +12,6 @@ if (WIN32)
 else ()
     set (PYLIB_LIB_TYPE MODULE CACHE STRING "Type of library to build for python module (MODULE or SHARED)")
 endif ()
-
-
-# Find Python. This macro should only be called if python is required. If
-# Python cannot be found, it will be a fatal error.
-macro (find_python)
-    if (NOT VERBOSE)
-        set (PythonInterp_FIND_QUIETLY true)
-        set (PythonLibs_FIND_QUIETLY true)
-    endif ()
-
-    # Attempt to find the desired version, but fall back to other
-    # additional versions.
-    unset (_req)
-    if (USE_PYTHON)
-        set (_req REQUIRED)
-        if (PYTHON_VERSION)
-            list (APPEND _req EXACT)
-        endif ()
-    endif ()
-    checked_find_package (Python ${PYTHON_VERSION}
-                          ${_req}
-                          COMPONENTS Interpreter Development
-                          PRINT Python_VERSION Python_EXECUTABLE
-                                Python_LIBRARIES
-                                Python_Development_FOUND
-                                Python_Interpreter_FOUND )
-
-    # The version that was found may not be the default or user
-    # defined one.
-    set (PYTHON_VERSION_FOUND ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR})
-
-    # Give hints to subsequent pybind11 searching to ensure that it finds
-    # exactly the same version that we found.
-    set (PythonInterp_FIND_VERSION PYTHON_VERSION_FOUND)
-    set (PythonInterp_FIND_VERSION_MAJOR ${Python_VERSION_MAJOR})
-
-    if (NOT DEFINED PYTHON_SITE_DIR)
-        set (PYTHON_SITE_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_FOUND}/site-packages/OpenImageIO")
-    endif ()
-    message (VERBOSE "    Python site packages dir ${PYTHON_SITE_DIR}")
-    message (VERBOSE "    Python to include 'lib' prefix: ${PYLIB_LIB_PREFIX}")
-    message (VERBOSE "    Python to include SO version: ${PYLIB_INCLUDE_SONAME}")
-endmacro()
 
 
 ###########################################################################
@@ -133,10 +89,10 @@ macro (setup_python_module)
             )
 
     install (TARGETS ${target_name}
-             RUNTIME DESTINATION ${PYTHON_SITE_DIR} COMPONENT user
-             LIBRARY DESTINATION ${PYTHON_SITE_DIR} COMPONENT user)
+             RUNTIME DESTINATION ${Python_SITELIB} COMPONENT user
+             LIBRARY DESTINATION ${Python_SITELIB} COMPONENT user)
 
-    install(FILES __init__.py DESTINATION ${PYTHON_SITE_DIR})
+    install(FILES __init__.py DESTINATION ${Python_SITELIB})
 
 endmacro ()
 


### PR DESCRIPTION
This really helps with cross compilation and virtual environments

The minimum CMake Version is already 3.15

xref: https://github.com/conda-forge/openimageio-feedstock/pull/87
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
