### PR TITLE
style: update our formatting standard to clang-format 17.0 and C++17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -121,7 +121,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        c++14
+Standard:        c++17
 StatementMacros: 
   - Q_UNUSED
   - QT_REQUIRE_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,21 +171,6 @@ jobs:
                              USE_OPENCV=0
             depcmds: sudo rm -rf /usr/local/include/OpenEXR
 
-          # Test formatting. This test entry doesn't do a full build, it
-          # just runs clang-format on everything, and passes if nothing is
-          # misformatted. Upon failure, the build artifact will be the full
-          # source code with the formatting fixed (diffs will also appear in
-          # the console output).
-          - desc: "clang-format"
-            nametag: clang-format
-            runner: ubuntu-latest
-            container: aswf/ci-osl:2022-clang12
-            vfxyear: 2022
-            cxx_std: 17
-            skip_tests: 1
-            setenvs: export BUILDTARGET=clang-format
-                            OIIO_CMAKE_FLAGS=-DUSE_PYTHON=0
-
           # Test ABI stability. `abi_check` is the version or commit that we
           # believe is the current standard against which we don't want to
           # break the ABI. Basically, we will build that version as well as
@@ -387,6 +372,22 @@ jobs:
             depcmds: |
               sudo rm -rf /usr/local/include/OpenEXR
               sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
+          # Test formatting. This test entry doesn't do a full build, it
+          # just runs clang-format on everything, and passes if nothing is
+          # misformatted. Upon failure, the build artifact will be the full
+          # source code with the formatting fixed (diffs will also appear in
+          # the console output).
+          - desc: "clang-format"
+            nametag: clang-format
+            runner: ubuntu-latest
+            cxx_std: 17
+            extra_artifacts: "src/*.*"
+            python_ver: "3.10"
+            skip_tests: 1
+            setenvs: export BUILDTARGET=clang-format
+                            OIIO_CMAKE_FLAGS=-DUSE_PYTHON=0
+                            LLVM_VERSION=17.0.6 LLVM_DISTRO_NAME=ubuntu-22.04
+                            SKIP_SYSTEM_DEPS_INSTALL=1 QT_VERSION=0
 
     runs-on: ${{ matrix.runner }}
     env:
@@ -437,6 +438,7 @@ jobs:
           path: |
             build/cmake-save
             build/testsuite/*/*.*
+            ${{ matrix.extra_artifacts }}
             !build/testsuite/oiio-images
             !build/testsuite/openexr-images
             !build/testsuite/fits-images

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -23,10 +23,11 @@ if [[ `uname` == "Linux" ]] ; then
     ls -l $LLVMTAR
     tar xf $LLVMTAR
     rm -f $LLVMTAR
-    echo "Installed ${LLVM_VERSION} in ${LLVM_INSTALL_DIR}"
+    echo "Installed LLVM ${LLVM_VERSION} in ${LLVM_INSTALL_DIR}"
     mkdir -p $LLVM_INSTALL_DIR && true
     mv clang+llvm*/* $LLVM_INSTALL_DIR
     export LLVM_DIRECTORY=$LLVM_INSTALL_DIR
     export PATH=${LLVM_INSTALL_DIR}/bin:$PATH
+    export LLVM_ROOT=${LLVM_INSTALL_DIR}
     # ls -a $LLVM_DIRECTORY
 fi

--- a/src/build-scripts/ci-build.bash
+++ b/src/build-scripts/ci-build.bash
@@ -57,6 +57,7 @@ if [[ "${DEBUG_CI:=0}" != "0" ]] ; then
 fi
 
 if [[ "$BUILDTARGET" == clang-format ]] ; then
+    echo "Running " `which clang-format` " version " `clang-format --version`
     git diff --color
     THEDIFF=`git diff`
     if [[ "$THEDIFF" != "" ]] ; then

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -75,15 +75,18 @@ else
         git cmake ninja-build ccache g++ \
         libboost-dev libboost-thread-dev libboost-filesystem-dev \
         libilmbase-dev libopenexr-dev \
