### PR TITLE
ci: test against gcc-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,11 +289,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: latest releases gcc11 C++17 avx2 exr3.2 ocio2.3
+          - desc: latest releases gcc12 C++17 avx2 exr3.2 ocio2.3
             nametag: linux-latest-releases
             runner: ubuntu-22.04
-            cc_compiler: gcc-11
-            cxx_compiler: g++-11
+            cc_compiler: gcc-12
+            cxx_compiler: g++-12
             cxx_std: 17
             fmt_ver: 10.1.1
             openexr_ver: v3.2.0
@@ -310,11 +310,11 @@ jobs:
                             USE_OPENVDB=0
                             WEBP_VERSION=v1.3.0
                             # The installed OpenVDB has a TLS conflict with Python 3.8
-          - desc: bleeding edge gcc12 C++20 py3.10 OCIO/libtiff/exr-master boost1.74 avx2
+          - desc: bleeding edge gcc13 C++20 py3.10 OCIO/libtiff/exr-master boost1.74 avx2
             nametag: linux-bleeding-edge
             runner: ubuntu-22.04
-            cc_compiler: gcc-12
-            cxx_compiler: g++-12
+            cc_compiler: gcc-13
+            cxx_compiler: g++-13
             cxx_std: 20
             fmt_ver: master
             openexr_ver: main

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,10 +15,10 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 ### Required dependencies -- OIIO will not build at all without these
 
  * C++14 or higher (also builds with C++17, and C++20)
-     * The default build mode is C++14. This can be controlled by via the
-       CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
+     * The default build mode is C++17. This can be controlled by via the
+       CMake configuration flag: `-DCMAKE_CXX_STANDARD=14`, etc.
      * ADVISORY: We expect that OIIO 2.6 in 2024 will require C++17 or higher.
- * Compilers: gcc 6.1 - 12.1, clang 3.4 - 16, MSVS 2017 - 2019,
+ * Compilers: gcc 6.1 - 13.1, clang 3.4 - 16, MSVS 2017 - 2019,
    Intel icc 17+, Intel OneAPI C++ compiler 2022+.
  * **CMake >= 3.15** (tested through 3.27)
  * **OpenEXR/Imath >= 2.4** (recommended: 3.1 or higher; tested through 3.2


### PR DESCRIPTION
Switch "bleeding edge" test to gcc13, "latest releases" test to gcc12
