### PR TITLE
build: Make C++17 be the default (C++14 is still the minimum for now)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,7 @@ help:
 	@echo "      STOP_ON_WARNING=0        Do not stop building if compiler warns"
 	@echo "      OPENIMAGEIO_SITE=xx      Use custom site build mods"
 	@echo "      MYCC=xx MYCXX=yy         Use custom compilers"
-	@echo "      CMAKE_CXX_STANDARD=14    C++ standard to build with (default is 14)"
+	@echo "      CMAKE_CXX_STANDARD=14    C++ standard to build with (default is 17)"
 	@echo "      USE_LIBCPLUSPLUS=1       For clang, use libc++"
 	@echo "      GLIBCXX_USE_CXX11_ABI=1  For gcc, use the new string ABI"
 	@echo "      EXTRA_CPP_ARGS=          Additional args to the C++ command"

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -29,7 +29,7 @@ ifeq (${SP_OS}, rhel7)
     SPI_COMPILER_PLATFORM ?= gcc-6.3
     ifeq (${SPI_COMPILER_PLATFORM},gcc-6.3)
         SPCOMP2_COMPILER ?= gcc63
-        CMAKE_CXX_STANDARD ?= 14
+        CMAKE_CXX_STANDARD ?= 17
         LLVM_VERSION ?= 12.0.1
     endif
     SP_PLATFORM ?= linux
@@ -37,7 +37,7 @@ else ifeq (${platform}, macosx)
     # Generic OSX machines (including LG's laptop)
     COMPILER ?= clang
     SPCOMP2_COMPILER ?= clang
-    CMAKE_CXX_STANDARD ?= 14
+    CMAKE_CXX_STANDARD ?= 17
     SP_OS ?= macosx
     SP_PLATFORM ?= macosx
 else

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -25,14 +25,17 @@ message (STATUS  "CMAKE_CXX_COMPILER_ID  = ${CMAKE_CXX_COMPILER_ID}")
 ###########################################################################
 # C++ language standard
 #
-set (CMAKE_CXX_STANDARD 14 CACHE STRING
-     "C++ standard to build with (14, 17, 20, etc.)")
+set (CMAKE_CXX_MINIMUM 14)
+set (CMAKE_CXX_STANDARD 17 CACHE STRING
+     "C++ standard to build with (14, 17, 20, etc.) Minimum is ${CMAKE_CXX_MINIMUM}.")
 set (DOWNSTREAM_CXX_STANDARD 14 CACHE STRING
      "C++ minimum standard to impose on downstream clients")
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 message (STATUS "Building with C++${CMAKE_CXX_STANDARD}, downstream minimum C++${DOWNSTREAM_CXX_STANDARD}")
-
+if (CMAKE_CXX_STANDARD VERSION_LESS CMAKE_CXX_MINIMUM)
+    message (ERROR "C++${CMAKE_CXX_STANDARD} is not supported, minimum is C++${CMAKE_CXX_MINIMUM}")
+endif ()
 
 ###########################################################################
 # Figure out which compiler we're using


### PR DESCRIPTION
This is for master only! Will not be backported to any release branch.

We are assuming the 2.5 release family will be the last to support C++14, and the next year's 2.6 family will raise the minimum to C++17. We're not ready to throw that switch yet, but as an intermediate step, let's raise the *default* level to C++17. It's still possible to compile for C++14, but to do so, one must proactively `-DCMAKE_CXX_STANDARD=14`.

This has two benefits:

1. The majority of people who are already using a C++17-capable compiler will take advantage of those features by default, instead of needlessly restricting to C++14.

2. The people using a compiler that tops out at C++14 (e.g., gcc 6.3) are going to have to set `-DCMAKE_CXX_STANDARD=14`, thus making them aware that (in master anyway) they're swimming against the current and have a limited time in which that will continue to work.

I hope that some time around the new year, we'll be able to fully raise the minimum to 17? But it's going to depend on my place and other major users finally retiring the DCC versions that require a gcc6/C++14 ecosystem, and we're not quite ready to do that at this moment. Soon, soon.
