### PR TITLE
fix(simd.h): fix leaking of Imath.h into public headers

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -46,10 +46,6 @@
 
 #include <OpenImageIO/detail/fmt.h>
 
-// Without SSE, we need to fall back on Imath for matrix44 invert
-#if !OIIO_SIMD_SSE
-#   include <OpenImageIO/Imath.h>
-#endif
 
 
 //////////////////////////////////////////////////////////////////////////
@@ -276,6 +272,12 @@
 #endif
 #ifdef False
 #    undef False
+#endif
+
+
+// Without SSE, we need to fall back on Imath for matrix44 invert
+#if !OIIO_SIMD_SSE
+#   include <OpenImageIO/Imath.h>
 #endif
 
 


### PR DESCRIPTION
A recent change (PR 4026) tried to include Imath.h in cases where there was no SSE support (to provide a fallback implementation of matrix invert, because simd.h's native one requires SSE), but it had a mistake -- it used `#if !OIIO_SIMD_SSE` prior to that symbol being defined! This caused the header to always be included, which is not what we wanted, as we desired for that header to not be exposed in the public headers.

This patch offers a temporary/partial fix by simply moving that guarded include later in the file to after OIIO_SIMD_SSE is defined. For architectures that support SSE, at least, this achieves our goal of not exposing Imath.h in public headers.

I need this patch right away to solve a particular problem I'm running into.

Longer term, we note that this isn't a full solution -- on non-SSE architectures (like ARM), it still ends up exposing Imath.h against our desire.

For today, so be it. A better fix would be to rewrite our current SSE-requiring invert to change the SSE intrinsics therein to the wrapped kind we use with our simd classes, which will let it work fine with ARM. But I feel like that needs to be done carefully and with more testing than I can afford at this minute when I need this fix. I will return to it shortly, but need this patch now.