-        libtbb-dev \
-        libtiff-dev libgif-dev libpng-dev libraw-dev libwebp-dev \
-        libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
-        dcmtk libopenvdb-dev \
-        libfreetype6-dev \
-        locales wget \
-        libopencolorio-dev \
-        libopencv-dev \
-        libhdf5-dev
+        libtiff-dev libgif-dev libpng-dev
+    if [[ "${SKIP_SYSTEM_DEPS_INSTALL}" != "1" ]] ; then
+        time sudo apt-get -q install -y \
+            libraw-dev libwebp-dev \
+            libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
+            dcmtk libopenvdb-dev \
+            libfreetype6-dev \
+            locales wget \
+            libopencolorio-dev \
+            libtbb-dev \
+            libopencv-dev
+    fi
     if [[ "${QT_VERSION:-5}" == "5" ]] ; then
         time sudo apt-get -q install -y \
             qt5-default || /bin/true
@@ -152,7 +155,7 @@ cmake --version
 # If we're using clang to compile on native Ubuntu, we need to install it.
 # If on an ASWF CentOS docker container, it already is installed.
 #
-if [[ "$CXX" == "clang++" && "$ASWF_ORG" == "" ]] ; then
+if [[ ("$CXX" == "clang++" && "$ASWF_ORG" == "") || "$LLVM_VERSION" != "" ]] ; then
     source src/build-scripts/build_llvm.bash
 fi
 

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -491,7 +491,7 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
     }
 
     m_spec   = ImageSpec(m_codec_context->width, m_codec_context->height,
-                       nchannels, datatype);
+                         nchannels, datatype);
     m_stride = (size_t)(m_spec.scanline_bytes());
 
     m_rgb_buffer.resize(av_image_get_buffer_size(m_dst_pix_format,

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -200,9 +200,9 @@ FitsOutput::create_fits_header(void)
             using Strutil::stoi;
             keyname = "Date";
             value   = Strutil::sprintf("%04u-%02u-%02uT%02u:%02u:%02u",
-                                     stoi(&value[0]), stoi(&value[5]),
-                                     stoi(&value[8]), stoi(&value[11]),
-                                     stoi(&value[14]), stoi(&value[17]));
+                                       stoi(&value[0]), stoi(&value[5]),
+                                       stoi(&value[8]), stoi(&value[11]),
+                                       stoi(&value[14]), stoi(&value[17]));
         }
 
         header += create_card(keyname, value);

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -193,8 +193,8 @@ GIFOutput::start_subimage(const ImageSpec& spec)
     if (m_subimage == 0) {
         m_gifwriter.f = ioproxy();
         bool ok       = GifBegin(&m_gifwriter, m_filename.c_str(), m_spec.width,
-                           m_spec.height, m_delay, 8 /*bit depth*/,
-                           true /*dither*/);
+                                 m_spec.height, m_delay, 8 /*bit depth*/,
+                                 true /*dither*/);
         if (!ok) {
             errorfmt("Could not open \"{}\"", m_filename);
             return false;
@@ -216,8 +216,8 @@ GIFOutput::finish_subimage()
         return true;
 
     bool ok         = GifWriteFrame(&m_gifwriter, &m_canvas[0], spec().width,
-                            spec().height, m_delay, 8 /*bitdepth*/,
-                            true /*dither*/);
+                                    spec().height, m_delay, 8 /*bitdepth*/,
+                                    true /*dither*/);
     m_pending_write = false;
     return ok;
 }

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -189,7 +189,7 @@ public:
     ArgParse(int argc, const char** argv);
 
     // Disallow copy ctr and assignment
-    ArgParse(const ArgParse&) = delete;
+    ArgParse(const ArgParse&)                  = delete;
     const ArgParse& operator=(const ArgParse&) = delete;
 
     /// Move constructor
@@ -426,7 +426,7 @@ public:
         {
         }
         // Disallow copy ctr and assignment
