### PR TITLE
perf: Improve perf of IBA::channels in-place operation

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -56,9 +56,11 @@ ImageBufAlgo::channels(ImageBuf& dst, const ImageBuf& src, int nchannels,
 {
     // Handle in-place case
     if (&dst == &src) {
-        ImageBuf tmp = src;
-        return channels(dst, tmp, nchannels, channelorder, channelvalues,
-                        newchannelnames, shuffle_channel_names, nthreads);
+        ImageBuf tmp;
+        bool ok = channels(tmp, src, nchannels, channelorder, channelvalues,
+                           newchannelnames, shuffle_channel_names, nthreads);
+        dst     = std::move(tmp);
+        return ok;
     }
 
     pvt::LoggedTimer logtime("IBA::channels");


### PR DESCRIPTION
For the in-place case (where src and dst refer to the same IB), we were doing an unnecessary full-image copy.
