### PR TITLE
iv: Assume iv display gamma 2.2

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -118,7 +118,7 @@ ImageViewer::ImageViewer(bool use_ocio, const std::string& image_color_space,
 {
     readSettings(false);
 
-    float gam = Strutil::stof(Sysutil::getenv("GAMMA"));
+    float gam = Strutil::stof(Sysutil::getenv("GAMMA", "2.2"));
     if (gam >= 0.1 && gam <= 5)
         m_default_gamma = gam;
     // FIXME -- would be nice to have a more nuanced approach to display


### PR DESCRIPTION
A better default for users is probably to assume a 2.2 value if the GAMMA env variable is not set. If you want something different, set GAMMA proactively or use a real color managed workflow.

Will this break anybody in important ways?

Fixes #318