-        Arg(const Arg&)    = delete;
+        Arg(const Arg&)                  = delete;
         const Arg& operator=(const Arg&) = delete;
 
         /// Set the help / description of this command line argument.

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -30,7 +30,8 @@ public:
     // in bytes, between subsequent color channels, pixels, and scanlines.
     virtual void apply(float* data, int width, int height, int channels,
                        stride_t chanstride, stride_t xstride,
-                       stride_t ystride) const = 0;
+                       stride_t ystride) const
+        = 0;
     // Convert a single 3-color
     void apply(float* data)
     {
@@ -348,7 +349,7 @@ public:
     static const ColorConfig& default_colorconfig();
 
 private:
-    ColorConfig(const ColorConfig&) = delete;
+    ColorConfig(const ColorConfig&)            = delete;
     ColorConfig& operator=(const ColorConfig&) = delete;
 
     class Impl;

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -415,6 +415,5 @@ constexpr ptrdiff_t ssize(const OIIO::span_strided<T, E>& c) {
 namespace fmt {
 template<typename T, OIIO::oiio_span_size_type Extent>
 struct formatter<OIIO::span<T, Extent>>
-    : OIIO::pvt::index_formatter<OIIO::span<T, Extent>> {
-};
+    : OIIO::pvt::index_formatter<OIIO::span<T, Extent>> {};
 }  // namespace fmt

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -1032,15 +1032,16 @@ inline ustring::ustring(ustringhash hash)
 
 
 /// ustring string literal operator
-inline ustring operator""_us(const char* str, std::size_t len)
+inline ustring
+operator""_us(const char* str, std::size_t len)
 {
     return ustring(str, len);
 }
 
 
 /// ustringhash string literal operator
-OIIO_DEVICE_CONSTEXPR ustringhash operator""_ush(const char* str,
-                                                 std::size_t len)
+OIIO_DEVICE_CONSTEXPR ustringhash
+operator""_ush(const char* str, std::size_t len)
 {
     return ustringhash(str, len);
 }

--- a/src/include/OpenImageIO/vecparam.h
+++ b/src/include/OpenImageIO/vecparam.h
@@ -168,8 +168,7 @@ public:
 
 /// C arrays of just the right length also are qualified for has_subscript_N.
 template<typename Base, int Nelem>
-struct has_subscript_N<Base[Nelem], Base, Nelem> : public std::true_type {
-};
+struct has_subscript_N<Base[Nelem], Base, Nelem> : public std::true_type {};
 
 
 
@@ -203,8 +202,7 @@ public:
 /// C arrays of just the right length also are qualified for has_double_subscript_RC.
 template<typename Base, int Rows, int Cols>
 struct has_double_subscript_RC<Base[Rows][Cols], Base, Rows, Cols>
-    : public std::true_type {
-};
+    : public std::true_type {};
 
 /// @}
 

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -598,10 +598,10 @@ IvGL::paintGL()
     ybegin     = std::max(spec.y, ybegin - (ybegin % m_texture_height));
     int xend   = (int)floor(real_centerx) + wincenterx;
     xend       = std::min(spec.x + spec.width,
-                    xend + m_texture_width - (xend % m_texture_width));
+                          xend + m_texture_width - (xend % m_texture_width));
     int yend   = (int)floor(real_centery) + wincentery;
     yend       = std::min(spec.y + spec.height,
-                    yend + m_texture_height - (yend % m_texture_height));
+                          yend + m_texture_height - (yend % m_texture_height));
     //std::cerr << "(" << xbegin << ',' << ybegin << ") - (" << xend << ',' << yend << ")\n";
 
     // Provide some feedback

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -320,7 +320,7 @@ Jpeg2000Input::open(const std::string& name, ImageSpec& p_spec)
     // std::cout << "color_space=" << m_image->color_space << "\n";
     TypeDesc format = (maxPrecision <= 8) ? TypeDesc::UINT8 : TypeDesc::UINT16;
     m_spec   = ImageSpec(datawindow.width(), datawindow.height(), channelCount,
-                       format);
+                         format);
     m_spec.x = datawindow.xbegin;
     m_spec.y = datawindow.ybegin;
     m_spec.full_x      = m_image->x0;

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -44,7 +44,8 @@ static ImageBuf imgA, imgB, imgR;
 
 
 
