### PR TITLE
fix(jpeg2000): include the headers we need to discern version

### DIFF
--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <openjpeg.h>
+#include <opj_config.h>
 
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -4,7 +4,8 @@
 
 #include <vector>
 
-#include "openjpeg.h"
+#include <openjpeg.h>
+#include <opj_config.h>
 
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>


### PR DESCRIPTION
Without getting the version properly, we weren't disabling use of a deprecated field for OpenJpeg >= 2.5, as we thought we were.

This fixes recently broken CI when building against the current openjpeg master.
