### PR TITLE
build: Add a way to cram in a custom extra library for iv

### DIFF
--- a/src/iv/CMakeLists.txt
+++ b/src/iv/CMakeLists.txt
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+set (OIIO_IV_EXTRA_IV_LIBRARIES "" CACHE STRING "Paths to extra libraries to force iv to link against")
+
 set (CMAKE_AUTOMOC ON)
 if (Qt5_POSITION_INDEPENDENT_CODE OR Qt6_POSITION_INDEPENDENT_CODE)
     set (CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -25,6 +27,7 @@ if (iv_enabled AND (Qt5_FOUND OR Qt6_FOUND) AND OPENGL_FOUND)
             ${OPENGL_LIBRARIES}
             $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIO>
             $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIOHeaders>
+            ${OIIO_IV_EXTRA_IV_LIBRARIES}
         )
     if (iv_enabled AND FORCE_OPENGL_1)
         target_compile_definitions(iv PRIVATE FORCE_OPENGL_1)


### PR DESCRIPTION
It's a little involved to explain why, but at work a combination of libraries and some trickery with static linkage led me to really need a way to inject another library into the mix, just for iv linkage.
