### PR TITLE
fix: to_OpenCV fails for ImageCache-backed images

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -343,12 +343,10 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
 
     size_t pixelsize = dstSpecFormat.size() * chans;
     size_t linestep  = pixelsize * roi.width();
-    bool converted   = parallel_convert_image(
-        chans, roi.width(), roi.height(), 1,
-        src.pixeladdr(roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
-        spec.format, spec.pixel_bytes(), spec.scanline_bytes(), 0, dst.ptr(),
-        dstSpecFormat, pixelsize, linestep, 0, -1, -1, nthreads);
-
+    // Make an IB that wraps the OpenCV buffer, then IBA:: copy to it
+    ImageBuf cvib(ImageSpec(roi.width(), roi.height(), chans, dstSpecFormat),
+                  dst.ptr(), pixelsize, linestep, AutoStride);
+    bool converted = ImageBufAlgo::copy(cvib, src);
     if (!converted) {
         OIIO::pvt::errorfmt(
             "to_OpenCV() was unable to convert source {} to cv::Mat of {}",


### PR DESCRIPTION
We were using parallel_convert_image but not realizing that asking for the IB::localpixels() would give us nullptr for an IC-backed image.

Instead, "wrap" the cv::Mat with an IB and then use IBA::copy().  This handles both in-memory and IC-backed ImageBuf's, and also has many other advantages (such as format conversion) we may wish to take advantage of in the future.

Fixes #3800 