### PR TITLE
cmake/compiler.cmake: provide compile_commands.json for use by tools

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -622,6 +622,10 @@ else ()
 endif ()
 
 
+###########################################################################
+# Generate compile_commands.json for use by editors and tools.
+set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 
 ###########################################################################
 # Macro to install targets to the appropriate locations.  Use this instead


### PR DESCRIPTION
## Description

`compile_commands.json` allows LSPs and other tools to better interact with the code.
## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (N/A)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary). (N/A)
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
