### PR TITLE
fix(oiiotool): --autocc bugfix and color config inventory cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,11 @@ if (${PROJ_NAME}_NAMESPACE_INCLUDE_PATCH)
 endif ()
 message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
 
+set (OIIO_SITE "" CACHE STRING "Site name for customization")
+if (OIIO_SITE)
+    add_definitions (-DOIIO_SITE_${OIIO_SITE})
+endif ()
+
 # Define OIIO_INTERNAL symbol only when building OIIO itself, will not be
 # defined for downstream projects using OIIO.
 add_definitions (-DOIIO_INTERNAL=1)

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5381,30 +5381,31 @@ input_file(Oiiotool& ot, cspan<const char*> argv)
             std::string colorspace(
                 ot.colorconfig.getColorSpaceFromFilepath(filename));
             if (colorspace.size() && ot.debug)
-                std::cout << "  From " << filename
-                          << ", we deduce color space \"" << colorspace
-                          << "\"\n";
+                print("  From {}, we deduce color space \"{}\"\n", filename,
+                      colorspace);
             if (colorspace.empty()) {
                 ot.read();
                 colorspace = ot.curimg->spec()->get_string_attribute(
                     "oiio:ColorSpace");
                 if (ot.debug)
-                    std::cout << "  Metadata of " << filename
-                              << " indicates color space \"" << colorspace
-                              << "\"\n";
+                    print("  Metadata of {} indicates color space \"{}\"\n",
+                          colorspace, filename);
             }
             std::string linearspace = ot.colorconfig.resolve("linear");
             if (colorspace.size()
-                && ot.colorconfig.equivalent(colorspace, linearspace)) {
+                && !ot.colorconfig.equivalent(colorspace, linearspace)) {
                 std::string cmd = "colorconvert:strict=0";
                 if (autoccunpremult)
                     cmd += ":unpremult=1";
                 const char* argv[] = { cmd.c_str(), colorspace.c_str(),
                                        linearspace.c_str() };
                 if (ot.debug)
-                    std::cout << "  Converting " << filename << " from "
-                              << colorspace << " to " << linearspace << "\n";
+                    print("  Converting {} from {} to {}\n", filename,
+                          colorspace, linearspace);
                 action_colorconvert(ot, argv);
+            } else if (ot.debug) {
+                print("  no auto conversion necessary for {}->{}\n", colorspace,
+                      linearspace);
             }
         }
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -662,8 +662,8 @@ RawInput::open_raw(bool unpack, const std::string& name,
             m_spec.attribute("raw:FilterPattern", filter);
 
             // Also, any previously set demosaicing options are void, so remove them
-            m_spec.erase_attribute("oiio:Colorspace");
-            m_spec.erase_attribute("raw:Colorspace");
+            m_spec.erase_attribute("oiio:ColorSpace");
+            m_spec.erase_attribute("raw:ColorSpace");
             m_spec.erase_attribute("raw:Exposure");
         } else {
             errorf("raw:Demosaic set to unknown value");

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -128,7 +128,7 @@ bool
 TermOutput::output()
 {
     // Color convert in place to sRGB, or it won't look right
-    std::string cspace = m_buf.spec()["oiio:colorspace"].get();
+    std::string cspace = m_buf.spec()["oiio:ColorSpace"].get();
     ImageBufAlgo::colorconvert(m_buf, m_buf, cspace, "sRGB");
 
     string_view method(m_method);


### PR DESCRIPTION
The important bug fix is in oiiotool image input when autocc is used, where we reversed the sense of a test and did the autocc-upon-input if the file's color space was equivalent to the scene_linear space (pointlessly), and skipped the conversion if they were different (oh no, big bug!).

Along the way:

* Add missing try/catch around OCIO call that should have had it.

* Some very ugly SPI-specific recognize-by-name color space heuristics. I hate this, sorry, but it solves a really important problem for me.

* A bunch of additional debugging messages during color space inventory, enabled only when debugging, so nobody should see these but me.

* A couple places where we canonicalize the spelling of "oiio:ColorSpace".

Note that there is still an issue with the color space classification using OCIO 2.3+'s identification of built-in equivalents by name. These are shockingly expensive. I will return to this later.
