### PR TITLE
LibRaw wavelet denoise options

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1926,8 +1926,15 @@ options are supported:
      - int
      - Set libraw user flip value : -1 ignored, other values are between [0; 8] with the same 
        definition than the Exif orientation code.
-
-
+   * - ``raw:threshold``
+     - float
+     - Libraw parameter for noise reduction through wavelet denoising.. 
+       The best threshold should be somewhere between 100 and 1000.
+   * - ``raw:fbdd_noiserd``
+     - int
+     - Controls FBDD noise reduction before demosaic.
+       0 - do not use FBDD noise reduction, 1 - light FBDD reduction,
+       2 (and more) - full FBDD reduction
 
 
 |

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1936,7 +1936,7 @@ options are supported:
      - Controls FBDD noise reduction before demosaic.
        0 - do not use FBDD noise reduction, 1 - light FBDD reduction,
        2 (and more) - full FBDD reduction
-       (Default: 0.0)
+       (Default: 0)
 
 
 |

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1928,13 +1928,15 @@ options are supported:
        definition than the Exif orientation code.
    * - ``raw:threshold``
      - float
-     - Libraw parameter for noise reduction through wavelet denoising.. 
+     - Libraw parameter for noise reduction through wavelet denoising.
        The best threshold should be somewhere between 100 and 1000.
+       (Default: 0.0)
    * - ``raw:fbdd_noiserd``
      - int
      - Controls FBDD noise reduction before demosaic.
        0 - do not use FBDD noise reduction, 1 - light FBDD reduction,
        2 (and more) - full FBDD reduction
+       (Default: 0.0)
 
 
 |

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -677,7 +677,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
     }
 
     // Wavelets denoise before demosaic
-    // Use wavelets to erase noise while preserving real detail. 
+    // Use wavelets to erase noise while preserving real detail.
     // The best threshold should be somewhere between 100 and 1000.
     m_processor->imgdata.params.threshold
         = config.get_float_attribute("raw:threshold", 0.0f);
@@ -687,7 +687,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // 1 - light FBDD reduction
     // 2 (and more) - full FBDD reduction
     m_processor->imgdata.params.fbdd_noiserd
-		= config.get_int_attribute("raw:fbdd_noiserd", 0);
+        = config.get_int_attribute("raw:fbdd_noiserd", 0);
     
     // Values returned by libraw are in linear, but are normalized based on the
     // whitepoint / sensor / ISO and shooting conditions.

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -688,7 +688,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // 2 (and more) - full FBDD reduction
     m_processor->imgdata.params.fbdd_noiserd
         = config.get_int_attribute("raw:fbdd_noiserd", 0);
-    
+
     // Values returned by libraw are in linear, but are normalized based on the
     // whitepoint / sensor / ISO and shooting conditions.
     // Technically the transformation for each camera body / lens / setup

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -676,6 +676,19 @@ RawInput::open_raw(bool unpack, const std::string& name,
         m_spec.attribute("raw:Demosaic", "AHD");
     }
 
+    // Wavelets denoise before demosaic
+    // Use wavelets to erase noise while preserving real detail. 
+    // The best threshold should be somewhere between 100 and 1000.
+    m_processor->imgdata.params.threshold
+        = config.get_float_attribute("raw:threshold", 0.0f);
+
+    // Controls FBDD noise reduction before demosaic.
+    // 0 - do not use FBDD noise reduction
+    // 1 - light FBDD reduction
+    // 2 (and more) - full FBDD reduction
+    m_processor->imgdata.params.fbdd_noiserd
+		= config.get_int_attribute("raw:fbdd_noiserd", 0);
+    
     // Values returned by libraw are in linear, but are normalized based on the
     // whitepoint / sensor / ISO and shooting conditions.
     // Technically the transformation for each camera body / lens / setup


### PR DESCRIPTION
``raw:threshold``
     - float
     - Libraw parameter for noise reduction through wavelet denoising..
       The best threshold should be somewhere between 100 and 1000.
- ``raw:fbdd_noiserd`` - int - Controls FBDD noise reduction before demosaic. 0 - do not use FBDD noise reduction, 1 - light FBDD reduction, 2 (and more) - full FBDD reduction

<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
