### PR TITLE
Fix AVX-512 round function

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -10180,7 +10180,7 @@ OIIO_FORCEINLINE vfloat16 floor (const vfloat16& a)
 OIIO_FORCEINLINE vfloat16 round (const vfloat16& a)
 {
 #if OIIO_SIMD_AVX >= 512
-    return _mm512_roundscale_ps (a, (1<<4) | 3); // scale=1, round to nearest smaller mag int
+    return _mm512_roundscale_ps (a, (_MM_FROUND_TO_NEAREST_INT |_MM_FROUND_NO_EXC));
 #else
     return vfloat16(round(a.lo()), round(a.hi()));
 #endif


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description
This PR fixes vfloat16 round function. Intrinsic `_mm512_roundscale_ps` was
used incorrectly, and caused failure on Zen4 CPU.

```
/var/tmp/portage/media-libs/openimageio-2.5.5.0-r1/work/OpenImageIO-2.5.5.0/src/libutil/simd_test.cpp:1579:
FAILED: round(F) == mkvec<VEC>(std::round(F[0]), std::round(F[1]), std::round(F[2]), std::round(F[3]))
	values were '-1.5 0 1.5 4 -1.5 0 1.5 4 -1.5 0 1.5 4 -1.5 0 1.5 4' and '-2 0 2 4 -2 0 2 4 -2 0 2 4 -2 0 2 4'
``` 

In old code `_mm512_roundscale_ps (a, (1<<4) | 3)` meant the following:
```
[0001] - Number of fixed points to preserve
[0] - Use MSCSR exception mask
[0] - Select mode from imm
[11] - Truncate mode
```
Effectively enabling rounding to nearest 0.5, not to integer.

References:
* https://www.felixcloutier.com/x86/vrndscalepd#fig-5-29
* https://stackoverflow.com/questions/50854991/instrinsic-mm512-round-ps-is-missing-for-avx512
<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests
* This fixes test_simd
<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
