### PR TITLE
feat: query/print build information

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,29 +8,40 @@ assignees: ''
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is. What happened, and
 what did you expect to happen instead.
 
+
+**OpenImageIO version and dependencies**
+
+Please run `oiiotool --buildinfo` and paste the output here.
+
+Also please tell us if there was anything unusual about your environment or
+nonstandard build options you used.
+
+
 **To Reproduce**
+
 Steps to reproduce the behavior:
 1. Do this...
 2. Then this...
 3. Then THIS happens (reproduce the exact error message if you can)
+4. Whereas I expected this other specific thing to happen instead.
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+If the problem occurs in your C++ or Python code that uses the OIIO APIs, can
+you also reproduce the problem using oiiotool? If so, please describe the
+exact command line that reproduces the problem. (Being able to reproduce the
+problem using only OIIO components makes it a lot easier for the developers
+investigate and makes it clear it's not your application's fault.)
+
 
 **Evidence**
-Do you have error messages? (please quote exactly) Screenshots? Example
-command lines or scripts that reliably reproduce the error? If it only
-happens with certain image files, can you attach the smallest image you
-can make that reproduces the problem?
 
-**Platform information:**
- - OIIO branch/version:
- - OS:
- - C++ compiler:
- - Any non-default build flags when you build OIIO:
+- Error messages (paste them here exactly)
+- Screenshots (if helpful)
+- Example input: If the problem only happens with certain image files, please
+  attach the smallest image you can make that reproduces the problem.
 
 
 **IF YOU ALREADY HAVE A CODE FIX:** There is no need to file a separate issue,

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -897,6 +897,11 @@ output each one to a different file, with names `sub0001.tif`,
     Print timing and memory statistics about the work done by
     :program:`oiiotool`.
 
+.. option:: --buildinfo
+
+    Print information about OIIO build-time options and dependencies.
+    This can be useful when reporting issues.
+
 .. option:: -a
 
     Performs all operations on all subimages and/or MIPmap levels of each

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3107,13 +3107,30 @@ inline bool attribute (string_view name, string_view val) {
 ///   (Added in OpenImageIO 2.5.2)
 ///
 /// - `string hw:simd`
-/// - `string oiio:simd` (read-only)
+/// - `string build:simd` (read-only)
 ///
 ///   A comma-separated list of hardware CPU features for SIMD (and some
-///   other things). The `"oiio:simd"` attribute is similarly a list of
+///   other things). The `"build:simd"` attribute is similarly a list of
 ///   which features this build of OIIO was compiled to support.
 ///
-///   This was added in OpenImageIO 1.8.
+///   These were added in OpenImageIO 1.8. The `"build:simd"` attribute was
+///   added added in OpenImageIO 2.5.8 as a preferred synonym for what
+///   previously was called `"oiio:simd"`, which is now deprecated.
+///
+/// - `string build:platform` (read-only)
+///
+///   THe name of the OS and CPU architecture that OpenImageIO was built
+///   for (e.g., `"Linux/x86_64"`).  (Added in OpenImageIO 2.5.8.)
+///
+/// - `string build:compiler` (read-only)
+///
+///   THe name and version of the compiler used to build OIIO.
+///   (Added in OpenImageIO 2.5.8.)
+///
+/// - `string build:dependencies` (read-only)
+///
+///   List of library dependencieis (where known) and versions, separatd by
+///   semicolons. (Added in OpenImageIO 2.5.8.)
 ///
 /// - `float resident_memory_used_MB`
 ///

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -115,6 +115,14 @@ else ()
     message (STATUS "OpenEXR core library will not be used by default")
 endif ()
 
+# Some extra definitions we need to retrieve build related attributes.
+target_compile_definitions(OpenImageIO
+              PRIVATE
+                  OIIO_QT_VERSION="${Qt6_VERSION}${Qt5_VERSION}"
+                  OIIO_PYTHON_VERSION="${Python_VERSION}"
+                  OIIO_TBB_VERSION="${TBB_VERSION}"
+             )
+
 # Source groups for libutil and libtexture
 source_group ("libutil"    REGULAR_EXPRESSION ".+/libutil/.+")
 source_group ("libtexture" REGULAR_EXPRESSION ".+/libtexture/.+")

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -14,8 +14,6 @@
 #include <OpenImageIO/Imath.h>
 #include <OpenImageIO/platform.h>
 
-#include <boost/version.hpp>
-
 #include <OpenEXR/ImfChannelList.h>
 #include <OpenEXR/ImfEnvmap.h>
 #include <OpenEXR/ImfInputFile.h>

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -14,8 +14,6 @@
 #include <OpenImageIO/Imath.h>
 #include <OpenImageIO/platform.h>
 
-#include <boost/version.hpp>
-
 #include "exr_pvt.h"
 
 #include <OpenEXR/openexr.h>


### PR DESCRIPTION
New OIIO global attributes (read only):

  - "build:platform" retrieves the OS and CPU type that this build of OIIO is fof (e.g., "Linux/x86_64").
  - "build:compiler" retrieves the compiler name and version used to build OIIO itself (e.g. "gcc 9.3").
  - "build:dependencies" retrieves a semicolon-separated list of library dependencies -- both for image format support (like libtiff) but also general (boost, TBB, Python, fmt, OCIO).
  - "build:simd" is a new (preferred) synonym for the SIMD and other hardware capabilities selected at build time. The old name, "oiio:simd" is hereby softly deprecated as confusing.

`oiiotool --buildinfo` is a new command that prints this information.

Example output:

```
$ oiiotool --buildinfo

OIIO 2.6.0.2spi | MacOS/x86_64
    Build compiler: Apple clang 15.0 | C++17/201703
    HW features enabled at build: sse2,sse3,ssse3,sse41,sse42
Dependencies: OpenEXR 3.2.1, LIBTIFF Version 4.6.0, jpeg-turbo
    3.0.1/jp80, dcmtk 3.6.8, FFMpeg 6.0 (Lavf60.16.100), gif_lib 5.2.1,
    libheif 1.17.6, OpenJpeg 2.5.0, null 1.0, OpenVDB 11.0.0abi11, libpng
    1.6.40, Ptex 2.4, libraw 0.21.2-Release, Webp 1.3.2, Boost 1.83,
    OpenColorIO 2.3.1, NO Python!, TBB 2021.11.0, fmt 10.2.1
```

This is all a convenience utility to make it easy to ask users to run a simple command that will tell us a lot of information relevant to resolving their issues in cases where it's related to some of their build-time compiler or dependencies.

Also cleaned up the "bug report issue template" to clarify the instructions and specifically ask people to run this command and include the information with any bug report.

