### PR TITLE
fix(exr): suppress exr attributes that interfere with our hints

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -647,6 +647,8 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
         if (!mipmap) {
             // Send hint to OpenEXR driver that we won't specify a MIPmap
             outspec.attribute("openexr:levelmode", 0 /* ONE_LEVEL */);
+        } else {
+            outspec.erase_attribute("openexr:levelmode");
         }
         // OpenEXR always uses border sampling for environment maps
         if (envlatlmode) {


### PR DESCRIPTION
Our exr writer uses some special hints starting with "openexr:" to control aspects of the writing, and the reader sets these to communicate some things about the file it's reading.

But what happens if... the actual exr file has metadata of tha same name. Oops, those get carried along and mess with things. We had previously accounted for this by suppressing arbitrary metaname named "openexr:lineOrder" if we find it in the input (the actual lineorder comes from a header field, not named metadata, but OIIO uses the name "openexr:lineOrder" to communicate it back as metadata.

Turns out that there are two more that we need to proactively suppress: "openexr:levelmode" and "openexr:roundingmode". There's no good reason for those to ever be in an exr file (like I said, those names are NOT how openexr itself sets those in a file). And yet, we found at least one example in the wile where it was.
