### PR TITLE
make_texture doc2test

### DIFF
--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -2925,41 +2925,31 @@ Import / export
 
   Examples:
 
-    .. tabs::
-  
-       .. code-tab:: c++
+   .. tabs::
 
-          ImageBuf Input ("in.exr");
-          ImageSpec config;
-          config["maketx:highlightcomp"] = 1;
-          config["maketx:filtername"] = "lanczos3";
-          config["maketx:opaque_detect"] = 1;
-      
-          bool ok = ImageBufAlgo::make_texture (ImageBufAlgo::MakeTxTexture,
-                                                Input, "texture.exr", config);
-          if (! ok)
-              std::cout << "make_texture error: " << OIIO::geterror() << "\n";
+      .. tab:: C++
+         .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+              :language: c++
+              :start-after: BEGIN-imagebufalgo-make-texture
+              :end-before: END-imagebufalgo-make-texture
+              :dedent: 4
 
-       .. code-tab:: py
+      .. tab:: Python
+         .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+              :language: py
+              :start-after: BEGIN-imagebufalgo-make-texture
+              :end-before: END-imagebufalgo-make-texture
+              :dedent: 4
 
-          Input = ImageBuf("in.exr")
-          config = ImageSpec()
-          config["maketx:highlightcomp"] = 1
-          config["maketx:filtername"] = "lanczos3"
-          config["maketx:opaque_detect"] = 1
-      
-          ok = ImageBufAlgo.make_texture (OpenImageIO.MakeTxTexture,
-                                          Input, "texture.exr", config)
-          if not ok :
-              print("make_texture error:", OpenImageIO.geterror())
+      .. tab:: oiiotool
+         .. sourcecode:: bash
+         
+            oiiotool in.exr -otex:hilightcomp=1:filtername=lanczos3:opaque_detect=1 texture.exr
 
-       .. code-tab:: bash oiiotool
+      .. tab:: maketx
+         .. sourcecode:: bash
 
-          oiiotool in.exr -otex:hilightcomp=1:filtername=lanczos3:opaque_detect=1 texture.exr
-
-       .. code-tab:: bash maketx
-
-          maketx in.exr --hicomp --filter lanczos3 --opaque-detect -o texture.exr
+            maketx in.exr --hicomp --filter lanczos3 --opaque-detect -o texture.exr
       
 |
 

--- a/testsuite/docs-examples-cpp/ref/out.txt
+++ b/testsuite/docs-examples-cpp/ref/out.txt
@@ -34,6 +34,8 @@ text2.exr            :  640 x  480, 3 channel, float openexr
     SHA-1: 53359E96A286F909A89ACC99A67A9ED3BADC4A7A
 cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
+texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
+    SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
 Comparing "simple.tif" and "ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "ref/scanlines.tif"

--- a/testsuite/docs-examples-cpp/run.py
+++ b/testsuite/docs-examples-cpp/run.py
@@ -44,6 +44,7 @@ hashes = [
     "text1.exr",
     "text2.exr",
     "cshift.exr",
+    "texture.exr"
 ]
 for file in hashes :
     command += info_command(file, verbose=False)

--- a/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
@@ -267,6 +267,23 @@ void example_circular_shift()
 // Section: Import / export
 
 
+void example_make_texture()
+{
+    // BEGIN-imagebufalgo-make-texture
+    ImageBuf Input ("grid.exr");
+    ImageSpec config;
+    config["maketx:highlightcomp"] = 1;
+    config["maketx:filtername"] = "lanczos3";
+    config["maketx:opaque_detect"] = 1;
+
+    bool ok = ImageBufAlgo::make_texture (ImageBufAlgo::MakeTxTexture,
+                                          Input, "texture.exr", config);
+    if (! ok)
+        std::cout << "make_texture error: " << OIIO::geterror() << "\n";
+    // END-imagebufalgo-make-texture
+}
+
+
 
 
 
@@ -308,6 +325,7 @@ int main(int /*argc*/, char** /*argv*/)
     // Section: Color space conversion
 
     // Section: Import / export
+    example_make_texture();
 
     return 0;
 }

--- a/testsuite/docs-examples-python/ref/out.txt
+++ b/testsuite/docs-examples-python/ref/out.txt
@@ -34,6 +34,8 @@ text2.exr            :  640 x  480, 3 channel, float openexr
     SHA-1: 53359E96A286F909A89ACC99A67A9ED3BADC4A7A
 cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
+texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
+    SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
 Comparing "simple.tif" and "ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "ref/scanlines.tif"

--- a/testsuite/docs-examples-python/run.py
+++ b/testsuite/docs-examples-python/run.py
@@ -35,6 +35,7 @@ hashes = [
     "text1.exr",
     "text2.exr",
     "cshift.exr",
+    "texture.exr"
 ]
 for file in hashes :
     command += info_command(file, verbose=False)

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -255,6 +255,21 @@ def example_circular_shift() :
 
 # Section: Import / export
 
+def example_make_texture():
+    # BEGIN-imagebufalgo-make-texture
+    Input = ImageBuf("grid.exr")
+    config = ImageSpec()
+    config["maketx:highlightcomp"] = 1
+    config["maketx:filtername"] = "lanczos3"
+    config["maketx:opaque_detect"] = 1
+
+    ok = ImageBufAlgo.make_texture (OpenImageIO.MakeTxTexture,
+                                    Input, "texture.exr", config)
+    if not ok :
+        print("make_texture error:", OpenImageIO.geterror())
+
+    # END-imagebufalgo-make-texture
+
 
 
 
@@ -297,3 +312,4 @@ if __name__ == '__main__':
     # Section: Color space conversion
 
     # Section: Import / export
+    example_make_texture()


### PR DESCRIPTION
## Description

Takes the make_texture section of the imagebufalgo doc and turns it into a unit test in both python and c++.

## Tests

This adds a make_texture section to the `docs-examples-cpp` test and the `docs-examples-python` test.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x]  I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
