### PR TITLE
fix(diff): Fix issue when computing perceptual diff

### DIFF
--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -301,7 +301,7 @@ main(int argc, char* argv[])
 
             int yee_failures = 0;
             if (perceptual && !img0.deep()) {
-                ImageBufAlgo::CompareResults cr;
+                cr           = {};
                 yee_failures = ImageBufAlgo::compare_Yee(img0, img1, cr);
             }
 

--- a/testsuite/diff/ref/out-fmt6.txt
+++ b/testsuite/diff/ref/out-fmt6.txt
@@ -23,13 +23,23 @@ Computing perceptual diff of "img1.exr" vs "img1.exr"
 PASS
 Comparing "img1.exr" and "img2.exr"
 64 x 64, 3 channels
-  Mean error = 0.0049235
-  RMS error = 0.049616
-  Peak SNR = 26.0876
-  Max error  = 0.5 @ (5, 17, G)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
-  121 pixels (2.95%) over 0.008
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = 0
+  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  0 pixels (0%) over 0.008
   121 pixels (2.95%) over 0.004
   121 pixels (2.9541%) failed the perceptual test
 FAILURE
 Comparing "img1.exr" and "img1.exr"
 PASS
+Comparing "img1.exr" and "img2.exr"
+64 x 64, 3 channels
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = 0
+  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  0 pixels (0%) over 0.008
+  121 pixels (2.95%) over 1.0
+  121 pixels (2.9541%) failed the perceptual test
+FAILURE

--- a/testsuite/diff/ref/out.txt
+++ b/testsuite/diff/ref/out.txt
@@ -23,13 +23,23 @@ Computing perceptual diff of "img1.exr" vs "img1.exr"
 PASS
 Comparing "img1.exr" and "img2.exr"
 64 x 64, 3 channels
-  Mean error = 0.0049235
-  RMS error = 0.049616
-  Peak SNR = 26.0876
-  Max error  = 0.5 @ (5, 17, G)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
-  121 pixels (2.95%) over 0.008
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = 0
+  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  0 pixels (0%) over 0.008
   121 pixels (2.95%) over 0.004
   121 pixels (2.9541%) failed the perceptual test
 FAILURE
 Comparing "img1.exr" and "img1.exr"
 PASS
+Comparing "img1.exr" and "img2.exr"
+64 x 64, 3 channels
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = 0
+  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  0 pixels (0%) over 0.008
+  121 pixels (2.95%) over 1
+  121 pixels (2.9541%) failed the perceptual test
+FAILURE

--- a/testsuite/diff/run.py
+++ b/testsuite/diff/run.py
@@ -19,6 +19,7 @@ command += oiiotool("-pdiff img1.exr img2.exr")
 command += oiiotool("-pdiff img1.exr img1.exr")
 command += diff_command("img1.exr", "img2.exr", extraargs="-p")
 command += diff_command("img1.exr", "img1.exr", extraargs="-p")
+command += diff_command("img1.exr", "img2.exr", extraargs="-p -fail 1")
 
 
 # Outputs to check against references


### PR DESCRIPTION
## Description

- Fix perceptual test false positive by removing the initialization of `cr` to avoid losing the information when leaving block scope

## Tests

Included additional test with parameter `-fail 1`, which was giving a false positive pass for a perceptual difference. 
This was due to the fact that the result variable `cr` was getting out of scope for the perceptual calculation and the first `if (cr.nfail <= imagesize_t(allowfailures)) {` was testing for the result of the absolute difference instead of the perceptual difference.

Before:
```
Comparing "img1.exr" and "img2.exr"
PASS
```
After:
```
Comparing "img1.exr" and "img2.exr"
64 x 64, 3 channels
  Mean error = 0
  RMS error = 0
  Peak SNR = 0
  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
  0 pixels (0%) over 0.008
  121 pixels (2.95%) over 1
  121 pixels (2.9541%) failed the perceptual test
FAILURE
```