-static void test_arrays(ROI)
+static void
+test_arrays(ROI)
 {
     const float* a = (const float*)imgA.localpixels();
     OIIO_DASSERT(a);
@@ -79,7 +80,8 @@ test_arrays_like_image(ROI roi)
 
 
 
-static void test_arrays_simd4(ROI)
+static void
+test_arrays_simd4(ROI)
 {
     const float* a = (const float*)imgA.localpixels();
     OIIO_DASSERT(a);

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1009,7 +1009,7 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
         if (m_nsubimages) {
             m_badfile          = false;
             m_pixelaspect      = m_spec.get_float_attribute("pixelaspectratio",
-                                                       1.0f);
+                                                            1.0f);
             m_current_subimage = subimage;
             m_current_miplevel = miplevel;
             m_spec_valid       = true;
@@ -2130,7 +2130,7 @@ interppixel_(const ImageBuf& img, float x, float y, float* pixel,
     int n             = img.spec().nchannels;
     float* localpixel = OIIO_ALLOCA(float, n * 4);
     float* p[4]       = { localpixel, localpixel + n, localpixel + 2 * n,
-                    localpixel + 3 * n };
+                          localpixel + 3 * n };
     x -= 0.5f;
     y -= 0.5f;
     int xtexel, ytexel;
@@ -2949,7 +2949,7 @@ ImageBufImpl::retile(int x, int y, int z, ImageCache::Tile*& tile,
         tilezbegin = m_spec.z + ztile * td;
         tilexend   = tilexbegin + tw;
         tile       = m_imagecache->get_tile(m_name, m_current_subimage,
-                                      m_current_miplevel, x, y, z);
+                                            m_current_miplevel, x, y, z);
         if (!tile) {
             // Even though tile is NULL, ensure valid black pixel data
             std::string e = m_imagecache->geterror();

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -906,10 +906,10 @@ text_size_from_unicode(cspan<uint32_t> utext, FT_Face face, int fontsize)
             continue;  // ignore errors
         size.ybegin = std::min(size.ybegin, y - slot->bitmap_top);
         size.yend   = std::max(size.yend, y + int(slot->bitmap.rows)
-                                            - int(slot->bitmap_top) + 1);
+                                              - int(slot->bitmap_top) + 1);
         size.xbegin = std::min(size.xbegin, x + int(slot->bitmap_left));
         size.xend   = std::max(size.xend, x + int(slot->bitmap.width)
-                                            + int(slot->bitmap_left) + 1);
+                                              + int(slot->bitmap_left) + 1);
         // increment pen position
         x += slot->advance.x >> 6;
     }

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -207,7 +207,7 @@ catalog_plugin(const std::string& format_name,
 
     std::string version_function = format_name + "_imageio_version";
     int* plugin_version          = (int*)Plugin::getsym(handle,
-                                               version_function.c_str());
+                                                        version_function.c_str());
     if (!plugin_version || *plugin_version != OIIO_PLUGIN_VERSION) {
         Plugin::close(handle);
         return;

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -500,7 +500,7 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
                                 m_spec.z + m_spec.depth);
             for (int y = 0; y < m_spec.height; y += m_spec.tile_height) {
                 int yend      = std::min(y + m_spec.y + m_spec.tile_height,
-                                    m_spec.y + m_spec.height);
+                                         m_spec.y + m_spec.height);
                 const char* d = (const char*)data + z * zstride + y * ystride;
                 ok &= write_tiles(m_spec.x, m_spec.x + m_spec.width,
                                   y + m_spec.y, yend, z + m_spec.z, zend,
@@ -521,7 +521,7 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
         for (int z = 0; z < m_spec.depth; ++z)
             for (int y = 0; y < m_spec.height && ok; y += chunk) {
                 int yend      = std::min(y + m_spec.y + chunk,
-                                    m_spec.y + m_spec.height);
+                                         m_spec.y + m_spec.height);
                 const char* d = (const char*)data + z * zstride + y * ystride;
                 ok &= write_scanlines(y + m_spec.y, yend, z + m_spec.z, format,
                                       d, xstride, ystride);

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -456,7 +456,7 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
     float invsamples;
     if (aniso) {
         aspect    = anisotropic_aspect(majorlength, minorlength, options,
-                                    trueaspect);
+                                       trueaspect);
         filtwidth = minorlength;
         if (trueaspect > stats.max_aniso)
             stats.max_aniso = trueaspect;
@@ -501,7 +501,7 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
                 miplevel[0] = m - 1;
                 miplevel[1] = m;
                 levelblend  = OIIO::clamp(2.0f * filtwidth_ras - 1.0f, 0.0f,
-                                         1.0f);
+                                          1.0f);
                 break;
             }
         }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -584,7 +584,7 @@ ImageCacheFile::open(ImageCachePerThreadInfo* thread_info)
                     }
                     tempspec.tile_height = std::min(tempspec.height, autotile);
                     tempspec.tile_depth  = std::min(std::max(tempspec.depth, 1),
-                                                   autotile);
+                                                    autotile);
                 } else {
                     // Don't auto-tile -- which really means, make it look like
                     // a single tile that's as big as the whole image.

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1753,8 +1753,8 @@ ellipse_axes(float dsdx, float dtdx, float dsdy, float dtdy, float& majorlength,
     minorlength = std::min(safe_sqrt (float(F / Cprime)), 1000.0f);
 #else
     // Wolfram says that this is equivalent to:
-    majorlength  = std::min(safe_sqrt(float(Cprime)), 1000.0f);
-    minorlength  = std::min(safe_sqrt(float(Aprime)), 1000.0f);
+    majorlength = std::min(safe_sqrt(float(Cprime)), 1000.0f);
+    minorlength = std::min(safe_sqrt(float(Aprime)), 1000.0f);
 #endif
     theta = fast_atan2(B, A - C) * 0.5f + float(M_PI_2);
     if (ABCF) {
@@ -2552,7 +2552,7 @@ namespace {
         OIIO_SIMD_FLOAT4_CONST4(z22z, 0.0f, 2.0f, 2.0f, 0.0f);
         simd::vfloat4 one_frac = vfloat4::One() - fraction;
         simd::vfloat4 ofof     = AxBxAyBy(one_frac,
-                                      fraction);  // 1-frac, frac, 1-frac, frac
+                                          fraction);  // 1-frac, frac, 1-frac, frac
         simd::vfloat4 C = (*(vfloat4*)&om1m1o) * ofof + (*(vfloat4*)&z22z);
         return (*(vfloat4*)&A) + (*(vfloat4*)&B) * ofof * ofof * C;
 #endif
@@ -3008,8 +3008,8 @@ TextureSystemImpl::visualize_ellipse(const std::string& name, float dsdx,
     TextureOpt options;
     float trueaspect;
     float aspect      = TextureSystemImpl::anisotropic_aspect(majorlength,
-                                                         minorlength, options,
-                                                         trueaspect);
+                                                              minorlength, options,
+                                                              trueaspect);
     bool stoch_aniso  = (m_stochastic & StochasticStrategy_Aniso);
     int maxsamples    = round_to_multiple_of_pow2(2 * options.anisotropic, 4);
     float* lineweight = OIIO_ALLOCA(float, 4 * maxsamples);

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -67,11 +67,11 @@ static void
 test_old()
 {
     auto args   = split_commands("basic alpha --flag --unflag --intarg 42 "
-                               "--floatarg 3.5 --stringarg foo "
-                               "--append xxx --append yyy "
-                               "--hidden "
-                               "--callback who "
-                               "bravo charlie");
+                                   "--floatarg 3.5 --stringarg foo "
+                                   "--append xxx --append yyy "
+                                   "--hidden "
+                                   "--callback who "
+                                   "bravo charlie");
     bool flag   = false;
     bool unflag = true;
     bool hidden = false;

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -506,7 +506,7 @@ Filesystem::unique_path(string_view model)
     // to convert char* to wchar_t* because they do not know the encoding
     // See boost/filesystem/path.hpp
     // The only correct way to do this is to do the conversion ourselves
-    std::wstring modelStr    = Strutil::utf8_to_utf16wstring(model);
+    std::wstring modelStr = Strutil::utf8_to_utf16wstring(model);
 #    else
     std::string modelStr = model.str();
 #    endif

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -78,7 +78,7 @@ test_1d()
         // Graph it
         float scale          = normalize ? 1.0f / (*f)(0.0f) : 1.0f;
         float color[3]       = { 0.25f * (i & 3), 0.25f * ((i >> 2) & 3),
-                           0.25f * ((i >> 4) & 3) };
+                                 0.25f * ((i >> 4) & 3) };
         std::string filtname = filtdesc.name;
         if (filtdesc.name != f->name())
             filtname = Strutil::fmt::format("{} ({})", filtname, f->name());
@@ -132,7 +132,7 @@ test_2d()
         // Graph it
         float scale          = normalize ? 1.0f / (*f)(0.0f, 0.0f) : 1.0f;
         float color[3]       = { 0.25f * (i & 3), 0.25f * ((i >> 2) & 3),
-                           0.25f * ((i >> 4) & 3) };
+                                 0.25f * ((i >> 4) & 3) };
         std::string filtname = filtdesc.name;
         if (filtdesc.name != f->name())
             filtname = Strutil::fmt::format("{} ({})", filtname, f->name());

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -233,7 +233,7 @@ Strutil::vsprintf(const char* fmt, va_list ap)
 #ifdef va_copy
         va_copy(ap, apsave);
 #else
-        ap     = apsave;
+        ap = apsave;
 #endif
     }
 }

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -301,10 +301,10 @@ public:
     bool very_busy() const { return jobs_in_queue() > size_t(4 * m_size); }
 
 private:
