### PR TITLE
build: Don't fail for 32 bit builds because of static_assert check

### DIFF
--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -567,9 +567,11 @@ struct TileID {
         static_assert(
             sizeof(*this) == member_size,
             "All TileID members must be accounted for so we can hash the entire class.");
+#ifdef __LP64__
         static_assert(
             sizeof(*this) % sizeof(uint64_t) == 0,
             "FastHash uses the fewest instructions when data size is a multiple of 8 bytes.");
+#endif
         return fasthash::fasthash64(this, sizeof(*this));
     }
 


### PR DESCRIPTION
A static_assert was added recently as part of PR #3898, which assures that the size of a TileID is a multiple of 8 bytes. But on architectures with 32 bit pointers, this assertion fails. Which is not quite what we want, because the code isn't wrong if the struct isn't a multiple of 8 bytes; it's just less efficient. And we don't want to fail for 32 bit arch.

Bottom line: only do this check to ensure we're in the most efficient case if we're 64 bits. Nobody's expecting highest performance on a 32 bit machine anyway.

Fixes #4001
