### PR TITLE
feat: split off the current image in iv into a separate window (#2058)

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -141,7 +141,7 @@ ImageViewer::ImageViewer()
     setWindowTitle(tr("Image Viewer"));
     resize(m_default_width, m_default_height);
     //    setSizePolicy (QSizePolicy::Ignored, QSizePolicy::Ignored);
-    
+
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
@@ -194,7 +194,7 @@ ImageViewer::createActions()
     saveSelectionAsAct = new QAction(tr("Save Selection As..."), this);
     connect(saveSelectionAsAct, SIGNAL(triggered()), this,
             SLOT(saveSelectionAs()));
-    
+
     moveToNewWindowAct = new QAction(tr("Move to new window"), this);
     connect(moveToNewWindowAct, SIGNAL(triggered()), this,
             SLOT(moveToNewWindow()));
@@ -876,10 +876,9 @@ ImageViewer::saveSelectionAs()
 void
 ImageViewer::moveToNewWindow()
 {
-    if (m_images.size())
-    {
+    if (m_images.size()) {
         ImageViewer* imageViewer = new ImageViewer();
-        
+
         imageViewer->show();
         imageViewer->rawcolor(rawcolor());
         imageViewer->add_image(m_images[m_current_image]->name());

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -141,6 +141,8 @@ ImageViewer::ImageViewer()
     setWindowTitle(tr("Image Viewer"));
     resize(m_default_width, m_default_height);
     //    setSizePolicy (QSizePolicy::Ignored, QSizePolicy::Ignored);
+    
+    setAttribute(Qt::WA_DeleteOnClose);
 }
 
 
@@ -192,6 +194,10 @@ ImageViewer::createActions()
     saveSelectionAsAct = new QAction(tr("Save Selection As..."), this);
     connect(saveSelectionAsAct, SIGNAL(triggered()), this,
             SLOT(saveSelectionAs()));
+    
+    moveToNewWindowAct = new QAction(tr("Move to new window"), this);
+    connect(moveToNewWindowAct, SIGNAL(triggered()), this,
+            SLOT(moveToNewWindow()));
 
     printAct = new QAction(tr("&Print..."), this);
     printAct->setShortcut(tr("Ctrl+P"));
@@ -457,6 +463,7 @@ ImageViewer::createMenus()
     fileMenu->addAction(saveWindowAsAct);
     fileMenu->addAction(saveSelectionAsAct);
     fileMenu->addSeparator();
+    fileMenu->addAction(moveToNewWindowAct);
     fileMenu->addAction(printAct);
     fileMenu->addAction(deleteCurrentImageAct);
     fileMenu->addSeparator();
@@ -866,7 +873,21 @@ ImageViewer::saveSelectionAs()
                this);
 }
 
-
+void
+ImageViewer::moveToNewWindow()
+{
+    if (m_images.size())
+    {
+        ImageViewer* imageViewer = new ImageViewer();
+        
+        imageViewer->show();
+        imageViewer->rawcolor(rawcolor());
+        imageViewer->add_image(m_images[m_current_image]->name());
+        imageViewer->current_image(0);
+        imageViewer->raise();
+        imageViewer->activateWindow();
+    }
+}
 
 void
 ImageViewer::updateTitle()

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -248,6 +248,7 @@ private slots:
     void saveAs();              ///< Save As... functionality
     void saveWindowAs();        ///< Save As... functionality
     void saveSelectionAs();     ///< Save As... functionality
+    void moveToNewWindow();     ///< Split current image off as a new window
     void print();               ///< Print current image
     void deleteCurrentImage();  ///< Deleting displayed image
     void zoomIn();              ///< Zoom in to next power of 2
@@ -332,6 +333,7 @@ private:
     static const unsigned int MaxRecentFiles = 10;
     QAction* openRecentAct[MaxRecentFiles];
     QAction *saveAsAct, *saveWindowAsAct, *saveSelectionAsAct;
+    QAction* moveToNewWindowAct;
     QAction* printAct;
     QAction* deleteCurrentImageAct;
     QAction* exitAct;


### PR DESCRIPTION
## Description

This change adds a menu item "Split off" under the menu "File" which creates a new window and initialises it with the currently displayed image. 

## Tests

I have tested the UI changes on Mac and linux, I don't have a Windows machine currently. 
No other functionality should be affected by this change.


## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
