### PR TITLE
Fix fast_exp simd test when building with aggressive optimization flags

### DIFF
--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1587,8 +1587,8 @@ void test_mathfuncs ()
     VEC expA = mkvec<VEC> (0.367879441171442f, 1.0f, 2.718281828459045f, 90.0171313005218f);
     OIIO_CHECK_SIMD_EQUAL (exp(A), expA);
     OIIO_CHECK_SIMD_EQUAL_THRESH (log(expA), A, 1e-6f);
-    OIIO_CHECK_SIMD_EQUAL (fast_exp(A),
-                mkvec<VEC>(fast_exp(A[0]), fast_exp(A[1]), fast_exp(A[2]), fast_exp(A[3])));
+    OIIO_CHECK_SIMD_EQUAL_THRESH (fast_exp(A),
+                mkvec<VEC>(fast_exp(A[0]), fast_exp(A[1]), fast_exp(A[2]), fast_exp(A[3])), 1e-6f);
     OIIO_CHECK_SIMD_EQUAL_THRESH (fast_log(expA),
                 mkvec<VEC>(fast_log(expA[0]), fast_log(expA[1]), fast_log(expA[2]), fast_log(expA[3])), 0.00001f);
     OIIO_CHECK_SIMD_EQUAL_THRESH (fast_pow_pos(VEC(2.0f), A),


### PR DESCRIPTION
## Description

After building OIIO on my machine and running the test suite, I noticed that I had some failures.
All failures besides the simd test was fixed by adding `-ffp-contract=off` to my compile flags.
(IIRC, GCC adds `-ffp-contract=on` when compiling with more aggressive flags while Clang and the intel compilers seems to not add this)

As only the single `fast_exp` test is failing, I'm guessing that adding a threshold to this test is fine?
Or is this expected to have no deviation at all no matter what?

I've tested this on three different x86_64 Linux computers (AMD/Intel CPUs). All fail in the same way and this fix seem to remedy the `fast_exp` failure.

My compile flags are `-march=native -O2 -pipe -ffp-contract=off`.
The simd test passes without this patch if I remove `-march=native`.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
> I haven't signed the CLA yet, but I can if the change is deemed applicable.
> I also don't mind someone committing this in their name as the change is so minimal. 
