### PR TITLE
ci: Rename macro to avoid conflict during CI unity builds

### DIFF
--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -149,7 +149,7 @@ dump_flat_data(std::ostream& out, ImageInput* input,
 
 
 // Macro to call a type-specialzed version func<type>(R,...)
-#define OIIO_DISPATCH_TYPES(ret, name, func, type, R, ...)                    \
+#define PRINTINFO_DISPATCH_TYPES(ret, name, func, type, R, ...)               \
     switch (type.basetype) {                                                  \
     case TypeDesc::FLOAT: ret = func<float>(R, __VA_ARGS__); break;           \
     case TypeDesc::UINT8: ret = func<unsigned char>(R, __VA_ARGS__); break;   \
@@ -211,8 +211,8 @@ dump_data(std::ostream& out, ImageInput* input,
 
     } else {
         OIIO_UNUSED_OK bool ok = true;
-        OIIO_DISPATCH_TYPES(ok, "dump_flat_data", dump_flat_data, spec.format,
-                            out, input, opt, subimage);
+        PRINTINFO_DISPATCH_TYPES(ok, "dump_flat_data", dump_flat_data,
+                                 spec.format, out, input, opt, subimage);
     }
 }
 


### PR DESCRIPTION
Unity builds (which we do for CI to speed it up) combine source files,
sometimes in ways that are a bit non-deterministic, and can run into
violations of the ODR that were not a problem when separate definitions
of the same thing (a macro in this case) were in different compilation
units but are in the same one as a unity build.

In this case, a private OIIO_DISPATCH_TYPES macro in printinfo.cpp
conflicted with a different macro of the same name in imagebufalgo_util.h.