-    Impl(const Impl&) = delete;
-    Impl(Impl&&)      = delete;
+    Impl(const Impl&)            = delete;
+    Impl(Impl&&)                 = delete;
     Impl& operator=(const Impl&) = delete;
-    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl&&)      = delete;
 
     void set_thread(int i)
     {

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -24,8 +24,7 @@
 using namespace OIIO;
 
 
-struct notype {
-};
+struct notype {};
 
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -418,7 +418,7 @@ Oiiotool::remember_input_channelformats(ImageRecRef img)
         // Overall default format is the merged type of all subimages
         // of the first input image.
         input_dataformat         = TypeDesc::basetype_merge(input_dataformat,
-                                                    nspec.format);
+                                                            nspec.format);
         std::string subimagename = nspec.get_string_attribute(
             "oiio:subimagename");
         if (subimagename.size()) {
@@ -786,7 +786,7 @@ set_output_dataformat(ImageSpec& spec, TypeDesc format,
         for (int c = 0; c < spec.nchannels; ++c) {
             std::string chname = spec.channel_name(c);
             auto subchname     = Strutil::fmt::format("{}.{}", subimagename,
-                                                  chname);
+                                                      chname);
             if (channelformats[subchname] != "" && subimagename.size())
                 spec.channelformats[c] = TypeDesc(channelformats[subchname]);
             else if (channelformats[chname] != "")
@@ -3167,7 +3167,7 @@ action_chappend(Oiiotool& ot, cspan<const char*> argv)
     std::string command = ot.express(argv[0]);
     auto options        = ot.extract_options(command);
     int n               = OIIO::clamp(options["n"].get<int>(2), 2,
-                        int(ot.image_stack.size() + 1));
+                                      int(ot.image_stack.size() + 1));
     command             = remove_modifier(command, "n");
     bool ok             = true;
 
@@ -3361,7 +3361,7 @@ action_subimage_append(Oiiotool& ot, cspan<const char*> argv)
     OTScopedTimer timer(ot, command);
     auto options = ot.extract_options(command);
     int n        = OIIO::clamp(options["n"].get<int>(2), 2,
-                        int(ot.image_stack.size() + 1));
+                               int(ot.image_stack.size() + 1));
 
     action_subimage_append_n(ot, n, command);
 }
