### PR TITLE
test: Fix docs test, used wrong namespace

### DIFF
--- a/testsuite/docs-examples-python/run.py
+++ b/testsuite/docs-examples-python/run.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+redirect = " >> out.txt 2>&1 "
 
 # Prep:
 command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr grid.exr")
@@ -12,7 +13,7 @@ command += run_app("cmake -E copy " + test_source_dir + "/../common/tahoe-small.
 # Run the examples for each chapter
 for chapter in [ "imageioapi", "imageoutput", "imageinput", "writingplugins",
                  "imagecache", "texturesys", "imagebuf", "imagebufalgo" ] :
-    command += pythonbin + " src/docs-examples-" + chapter + ".py >> out.txt ;"
+    command += pythonbin + " src/docs-examples-" + chapter + ".py " + redirect + " ;"
 
 # hashes merely check that the images don't change, but saves us the space
 # of checking in a full copy of the image if it's not needed.

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -263,10 +263,10 @@ def example_make_texture():
     config["maketx:filtername"] = "lanczos3"
     config["maketx:opaque_detect"] = 1
 
-    ok = ImageBufAlgo.make_texture (OpenImageIO.MakeTxTexture,
+    ok = ImageBufAlgo.make_texture (oiio.MakeTxTexture,
                                     Input, "texture.exr", config)
     if not ok :
-        print("make_texture error:", OpenImageIO.geterror())
+        print("make_texture error:", oiio.geterror())
 
     # END-imagebufalgo-make-texture
 


### PR DESCRIPTION
We did `import OpenImageIO as oiio` then instead of using `oiio`, we used `OpenImageIO`.

This was failing sometimes. Frankly, I'm not sure why it ever worked.
Maybe it works on some versions of Python but not others?
I dunno. But this fixes it everywhere and is clearly correct.