### PR TITLE
build: Protect against mismatch of OpenVDB vs C++

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,7 +50,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * OpenJpeg >= 2.0 (tested through 2.5; we recommend 2.4 or higher
        for multithreading support)
  * If you want support for OpenVDB files:
-     * OpenVDB >= 5.0 (tested through 10.0)
+     * OpenVDB >= 5.0 (tested through 10.1). Note that using OpenVDB >= 10.0
+       requires that you compile OIIO with C++17 or higher.
  * If you want to use TBB as the thread pool:
      * TBB >= 2018 (tested through 2021 and OneTBB)
  * If you want support for converting to and from OpenCV data structures,

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -235,6 +235,10 @@ checked_find_package (OpenVDB
                       VERSION_MIN 5.0
                       DEPS         TBB
                       DEFINITIONS  -DUSE_OPENVDB=1)
+if (OpenVDB_FOUND AND OpenVDB_VERSION VERSION_GREATER_EQUAL 10.0 AND CMAKE_CXX_STANDARD VERSION_LESS 17)
+    message (WARNING "${ColorYellow}OpenVDB >= 10.0 (we found ${OpenVDB_VERSION}) can only be used when we build with C++17 or higher. Disabling OpenVDB support.${ColorReset}")
+    set (OpeVDB_FOUND 0)
+endif ()
 
 checked_find_package (Ptex PREFER_CONFIG)
 if (NOT Ptex_FOUND OR NOT Ptex_VERSION)


### PR DESCRIPTION
Looks like OpenVDB >= 10.0 requires a minimum of C++17. Warn at build time if trying to use an OpenVDB too new for the C++ compiler being used.
