### PR TITLE
fix: Remove redundant line in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,5 @@
 Language:        Cpp
 BasedOnStyle:  WebKit
-SpaceBeforeParens: ControlStatements
 
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align


### PR DESCRIPTION
Used to be no problem, but after a recent VSCode update, this seems to have been causing errors when asking VSCode to format. No idea why this recently became problematic.
