### PR TITLE
Fixes to reduce problems identified by static analysis

### DIFF
--- a/src/dpx.imageio/libdpx/WriterInternal.h
+++ b/src/dpx.imageio/libdpx/WriterInternal.h
@@ -203,7 +203,11 @@ namespace dpx
 	// this routine expects a type of U16
 	template <typename IB, Packing METHOD>
 	void WritePackedMethodAB_10bit(IB *src, IB *dst, const int len, const bool reverse, BufferAccess &access)
-	{	
+    {
+		OIIO_DASSERT(len >= 1);
+		if (len < 1)
+			return;
+
 		// pack into the same memory space
 		U32 *dst_u32 = reinterpret_cast<U32*>(dst);
 	

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -147,7 +147,7 @@ ImageBufAlgo::mad(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_,
         A_.swap(B_);
     // Get pointers to any image. At least one of A or B must be an image.
     const ImageBuf *A = A_.imgptr(), *B = B_.imgptr(), *C = C_.imgptr();
-    if (!A && !B) {
+    if (!A) {
         dst.errorfmt(
             "ImageBufAlgo::mad(): at least one of the first two arguments must be an image");
         return false;

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -529,6 +529,7 @@ OiioTool::print_info(std::ostream& out, Oiiotool& ot, ImageRec* img,
     }
 
     for (int s = 0, nsubimages = img->subimages(); s < nsubimages; ++s) {
+        DASSERT((opt.native ? img->nativespec(s) : img->spec(s)) != nullptr);
         print_info_subimage(out, ot, s, nsubimages, img->miplevels(s),
                             opt.native ? *img->nativespec(s) : *img->spec(s),
                             img, nullptr, "", opt, field_re, field_exclude_re,

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -119,7 +119,10 @@ PNGOutput::PNGOutput() { init(); }
 PNGOutput::~PNGOutput()
 {
     // Close, if not already done.
-    close();
+    try {
+        close();
+    } catch (...) {
+    }
 }
 
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1413,6 +1413,7 @@ do_tex_thread_workout(int iterations, int mythread)
     float s = 0.1f, t = 0.1f;
     int nchannels = nchannels_override ? nchannels_override : 3;
     float* result = OIIO_ALLOCA(float, nchannels);
+    memset(result, 0, sizeof(float) * nchannels);
     TextureOpt opt;
     initialize_opt(opt);
     float* dresultds = test_derivs ? OIIO_ALLOCA(float, nchannels) : NULL;


### PR DESCRIPTION
* pngoutput.cpp: Catch possible exceptions.
* printinfo.cpp: assertions to assure we don't dereference a null pointer.
* testtex.cpp: make sure allocated chunk is initialized
* WriterInternal.h: Catch condition that could lead to buffer underflow.
* imagebufalgo_mad.cpp: Simplify pointless clause. The prior test was redundant. Since a few lines above, if B was an image but A was not, we swapped to ensure that A was always an image. So here, we can just test A to know for sure that at least one of them is an image. That makes the test here simpler, but it also makes it more clear to static analysis that from this point forward, A can't be nullptr.
