### PR TITLE
build: Adjust OpenVDB version requirements vs C++17

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -235,8 +235,8 @@ checked_find_package (OpenVDB
                       VERSION_MIN 5.0
                       DEPS         TBB
                       DEFINITIONS  -DUSE_OPENVDB=1)
-if (OpenVDB_FOUND AND OpenVDB_VERSION VERSION_GREATER_EQUAL 10.0 AND CMAKE_CXX_STANDARD VERSION_LESS 17)
-    message (WARNING "${ColorYellow}OpenVDB >= 10.0 (we found ${OpenVDB_VERSION}) can only be used when we build with C++17 or higher. Disabling OpenVDB support.${ColorReset}")
+if (OpenVDB_FOUND AND OpenVDB_VERSION VERSION_GREATER_EQUAL 10.1 AND CMAKE_CXX_STANDARD VERSION_LESS 17)
+    message (WARNING "${ColorYellow}OpenVDB >= 10.1 (we found ${OpenVDB_VERSION}) can only be used when we build with C++17 or higher. Disabling OpenVDB support.${ColorReset}")
     set (OpeVDB_FOUND 0)
 endif ()
 


### PR DESCRIPTION
Revision of PR #4023

I have since determined that although OpenVDB raised their own build requirements to C++17 starting with 10.0, it wasn't until 10.1 that C++17-isms crept into their header files and force downstream projects to need C++17 to consume OpenVDB's headers. So we can go back to allowing use of OpenVDB 10.0 even when we are building with C++14.
