### PR TITLE
test: improve color management test in imagebufalgo_test

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -612,6 +612,9 @@ ColorConfig::Impl::classify_by_name(CSInfo& cs)
     } else if (cs.name == "srgbf" || cs.name == "srgbh" || cs.name == "srgb16"
                || cs.name == "srgb8") {
         cs.setflag(CSInfo::is_srgb, srgb_alias);
+    } else if (cs.name == "srgblnf" || cs.name == "srgblnh"
+               || cs.name == "srgbln16" || cs.name == "srgbln8") {
+        cs.setflag(CSInfo::is_lin_srgb, lin_srgb_alias);
     }
 #endif
 


### PR DESCRIPTION
Add a few more assertion checks and error messages in imagebufalgo_test.

I observe that if somebody runs the testsuite with `$OCIO` set to a config that doesn't contain the required color space names for this test, it will fail. As a backstop, use the default built-in config if the initial request fails. That will always give a working processor between these spaces if OCIO >= 2.2 is being used.

Also one more tiny SPI-specific enhancement to hacky identification of nonconforming color space names in our old configs.
