### PR TITLE
Deprecate Sysutil::physical_concurrency()

### DIFF
--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -86,15 +86,24 @@ OIIO_API bool
 put_in_background(int argc, char* argv[]);
 
 /// Number of virtual cores available on this platform (including
-/// hyperthreads).
+/// hyperthreads). Note that this is just a wrapper/synonym for C++
+/// std::thread::hardware_concurrency(), and was put in OIIO to allow its use
+/// before C++11 was our minimum.
 OIIO_API unsigned int
 hardware_concurrency();
 
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2, 6, 0)
 /// Number of full hardware cores available on this platform (does not
 /// include hyperthreads). This is not always accurate and on some
 /// platforms will return the number of virtual cores.
+///
+/// This is considered DEPRECATED(2.6) and will be removed from a future
+/// release of OpenImageIO. It is now a synonym for hardware_concurrency().
+OIIO_DEPRECATED(
+    "unreliable, replace with hardware_concurrency() [DEPRECATED in 2.6.0.0]")
 OIIO_API unsigned int
 physical_concurrency();
+#endif
 
 /// Get the maximum number of open file handles allowed on this system.
 OIIO_API size_t

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -24,7 +24,7 @@ using namespace OIIO;
 // value at the end.
 
 static int iterations = 2000000;
-static int numthreads = clamp((int)Sysutil::physical_concurrency(), 2, 16);
+static int numthreads = clamp((int)Sysutil::hardware_concurrency(), 2, 16);
 static int ntrials    = 5;
 static bool verbose   = false;
 static bool wedge     = false;

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -75,12 +75,6 @@
 #    endif
 #endif
 
-// clang 7.0 (rc2) has errors when including boost thread!
-// The only thing we're using there is boost::physical_concurrency.
-#if !(OIIO_CLANG_VERSION >= 7)
-#    include <boost/thread.hpp>
-#endif
-
 OIIO_INTEL_PRAGMA(warning disable 2196)
 
 
@@ -607,12 +601,7 @@ Sysutil::hardware_concurrency()
 unsigned int
 Sysutil::physical_concurrency()
 {
-    // clang 7.0.0rc2 has trouble compiling boost thread
-#if BOOST_VERSION >= 105600 && !(OIIO_CLANG_VERSION >= 7)
-    return boost::thread::physical_concurrency();
-#else
     return std::thread::hardware_concurrency();
-#endif
 }
 
 


### PR DESCRIPTION
It is a implemented by simply wrapping boost::physical_concurrency(). So this is one more step in eliminating boost from our requirements.

Until it's fully removed, just make it be a synonym for hardware_concurrency().

We don't seem to use physical_concurrency anywhere, and I'm not sure what it's good for. The underlying boost impementation just falls back to hardware_concurrency on many platforms or circumstances.

Note for the record that Sysutil::hardware_concurrency() is also redundant, and merely wraps the std::thread function of the same name.
