### PR TITLE
fix for install.md wrong location for testimages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -380,7 +380,7 @@ support, and make test expects them to also be present. To run full tests,
 you will need to download and unpack the test image collections from:
 
 * http://www.simplesystems.org/libtiff/images.html
-* https://openexr.com/en/latest/_test_images/index.html#test-images
+* https://openexr.com/en/latest/_test_images/index.html#test-images -- in githttps://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main/TestImages/
 * http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803
 * http://www.cv.nrao.edu/fits/data/tests/
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -380,7 +380,7 @@ support, and make test expects them to also be present. To run full tests,
 you will need to download and unpack the test image collections from:
 
 * http://www.simplesystems.org/libtiff/images.html
-* http://www.openexr.com/downloads.html
+* https://openexr.com/en/latest/_test_images/index.html#test-images
 * http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803
 * http://www.cv.nrao.edu/fits/data/tests/
 


### PR DESCRIPTION
                                    -->


## Description

http://www.openexr.com/downloads.html is a 404
the new location appears to be
https://openexr.com/en/latest/_test_images/index.html#test-images

## Tests

just updated the markdown

## Checklist:


- [x ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ x] I have updated the documentation, if applicable.
- [ ]x I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
