### PR TITLE
Only check REST arguments if the file does not exist

### DIFF
--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -649,10 +649,14 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
     std::unique_ptr<ImageInput> in;
     std::map<std::string, std::string> args;
     std::string filename_stripped;
-    if (!Strutil::get_rest_arguments(filename, filename_stripped, args)) {
-        OIIO::pvt::errorfmt(
-            "ImageInput::create() called with malformed filename");
-        return in;
+
+    // Only check REST arguments if the file does not exist
+    if (!Filesystem::exists(filename)) {
+        if (!Strutil::get_rest_arguments(filename, filename_stripped, args)) {
+            OIIO::pvt::errorfmt(
+                "ImageInput::create() called with malformed filename");
+            return in;
+        }
     }
 
     if (filename_stripped.empty())


### PR DESCRIPTION
## Description
Fix for #4084. Will now check if the given filename exists before checking for REST parameters.

## Tests
I did not look into test cases for this, but I ran the following command before and after the change:

Before:
```
bin % ./oiiotool \?.png -o \?-output.png
oiiotool ERROR: read : "?.png": ImageInput::create() called with malformed filename
Full command line was:
> oiiotool ?.png -o ?-output.png
```

After: 
```
bin % ./oiiotool \?.png -o \?-output.png
```
No output, `?-output.png` created.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
