### PR TITLE
Fix link to openexr test images

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -368,24 +368,21 @@ produce a dynamic-linked version.
 Test Images
 -----------
 
-We have yet another project containing a set of sample images for testing
-OpenImageIO. We split test images into a separate project in order to make
-the main source code tree smaller and simpler for people who don't need the
-test suite.
+There are several projects containing sets of sample images for testing
+OpenImageIO.
 
-    git clone https://github.com/AcademySoftwareFoundation/OpenImageIO-images.git
+They are kept separate in order to make the main source code
+tree smaller and simpler for people who don't need the test suite.
+Additionally, some of these packages are maintained outside the OpenImageIO
+project by their respective organizations.
 
-Also, there are collections of images for some of the file formats we
-support, and make test expects them to also be present. To run full tests,
-you will need to download and unpack the test image collections from:
-
-* http://www.simplesystems.org/libtiff/images.html
-* https://openexr.com/en/latest/_test_images/index.html#test-images
-* http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803
-* http://www.cv.nrao.edu/fits/data/tests/
-
-These images should be placed in a sibling directory to the OpenImageIO
-repository named oiio-testimages.
+| Download | Directory Placement | Notes |
+| --- | --- | --- |
+| git clone https://github.com/AcademySoftwareFoundation/OpenImageIO-images.git | `<path>/../oiio-images` | CMake will download if not present |
+| git clone https://github.com/AcademySoftwareFoundation/openexr-images.git | `<path>/../openexr-images` | CMake will download if not present |
+| http://www.cv.nrao.edu/fits/data/tests/ | `<path>/../fits-images` | Manual download required |
+| https://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803 | `<path>/../j2kp4files_v1_5` | Manual download required |
+Where `<path>` is the location of the main `OpenImageIO` repository.
 
 You do not need any of these packages in order to build or use
 OpenImageIO. But if you are going to contribute to OpenImageIO

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -380,7 +380,7 @@ support, and make test expects them to also be present. To run full tests,
 you will need to download and unpack the test image collections from:
 
 * http://www.simplesystems.org/libtiff/images.html
-* http://www.openexr.com/downloads.html
+* https://openexr.com/en/latest/_test_images/index.html#test-images
 * http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803
 * http://www.cv.nrao.edu/fits/data/tests/
 


### PR DESCRIPTION
## Description

Minimal change to update link to OpenEXR's new Test Images page. I poked around a bit to find a "friendlier" variant of the link but could find none.  

Note that the section containing this link implies that folks need to download these files themselves and should be "placed in a sibling directory to oiio-testimages". The problem is that not even OpenEXR lists the repository for the test images nor does the page linked above offer a download.

Should we list out the openexr-images repo address too and say to just clone that?

Fixes #4042

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
