### PR TITLE
ci: Remove MacOS-11 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,17 +449,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: MacOS-11
-            runner: macos-11
-            nametag: macos11-py39
-            cxx_std: 17
-            python_ver: "3.9"
-            aclang: 13
-            setenvs: export QT_VERSION=@5
           - desc: MacOS-12
             runner: macos-12
             nametag: macos12-py310
-            cxx_std: 20
+            cxx_std: 17
             python_ver: "3.10"
             aclang: 13
             setenvs: export CTEST_TEST_TIMEOUT=600


### PR DESCRIPTION
It's started failing on GHA and is old enough that it's not worth trying to track down what's broken. We still have MacOS 12 and 13 tests in the matrix.