@@ -4565,7 +4565,7 @@ action_pixelaspect(Oiiotool& ot, cspan<const char*> argv)
     if (scale_full_width != Aspec->full_width
         || scale_full_height != Aspec->full_height) {
         std::string resize  = format_resolution(scale_full_width,
-                                               scale_full_height, 0, 0);
+                                                scale_full_height, 0, 0);
         std::string command = "resize";
         if (filtername.size())
             command += Strutil::fmt::format(":filter={}", filtername);
@@ -5743,10 +5743,10 @@ output_file(Oiiotool& ot, cspan<const char*> argv)
         roi.zend           = std::max(roi.zbegin + 1, roi.zend);
         std::string crop   = (ir->spec(0, 0)->depth == 1)
                                  ? format_resolution(roi.width(), roi.height(),
-                                                   roi.xbegin, roi.ybegin)
+                                                     roi.xbegin, roi.ybegin)
                                  : format_resolution(roi.width(), roi.height(),
-                                                   roi.depth(), roi.xbegin,
-                                                   roi.ybegin, roi.zbegin);
+                                                     roi.depth(), roi.xbegin,
+                                                     roi.ybegin, roi.zbegin);
         const char* argv[] = { "crop:allsubimages=1", crop.c_str() };
         void action_crop(Oiiotool & ot,
                          cspan<const char*> argv);  // forward decl

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1432,9 +1432,9 @@ OpenEXROutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
         int y1         = std::min(ybegin + chunk, yend);
         int nscanlines = y1 - ybegin;
         const void* d  = to_native_rectangle(m_spec.x, m_spec.x + m_spec.width,
-                                            ybegin, y1, z, z + 1, format, data,
-                                            xstride, ystride, zstride,
-                                            m_scratch);
+                                             ybegin, y1, z, z + 1, format, data,
+                                             xstride, ystride, zstride,
+                                             m_scratch);
 
         // Compute where OpenEXR needs to think the full buffers starts.
         // OpenImageIO requires that 'data' points to where client stored

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -61,7 +61,10 @@ wrerr_handler(png_structp png, png_const_charp data)
 }
 
 
