### PR TITLE
clean up after removing Findfmt.cmake

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -169,13 +169,6 @@ if (MINGW)
     target_link_libraries (OpenImageIO PRIVATE ws2_32)
 endif()
 
-if (INTERNALIZE_FMT OR OIIO_USING_FMT_LOCAL)
-    add_dependencies(OpenImageIO_Util fmt_internal_target)
-else ()
-    target_link_libraries (OpenImageIO_Util
-                           PUBLIC fmt::fmt-header-only)
-endif ()
-
 file (GLOB iba_sources "imagebufalgo_*.cpp")
 if (MSVC)
     # In some MSVC setups, the IBA functions with huge template expansions


### PR DESCRIPTION
## Description

Remove duplicate dependecy for OpenImageIO_Util to fmt.
OpenImageIO target already depends on fmt through OpenImangeIO_Util library.

## Checklist:

- [X] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
