### PR TITLE
fix: always seek to the beginning of the ioproxy during open for DDS and PSD files

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -357,6 +357,7 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
 
     if (!ioproxy_use_or_open(name))
         return false;
+    ioseek(0);
 
     static_assert(sizeof(dds_header) == 128, "dds header size does not match");
     if (!ioread(&m_dds, sizeof(m_dds), 1))

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -546,6 +546,7 @@ PSDInput::open(const std::string& name, ImageSpec& newspec)
     m_filename = name;
     if (!ioproxy_use_or_open(name))
         return false;
+    ioseek(0);
 
     // File Header
     if (!load_header()) {


### PR DESCRIPTION
## Description

During certain creation tasks, open may be called twice on the ImageInput. If the first open call moves the ioproxy forward, then the second call to open may fail.

DDS and PSD were affected so they've been fixed to mirror what other formats (png, hdr, tga, etc.) do by always explicitly seeking to position 0.

Fixes #4043 

## Tests

The example code from the bug now works.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