-static void null_png_handler(png_structp /*png*/, png_const_charp /*data*/) {}
+static void
+null_png_handler(png_structp /*png*/, png_const_charp /*data*/)
+{
+}
 
 
 
@@ -625,7 +628,7 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
         if (icc_profile && length)
             png_set_iCCP(sp, ip, "Embedded Profile", 0, icc_profile, length);
 #else
-        char* icc_profile      = (char*)icc_profile_parameter->data();
+        char* icc_profile = (char*)icc_profile_parameter->data();
         if (icc_profile && length)
             png_set_iCCP(sp, ip, (png_charp) "Embedded Profile", 0, icc_profile,
                          length);

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1108,7 +1108,8 @@ PSDInput::handle_resources(ImageResourceMap& resources)
 
 
 
-bool PSDInput::load_resource_1005(uint32_t /*length*/)
+bool
+PSDInput::load_resource_1005(uint32_t /*length*/)
 {
     ResolutionInfo resinfo;
     // Fixed 16.16
@@ -1170,7 +1171,8 @@ PSDInput::load_resource_1006(uint32_t length)
 
 
 
-bool PSDInput::load_resource_1010(uint32_t /*length*/)
+bool
+PSDInput::load_resource_1010(uint32_t /*length*/)
 {
     int8_t color_id = 0;
     int32_t color   = 0;
@@ -1220,7 +1222,8 @@ PSDInput::load_resource_1039(uint32_t length)
 
 
 
-bool PSDInput::load_resource_1047(uint32_t /*length*/)
+bool
+PSDInput::load_resource_1047(uint32_t /*length*/)
 {
     if (!read_bige<int16_t>(m_transparency_index))
         return false;
@@ -1278,7 +1281,8 @@ PSDInput::load_resource_1060(uint32_t length)
 
 
 
-bool PSDInput::load_resource_1064(uint32_t /*length*/)
+bool
+PSDInput::load_resource_1064(uint32_t /*length*/)
 {
     uint32_t version;
     if (!read_bige<uint32_t>(version))
@@ -1579,7 +1583,7 @@ PSDInput::load_layer_channel(Layer& layer, ChannelInfo& channel_info)
     uint32_t width, height;
     if (channel_info.channel_id == ChannelID_LayerMask) {
         width  = (uint32_t)std::abs((int)layer.mask_data.right
-                                   - (int)layer.mask_data.left);
+                                    - (int)layer.mask_data.left);
         height = (uint32_t)std::abs((int)layer.mask_data.bottom
                                     - (int)layer.mask_data.top);
     } else {

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -10,8 +10,7 @@
 namespace PyOpenImageIO {
 
 
-class IBA_dummy {
-};  // dummy class to establish a scope
+class IBA_dummy {};  // dummy class to establish a scope
 
 
 

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -546,7 +546,7 @@ make_numpy_array(T* data, int dims, size_t chans, size_t width, size_t height,
     // Create a Python object that will free the allocated memory when
     // destroyed:
     py::capsule free_when_done(mem, [](void* f) {
-        delete[](reinterpret_cast<T*>(f));
+        delete[] (reinterpret_cast<T*>(f));
     });
 
     std::vector<size_t> shape, strides;
@@ -600,7 +600,7 @@ make_numpy_array(TypeDesc format, void* data, int dims, size_t chans,
                                 depth);
     if (format == TypeDesc::INT)
         return make_numpy_array((int*)data, dims, chans, width, height, depth);
-    delete[](char*) data;
+    delete[] (char*)data;
     return py::none();
 }
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -296,7 +296,7 @@ exif_parser_cb(ImageSpec* spec, int tag, int tifftype, int len,
     // std::cerr << "Stream position " << streampos << "\n";
 
     TypeDesc type          = tiff_datatype_to_typedesc(TIFFDataType(tifftype),
-                                              size_t(len));
+                                                       size_t(len));
     const TagInfo* taginfo = tag_lookup("Exif", tag);
     if (!taginfo) {
         // print(stderr, "NO TAGINFO FOR CALLBACK tag=%d (0x{:x}): tifftype={},len={} ({}), byteorder=0x{:x}\n",

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1117,7 +1117,10 @@ test_texture3d_batch(ustring filename, Mapping3DWide mapping)
 
 
 
-static void test_shadow(ustring /*filename*/) {}
+static void
+test_shadow(ustring /*filename*/)
+{
+}
 
 
 
@@ -1856,8 +1859,8 @@ main(int argc, const char* argv[])
     if (gtiname.size()) {
         const char* attrib = nullptr;
         bool result        = texsys->get_texture_info(filenames[0], 0,
-                                               ustring(gtiname), TypeString,
-                                               &attrib);
+                                                      ustring(gtiname), TypeString,
+                                                      &attrib);
         if (result)
             Strutil::print("Image \"{}\" attrib \"{}\" = \"{}\"\n",
                            filenames[0], gtiname, attrib);

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -611,7 +611,10 @@ reader_mapproc(thandle_t, tdata_t*, toff_t*)
     return 0;
 }
 
-static void reader_unmapproc(thandle_t, tdata_t, toff_t) {}
+static void
+reader_unmapproc(thandle_t, tdata_t, toff_t)
+{
+}
 
 
 
@@ -1948,7 +1951,7 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             char* cbuf        = compressed_scratch.get() + stripidx * cbound;
             tstrip_t stripnum = (y - m_spec.y) / m_rowsperstrip;
             tsize_t csize     = TIFFReadRawStrip(m_tif, stripnum, cbuf,
-                                             tmsize_t(cbound));
+                                                 tmsize_t(cbound));
             if (csize < 0) {
                 std::string err = oiio_tiff_last_error();
                 errorfmt("TIFFRead{}Strip failed reading line y={},z={}: {}",

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -399,7 +399,11 @@ allval(const std::vector<T>& d, T v = T(0))
 }
 
 
-static tsize_t writer_readproc(thandle_t, tdata_t, tsize_t) { return 0; }
+static tsize_t
+writer_readproc(thandle_t, tdata_t, tsize_t)
+{
+    return 0;
+}
 
 static tsize_t
 writer_writeproc(thandle_t handle, tdata_t data, tsize_t size)
@@ -444,7 +448,10 @@ writer_mapproc(thandle_t, tdata_t*, toff_t*)
     return 0;
 }
 
-static void writer_unmapproc(thandle_t, tdata_t, toff_t) {}
+static void
+writer_unmapproc(thandle_t, tdata_t, toff_t)
+{
+}
 
 
 
@@ -1317,8 +1324,8 @@ TIFFOutput::compress_one_strip(void* uncompressed_buf, size_t strip_bytes,
                              height);
     *compressed_size = cbound;
     auto zok         = compress2((Bytef*)compressed_buf, compressed_size,
-                         (const Bytef*)uncompressed_buf,
-                         (unsigned long)strip_bytes, m_zipquality);
+                                 (const Bytef*)uncompressed_buf,
+                                 (unsigned long)strip_bytes, m_zipquality);
     if (zok != Z_OK)
         *ok = false;
 }


### PR DESCRIPTION
Bump our clang-format standard from llvm 12 to llvm 17, and our
C++ standard (for formatting) to 17.

Fixes/improvements along the way:

* Moved the clang-format CI test from an aswf container to bare Ubuntu
  to make it run faster -- it doesn't need most of the dependencies,
  so there's no point wasting 2 minutes or so downloading a container.

* build_llvm.bash: Make sure llvm installs when needed, even if not
  using clang.

* gh-installdeps.bash: Setting SKIP_SYSTEM_DEPS_INSTALL=1 skips
  installation of many non-essential dependencies.

There is some reformatting here and there as 12->17 changed some formatting
choices somewhat, but it's fairly minor. Most changes are improvements,
some are neutral, a few are inexplicable but not less readable than before.
We've long since accepted the tradeoff that using clang-format makes some
things formatted differently/worse than we would have preferred, but we deem
it worthy of the benefit of having it all 10% automatic and never fighting
over formatting in PRs.