### PR TITLE
idiff: allow users to specify a directory as the 2nd argument

### DIFF
--- a/src/doc/idiff.rst
+++ b/src/doc/idiff.rst
@@ -26,11 +26,14 @@ Using `idiff`
 
 The `idiff` utility is invoked as follows:
 
-    `idiff` [*options*] *image1* *image2*
+    `idiff` [*options*] *input1* *input2|directory*
 
 Where *input1* and *input2* are the names of two image files that should be
 compared.  They may be of any format recognized by OpenImageIO (i.e., for
 which image-reading plugins are available).
+
+When a *directory* is specified instead of *input2* then `idiff` will use
+the same-named file as *input1* in the specified directory.
 
 If the two input images are not the same resolutions, or do not have the
 same number of channels, the comparison will return FAILURE immediately and

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -43,7 +43,7 @@ getargs(int argc, char* argv[])
     ArgParse ap;
     ap.intro("idiff -- compare two images\n"
              OIIO_INTRO_STRING)
-      .usage("idiff [options] image1 image2")
+      .usage("idiff [options] <image1> <image2 | directory>")
       .add_version(OIIO_VERSION_STRING)
       .print_defaults(true);
 

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -169,6 +169,24 @@ print_subimage(ImageBuf& img0, int subimage, int miplevel)
 }
 
 
+// Append the filename from "first" when "second" is a directory.
+// "second" is an output variable and modified in-place.
+inline void
+add_filename_to_directory(const std::string& first, std::string& second)
+{
+    if (Filesystem::is_directory(second)) {
+        char last_byte = second.at(second.size() - 1);
+        if (last_byte != '/' && last_byte != '\\') {
+#if defined(_MSC_VER)
+            second += '\\';
+#else
+            second += '/';
+#endif
+        }
+        second += Filesystem::filename(first);
+    }
+}
+
 
 int
 main(int argc, char* argv[])
@@ -181,7 +199,9 @@ main(int argc, char* argv[])
     ArgParse ap = getargs(argc, argv);
 
     std::vector<std::string> filenames = ap["filename"].as_vec<std::string>();
-    if (filenames.size() != 2) {
+    if (filenames.size() == 2) {
+        add_filename_to_directory(filenames[0], filenames[1]);
+    } else {
         print(stderr, "idiff: Must have two input filenames.\n");
         print(stderr, "> {}\n", Strutil::join(filenames, ", "));
         ap.usage();


### PR DESCRIPTION
## Description

Teach `idiff` to accept a directory as the 2nd argument.

Fixes #4009

## Tests

Functional tests for `idiff` don't currently exist. Manual testing verifies it works as advertised.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Usage strings updated)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary). (N/A)
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options). (N/A)
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
