### PR TITLE
Internals: various fixes for memory safey and reduce static analysis complaints

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -126,7 +126,7 @@ jobs:
             echo "BUILD_OUTPUT_DIR is " "${{ env.BUILD_WRAPPER_OUT_DIR }}"
             find . -name "*.gcov" -print
             # sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
-            sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="$BUILD_WRAPPER_OUT_DIR" --define sonar.cfamily.gcov.reportsPath="_coverage" --define sonar.cfamily.threads="$PARALLEL"
+            time sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="$BUILD_WRAPPER_OUT_DIR" --define sonar.cfamily.gcov.reportsPath="_coverage" --define sonar.cfamily.threads="$PARALLEL"
         # Consult https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarscanner-cli/ for more information and options
 
       # - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -306,6 +306,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
                 profile[11] = 0;
                 profile[12] = curr_marker;
                 profile[13] = (JOCTET)num_markers;
+                OIIO_ASSERT(profile_size >= ICC_HEADER_SIZE + length);
                 memcpy(profile.data() + ICC_HEADER_SIZE,
                        icc_profile + length * (curr_marker - 1),
                        length);  //NOSONAR

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -275,6 +275,7 @@ Jpeg2000Input::open(const std::string& name, ImageSpec& p_spec)
         close();
         return false;
     }
+    OIIO_ASSERT(m_image != nullptr);
 
     // we support only one, three or four components in image
     const int channelCount = m_image->numcomps;

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1350,8 +1350,10 @@ TextureSystemImpl::texture(TextureHandle* texture_handle,
 
     bool ok          = true;
     Tex::RunMask bit = 1;
+    float* r         = OIIO_ALLOCA(float, 3 * nchannels);
+    float* drds      = r + nchannels;
+    float* drdt      = drds + nchannels;
     for (int i = 0; i < Tex::BatchWidth; ++i, bit <<= 1) {
-        float r[4], drds[4], drdt[4];  // temp result
         if (mask & bit) {
             opt.sblur  = options.sblur[i];
             opt.tblur  = options.tblur[i];
@@ -2102,6 +2104,7 @@ TextureSystemImpl::fade_to_pole(float t, float* accum, float& weight,
                                thread_info->tile, options.subimage, miplevel,
                                1);
     }
+    OIIO_DASSERT(polecolor != nullptr);
     pole = OIIO::clamp(pole, 0.0f, 1.0f);
     pole *= pole;  // squaring makes more pleasing appearance
     polecolor += options.firstchannel;

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -529,9 +529,9 @@ OiioTool::print_info(std::ostream& out, Oiiotool& ot, ImageRec* img,
     }
 
     for (int s = 0, nsubimages = img->subimages(); s < nsubimages; ++s) {
-        DASSERT((opt.native ? img->nativespec(s) : img->spec(s)) != nullptr);
-        print_info_subimage(out, ot, s, nsubimages, img->miplevels(s),
-                            opt.native ? *img->nativespec(s) : *img->spec(s),
+        const ImageSpec* spec = opt.native ? img->nativespec(s) : img->spec(s);
+        DASSERT(spec != nullptr);
+        print_info_subimage(out, ot, s, nsubimages, img->miplevels(s), *spec,
                             img, nullptr, "", opt, field_re, field_exclude_re,
                             serformat, verbose);
         // If opt.subimages is not set, we print info about first subimage


### PR DESCRIPTION
* jpeg output: Extra memory check
* TS: batch texture call fixed to handle any number of channels
* TS: assert to guard against possible null pointer dereference
* oiiotool printinfo: clarify assertion for the sake of static analysis
* jpeg2000 reader: assertion to ensure we don't dereference a null pointer

