### PR TITLE
fix(oiiotool): Overhaul and fix bugs in mixed-channel propogation

### DIFF
--- a/testsuite/perchannel/ref/out.txt
+++ b/testsuite/perchannel/ref/out.txt
@@ -6,3 +6,9 @@ Comparing "../openexr-images/Tiles/Spirals.exr" and "spiral1.exr"
 PASS
 Comparing "../openexr-images/Tiles/Spirals.exr" and "spiral2.exr"
 PASS
+hfhf.exr             :   64 x   64, 4 channel, half/float/half/float openexr
+    SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
+hfhf_copy.exr        :   64 x   64, 4 channel, half/float/half/float openexr
+    SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
+hfhf_mod.exr         :   64 x   64, 4 channel, half/float/half/float openexr
+    SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9

--- a/testsuite/perchannel/run.py
+++ b/testsuite/perchannel/run.py
@@ -33,6 +33,17 @@ command += diff_command (image, "spiral1.exr")
 command += (oiio_app("oiiotool") + image + " -o spiral2.exr ;\n")
 command += diff_command (image, "spiral2.exr")
 
+# Create a file with per-channel data types, make sure that works
+command += oiiotool("--create 64x64 4 --d R=half,G=float,B=half,A=float -o hfhf.exr")
+command += info_command("hfhf.exr", verbose=False)
+
+# Make sure that read/write unmodified will preserve the channel types
+command += oiiotool("hfhf.exr -o hfhf_copy.exr")
+command += info_command("hfhf_copy.exr", verbose=False)
+
+# Make sure that read/modify/write preserves the channel types of the input
+command += oiiotool("hfhf.exr -mulc 0.5,0.5,0.5,0.5 -o hfhf_mod.exr")
+command += info_command("hfhf_mod.exr", verbose=False)
 
 #print "Running this command:\n" + command + "\n"
 


### PR DESCRIPTION
Remember that ImageBuf only stores one pixel data type per buffer, but of course they may have differing-per-channel types in image files. So how does oiiotool know what to write? There is a series of heuristics: -d is for explicit user control, if not, then try to deduce it from the input files.

A bedrock precept is that `oiiotool in.exr -o out.exr` ought to write the same channel types that it read in.

The logic to implement this with the various image operations and possible overrides can be hard to get right. Indeed, I did not get it right. It made mistakes even in simple cases like the above. And the code was complicated and hard to understand, as well.

This PR rewrites a couple functions that implement this chunk of this logic, both correcting several errors as well as (I hope) being clearer and better commented so that we can more easily reason about it and modify it in the future.

I also added some additional tests to testsuite/perchannel to verify some of the cases that were previously failing.
