### PR TITLE
SIMD: faster vint4 load/store with unsigned char conversion

### DIFF
--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -506,6 +506,14 @@ void test_conversion_loadstore_int ()
     OIIO_CHECK_SIMD_EQUAL (VEC(uc1234), C1234);
     OIIO_CHECK_SIMD_EQUAL (VEC( c1234), C1234);
 
+    // Check store to integers
+    VEC CStep = VEC::Iota(-130, 131);
+    unsigned char ucStepExp[]  = {126, 1, 132, 7, 138, 13, 144, 19, 150, 25, 156, 31, 162, 37, 168, 43};
+    unsigned char ucStepGot[VEC::elements] = {};
+    CStep.store(ucStepGot);
+    for (int i = 0; i < VEC::elements; ++i)
+        OIIO_CHECK_EQUAL ((int)ucStepGot[i], (int)ucStepExp[i]);
+
     benchmark ("load from int[]", [](const int *d){ return VEC(d); }, i1234);
     benchmark ("load from unsigned short[]", [](const unsigned short *d){ return VEC(d); }, us1234);
     benchmark ("load from short[]", [](const short *d){ return VEC(d); }, s1234);


### PR DESCRIPTION
## Description

vint4::load from unsigned char pointer got pre-SSE4 code path. Testing on Ryzen 5950X / VS2022 (with only SSE2 enabled in the build):
- vint4 load from unsigned char[]: 946.1 -> 4232.8 Mvals/sec

vint4::store to unsigned char pointer got simpler/faster SSE code path, and a NEON code path. Additionally, it got test correctness coverage, including what happens to values outside of unsigned char range (current behavior just masks lowest byte, i.e. does not clamp the integer lanes).

- vint4 store to unsigned char[]: 3489.8 -> 3979.3 Mvals/sec
- vint8 store to unsigned char[]: 5516.9 -> 7325.3 Mvals/sec

NEON code path as tested on Mac M1 Max (clang 15):
- vint4 store to unsigned char[]: 4137.2 -> 6074.8 Mvals/sec

## Tests

vint4 store to unsigned char pointer got actual correctness checking test, which seemingly was lacking before (only had a benchmark test).

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
