### PR TITLE
fix(iv): avoid crash with OpenGL + multi-channel images

### DIFF
--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1536,7 +1536,10 @@ IvGL::load_texture(int x, int y, int width, int height)
     }
 
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, m_pbo_objects[m_last_pbo_used]);
-    glBufferData(GL_PIXEL_UNPACK_BUFFER, width * height * spec.pixel_bytes(),
+    glBufferData(GL_PIXEL_UNPACK_BUFFER,
+                 GLsizeiptr(uint64_t(width) * uint64_t(height)
+                            * uint64_t(nchannels)
+                            * uint64_t(spec.format.size())),
                  &m_tex_buffer[0], GL_STREAM_DRAW);
     print_error("After buffer data");
     m_last_pbo_used = (m_last_pbo_used + 1) & 1;


### PR DESCRIPTION
For image with more than 4 channels, we were misallocating the OpenGL buffer by using the total channels instead of the 4 we wanted to create the texture out of. Also, make sure the calculation usees wide types to avoid possible integer overflow.
