### PR TITLE
fix(png): Fix crash for writing large PNGs with alpha

### DIFF
--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -385,7 +385,7 @@ PNGOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
         unassoc_scratch.reset(new float[nvals]);
         float* floatvals = unassoc_scratch.get();
         // Contiguize and convert to float
-        OIIO::convert_image(m_spec.nchannels, m_spec.width, m_spec.height, 1,
+        OIIO::convert_image(m_spec.nchannels, m_spec.width, yend - ybegin, 1,
                             data, format, xstride, ystride, AutoStride,
                             floatvals, TypeFloat, AutoStride, AutoStride,
                             AutoStride);


### PR DESCRIPTION
There was a flaw in PNGOutput::write_scanlines when the y range of scanlines to write consisted of less than the whole image, and alpha de-association was needed -- we used the whole-image size instead of the y range of scanlines size.

Fixes #4044

