### PR TITLE
Added tests for Simple Image input and updated rst

### DIFF
--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -20,35 +20,16 @@ memory, even if that's not the way they're stored in the file):
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        #include <OpenImageIO/imageio.h>
-        using namespace OIIO;
-        ...
-
-        auto inp = ImageInput::open(filename);
-        if (! inp)
-            return;
-        const ImageSpec &spec = inp->spec();
-        int xres = spec.width;
-        int yres = spec.height;
-        int nchannels = spec.nchannels;
-        auto pixels = std::unique_ptr<unsigned char[]>(new unsigned char[xres * yres * nchannels]);
-        inp->read_image(0, 0, 0, nchannels, TypeDesc::UINT8, &pixels[0]);
-        inp->close();
-
+    .. tab:: C++
+        .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
+            :language: c++
+            :start-after: BEGIN-imageinput-simple
+            :end-before: END-imageinput-simple
     .. code-tab:: py
-
-        import OpenImageIO as oiio
-
-        inp = oiio.ImageInput.open(filename)
-        if inp :
-            spec = inp.spec()
-            xres = spec.width
-            yres = spec.height
-            nchannels = spec.nchannels
-            pixels = inp.read_image(0, 0, 0, nchannels, "uint8")
-            inp.close()
+        .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imageinput.py
+            :language: py
+            :start-after: BEGIN-imageinput-simple
+            :end-before: END-imageinput-simple
 
 Here is a breakdown of what work this code is doing:
 

--- a/testsuite/docs-examples-cpp/ref/out.txt
+++ b/testsuite/docs-examples-cpp/ref/out.txt
@@ -29,9 +29,9 @@ lines.exr            :  640 x  480, 4 channel, float openexr
 box.exr              :  640 x  480, 4 channel, float openexr
     SHA-1: 6CBE5E98B145C5975CB930A91BAEE981C30E6B32
 text1.exr            :  640 x  480, 3 channel, float openexr
-    SHA-1: 014ECFC5EBF07F77DF24A592F43BC7CB101534AE
+    SHA-1: 72E989716A14F0399886CE39B04B92C20BCB3242
 text2.exr            :  640 x  480, 3 channel, float openexr
-    SHA-1: 53359E96A286F909A89ACC99A67A9ED3BADC4A7A
+    SHA-1: 7210D03C177F8DD854B2BA70FB298BB6287AC2E7
 cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
 Comparing "simple.tif" and "ref/simple.tif"

--- a/testsuite/docs-examples-cpp/ref/out.txt
+++ b/testsuite/docs-examples-cpp/ref/out.txt
@@ -29,9 +29,9 @@ lines.exr            :  640 x  480, 4 channel, float openexr
 box.exr              :  640 x  480, 4 channel, float openexr
     SHA-1: 6CBE5E98B145C5975CB930A91BAEE981C30E6B32
 text1.exr            :  640 x  480, 3 channel, float openexr
-    SHA-1: 72E989716A14F0399886CE39B04B92C20BCB3242
+    SHA-1: 014ECFC5EBF07F77DF24A592F43BC7CB101534AE
 text2.exr            :  640 x  480, 3 channel, float openexr
-    SHA-1: 7210D03C177F8DD854B2BA70FB298BB6287AC2E7
+    SHA-1: 53359E96A286F909A89ACC99A67A9ED3BADC4A7A
 cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
 Comparing "simple.tif" and "ref/simple.tif"

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
@@ -32,10 +32,34 @@ void example1()
 
 
 
+// BEGIN-imageinput-simple
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void simple_read()
+{
+    const char* filename = "tahoe.tif";
+
+    auto inp = ImageInput::open(filename);
+    if (! inp)
+        return;
+    const ImageSpec &spec = inp->spec();
+    int xres = spec.width;
+    int yres = spec.height;
+    int nchannels = spec.nchannels;
+    auto pixels = std::unique_ptr<unsigned char[]>(new unsigned char[xres * yres * nchannels]);
+    inp->read_image(0, 0, 0, nchannels, TypeDesc::UINT8, &pixels[0]);
+    inp->close();
+}
+
+// END-imageinput-simple
+
+
+
 int main(int /*argc*/, char** /*argv*/)
 {
     // Each example function needs to get called here, or it won't execute
     // as part of the test.
-    example1();
+    simple_read();
     return 0;
 }

--- a/testsuite/docs-examples-python/src/docs-examples-imageinput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageinput.py
@@ -37,10 +37,24 @@ def example1() :
 ############################################################################
 
 
+# BEGIN-impageinput-simple
+import OpenImageIO as oiio
+def simple_read():
+    filename = "tahoe.tif"
+
+    inp = oiio.ImageInput.open(filename)
+    if inp :
+        spec = inp.spec()
+        xres = spec.width
+        yres = spec.height
+        nchannels = spec.nchannels
+        pixels = inp.read_image(0, 0, 0, nchannels, "uint8")
+        inp.close()
+# END-imageinput-simple
 
 
 
 if __name__ == '__main__':
     # Each example function needs to get called here, or it won't execute
     # as part of the test.
-    example1()
+    simple_read()


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

Added the simple input tests from the ImageInput chapter of the docs as C++ and Python examples, a part of the larger issue #3992 . Followed prototype (https://github.com/AcademySoftwareFoundation/OpenImageIO/wiki/Converting-documentation-examples-to-tests) approach.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
