### PR TITLE
build(deps): deal with changes in fmt's trunk

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -65,13 +65,13 @@ install (FILES ${detail_headers}
          COMPONENT developer)
 
 if (INTERNALIZE_FMT OR OIIO_USING_FMT_LOCAL)
-    set (fmt_headers_base_names core.h format-inl.h format.h ostream.h printf.h)
-    if (fmt_VERSION VERSION_GREATER_EQUAL 9)
-        list (APPEND fmt_headers_base_names std.h)
-    endif ()
-    if (EXISTS "${FMT_INCLUDE_DIR}/fmt/base.h")
-        list (APPEND fmt_headers_base_names base.h)
-    endif ()
+    set (fmt_headers_base_names)
+    foreach (header_name core.h format-inl.h format.h ostream.h printf.h
+             std.h base.h chrono.h)
+        if (EXISTS "${FMT_INCLUDE_DIR}/fmt/${header_name}")
+             list (APPEND fmt_headers_base_names ${header_name})
+        endif ()
+    endforeach ()
     set (fmt_internal_directory ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt)
     list (TRANSFORM fmt_headers_base_names
           PREPEND ${FMT_INCLUDE_DIR}/fmt/

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -64,6 +64,13 @@ OIIO_PRAGMA_WARNING_PUSH
 
 OIIO_PRAGMA_WARNING_POP
 
+// At some point a method signature changed
+#if FMT_VERSION >= 90000
+#    define OIIO_FMT_CUSTOM_FORMATTER_CONST const
+#else
+#    define OIIO_FMT_CUSTOM_FORMATTER_CONST
+#endif
+
 
 OIIO_NAMESPACE_BEGIN
 namespace pvt {
@@ -118,7 +125,8 @@ template<typename T,
          OIIO_ENABLE_IF(has_subscript<T>::value&& has_size_method<T>::value)>
 struct index_formatter : format_parser_with_separator {
     // inherits parse() from format_parser_with_separator
-    template<typename FormatContext> auto format(const T& v, FormatContext& ctx)
+    template<typename FormatContext>
+    auto format(const T& v, FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
     {
         std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
                                             : std::string("{}");
@@ -162,7 +170,8 @@ struct index_formatter : format_parser_with_separator {
 template<typename T, typename Elem, int Size>
 struct array_formatter : format_parser_with_separator {
     // inherits parse() from format_parser_with_separator
-    template<typename FormatContext> auto format(const T& v, FormatContext& ctx)
+    template<typename FormatContext>
+    auto format(const T& v, FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
     {
         std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
                                             : std::string("{}");

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -620,7 +620,8 @@ struct formatter<OIIO::TypeDesc> {
     }
 
     template <typename FormatContext>
-    auto format(const OIIO::TypeDesc& t, FormatContext& ctx) -> decltype(ctx.out()) const {
+    auto format(const OIIO::TypeDesc& t, FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
+    {
         // C++14:   auto format(const OIIO::TypeDesc& p, FormatContext& ctx) const {
         // ctx.out() is an output iterator to write to.
         return format_to(ctx.out(), "{}", t.c_str());

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -1154,8 +1154,8 @@ FMT_BEGIN_NAMESPACE
 
 template<> struct formatter<OIIO::ustring> : formatter<fmt::string_view, char> {
     template<typename FormatContext>
-    auto format(const OIIO::ustring& u, FormatContext& ctx)
-        -> decltype(ctx.out()) const
+    auto format(const OIIO::ustring& u,
+                FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
     {
         return formatter<fmt::string_view, char>::format({ u.data(), u.size() },
                                                          ctx);
@@ -1165,8 +1165,8 @@ template<> struct formatter<OIIO::ustring> : formatter<fmt::string_view, char> {
 template<>
 struct formatter<OIIO::ustringhash> : formatter<fmt::string_view, char> {
     template<typename FormatContext>
-    auto format(const OIIO::ustringhash& h, FormatContext& ctx)
-        -> decltype(ctx.out()) const
+    auto format(const OIIO::ustringhash& h,
+                FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
     {
         OIIO::ustring u(h);
         return formatter<fmt::string_view, char>::format({ u.data(), u.size() },


### PR DESCRIPTION
Bleeding edge CI test failures due to more changes in fmt's trunk. Solutions:

* Accommodate some recent header refactoring in fmt.

* Straighten up some const issues that worked before, but break under the latest fmt. Making the custom formatter's 'format' method be const fixes the latest, but breaks some of the oldest versions of fmt we support, so we add the const only from fmt 9.0 on.
