### PR TITLE
WIP api(IBA): replace filter name or raw Filter2D* with FilterOpt

### DIFF
--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -17,8 +17,10 @@ ImageBuf's. The functions are declared in the header file
 ImageBufAlgo common principles
 ==============================
 
-.. .. doxygengroup: ImageBufAlgo_intro
-   Do I like the above one better?
+.. .. doxygengroup:: ImageBufAlgo_intro
+..
+
+..   Do I like the above one better?
 
 
 This section explains the general rules common to all ImageBufAlgo
@@ -150,6 +152,12 @@ possible.  The main reason to explicitly pass a different number
 and the thread calling the ImageBufAlgo function just wants to continue doing
 the computation without spawning additional threads, which might tend to
 crowd out the other application threads.
+
+`FilterOpt` options for filtering
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenclass:: OIIO::FilterOpt
+    :members:
 
 
 
@@ -1862,7 +1870,8 @@ Image arithmetic
           ImageBuf Compressed = ImageBufAlgo::rangecompress (Src);
       
           // 3. Now do the resize
-          ImageBuf Dst = ImageBufAlgo::resize (Compressed, "lanczos3", 6.0f,
+          ImageBuf Dst = ImageBufAlgo::resize (Compressed,
+                                               FilterOpt("lanczos3", 6.0f),
                                                ROI(0, 640, 0, 480));
       
           // 4. Expand range to be linear again (operate in-place)
@@ -1877,7 +1886,8 @@ Image arithmetic
           Compressed = ImageBufAlgo.rangecompress (Src)
       
           # 3. Now do the resize
-          Dst = ImageBufAlgo.resize (Compressed, "lanczos3", 6.0, ROI(0, 640, 0, 480))
+          Dst = ImageBufAlgo.resize (Compressed, filtername="lanczos3",
+                                     filtersize=6.0, roi=ROI(0, 640, 0, 480))
       
           # 4. Expand range to be linear again (operate in-place)
           ImageBufAlgo.rangeexpand (Dst, Dst)

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/string_view.h>
@@ -45,12 +47,23 @@ public:
     /// Return the name of the filter, e.g., "box", "gaussian"
     virtual string_view name(void) const = 0;
 
+    /// This static function allocates specific filter implementation for the
+    /// name you provide and returns it as a shared_ptr. It will be
+    /// automatically deleted when the last reference do it is released.
+    /// Example use:
+    ///        auto myfilt = Filter1D::create_shared("box", 1.0f);
+    /// If the name is not recognized, return an empty shared_ptr.
+    static std::shared_ptr<const Filter1D> create_shared(string_view filtername,
+                                                         float width);
+
     /// This static function allocates and returns an instance of the
     /// specific filter implementation for the name you provide.
     /// Example use:
-    ///        Filter1D *myfilt = Filter1::create ("box", 1);
+    ///        Filter1D *myfilt = Filter1D::create ("box", 1.0f);
     /// The caller is responsible for deleting it when it's done.
     /// If the name is not recognized, return NULL.
+    ///
+    /// Note that the create_shared method is preferred over create().
     static Filter1D* create(string_view filtername, float width);
 
     /// Destroy a filter that was created with create().
@@ -103,12 +116,23 @@ public:
     /// Return the name of the filter, e.g., "box", "gaussian"
     virtual string_view name(void) const = 0;
 
+    /// This static function allocates specific filter implementation for the
+    /// name you provide and returns it as a shared_ptr. It will be
+    /// automatically deleted when the last reference do it is released.
+    /// Example use:
+    ///        auto myfilt = Filter2D::create_shared("box", 1.0f, 1.0f);
+    /// If the name is not recognized, return an empty shared_ptr.
+    static std::shared_ptr<const Filter2D>
+    create_shared(string_view filtername, float width, float height);
+
     /// This static function allocates and returns an instance of the
     /// specific filter implementation for the name you provide.
     /// Example use:
-    ///        Filter2D *myfilt = Filter2::create ("box", 1, 1);
+    ///        Filter2D *myfilt = Filter2D::create ("box", 1.0f, 1.0f);
     /// The caller is responsible for deleting it when it's done.
     /// If the name is not recognized, return NULL.
+    ///
+    /// Note that the create_shared method is preferred over create().
     static Filter2D* create(string_view filtername, float width, float height);
 
     /// Destroy a filter that was created with create().

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -76,7 +76,7 @@ public:
     static const FilterDesc& get_filterdesc(int filternum);
 
 protected:
-    float m_w;
+    const float m_w;
 };
 
 
@@ -145,7 +145,7 @@ public:
     static const FilterDesc& get_filterdesc(int filternum);
 
 protected:
-    float m_w, m_h;
+    const float m_w, m_h;
 };
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -506,7 +506,7 @@ ImageBufAlgo::make_kernel(string_view name, float width, float height,
     spec.full_depth  = spec.depth;
     ImageBuf dst(spec);
 
-    std::unique_ptr<Filter2D> filter(Filter2D::create(name, width, height));
+    auto filter = Filter2D::create_shared(name, width, height);
     if (filter) {
         // Named continuous filter from filter.h
         for (ImageBuf::Iterator<float> p(dst); !p.done(); ++p)

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -1108,7 +1108,7 @@ ImageBufAlgo::st_warp(ImageBuf& dst, const ImageBuf& src, const ImageBuf& stbuf,
             filter.width = 6.0f;
         }
         filter.filter(
-            Filter2D::create(filter.name, filter.width, filter.width));
+            Filter2D::create_shared(filter.name, filter.width, filter.width));
     }
 
     bool ok;

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -887,6 +887,15 @@ Filter1D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 
 
 
+std::shared_ptr<const Filter1D>
+Filter1D::create_shared(string_view filtername, float width)
+{
+    return std::shared_ptr<const Filter1D>(create(filtername, width),
+                                           Filter1D::destroy);
+}
+
+
+
 // Filter1D::create is the static method that, given a filter name,
 // width, and height, returns an allocated and instantiated filter of
 // the correct implementation.  If the name is not recognized, return
@@ -980,6 +989,15 @@ Filter2D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 
 
 
+std::shared_ptr<const Filter2D>
+Filter2D::create_shared(string_view filtername, float width, float height)
+{
+    return std::shared_ptr<const Filter2D>(create(filtername, width, height),
+                                           Filter2D::destroy);
+}
+
+
+
 // Filter2D::create is the static method that, given a filter name,
 // width, and height, returns an allocated and instantiated filter of
 // the correct implementation.  If the name is not recognized, return
@@ -988,6 +1006,8 @@ Filter2D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 Filter2D*
 Filter2D::create(string_view filtername, float width, float height)
 {
+    if (height <= 0.0f)
+        height = width;
     if (filtername == "box")
         return new FilterBox2D(width, height);
     if (filtername == "triangle")

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -74,7 +74,8 @@ test_1d()
     for (int i = 0, e = Filter1D::num_filters(); i < e; ++i) {
         FilterDesc filtdesc;
         Filter1D::get_filterdesc(i, &filtdesc);
-        Filter1D* f = Filter1D::create(filtdesc.name, filtdesc.width);
+        auto filter = Filter1D::create_shared(filtdesc.name, filtdesc.width);
+        auto f      = filter.get();
         // Graph it
         float scale          = normalize ? 1.0f / (*f)(0.0f) : 1.0f;
         float color[3]       = { 0.25f * (i & 3), 0.25f * ((i >> 2) & 3),
@@ -96,8 +97,6 @@ test_1d()
 
         // Time it
         bench(filtdesc.name, [=]() { DoNotOptimize((*f)(0.25f)); });
-
-        Filter1D::destroy(f);
     }
 
     graph.write("filters.tif");
@@ -127,8 +126,9 @@ test_2d()
     for (int i = 0, e = Filter2D::num_filters(); i < e; ++i) {
         FilterDesc filtdesc;
         Filter2D::get_filterdesc(i, &filtdesc);
-        Filter2D* f = Filter2D::create(filtdesc.name, filtdesc.width,
-                                       filtdesc.width);
+        auto filter = Filter2D::create_shared(filtdesc.name, filtdesc.width,
+                                              filtdesc.width);
+        auto f      = filter.get();
         // Graph it
         float scale          = normalize ? 1.0f / (*f)(0.0f, 0.0f) : 1.0f;
         float color[3]       = { 0.25f * (i & 3), 0.25f * ((i >> 2) & 3),
@@ -150,8 +150,6 @@ test_2d()
 
         // Time it
         bench(filtdesc.name, [=]() { DoNotOptimize((*f)(0.25f, 0.25f)); });
-
-        Filter2D::destroy(f);
     }
 
     graph.write("filters2d.tif");

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4475,13 +4475,15 @@ public:
             ok &= ImageBufAlgo::rangecompress(tmpimg, *src);
             src = &tmpimg;
         }
-        if (do_warp[current_subimage()])
+        if (do_warp[current_subimage()]) {
+            FilterOpt filter(filtername, 0.0f, ImageBuf::WrapBlack);
+            filter.edgeclamp = edgeclamp;
             ok &= ImageBufAlgo::warp(*img[0], *src, M[current_subimage()],
-                                     filtername, 0.0f, false,
-                                     ImageBuf::WrapDefault, edgeclamp);
-        else
+                                     filter, false);
+        } else {
             ok &= ImageBufAlgo::resize(*img[0], *src, filtername, 0.0f,
                                        img[0]->roi());
+        }
         if (highlightcomp && ok) {
             // re-expand the range in place
             ok &= ImageBufAlgo::rangeexpand(*img[0], *img[0]);
@@ -4618,7 +4620,8 @@ action_fit(Oiiotool& ot, cspan<const char*> argv)
         newspec.x = newspec.full_x = fit_full_x;
         newspec.y = newspec.full_y = fit_full_y;
         (*R)(s, 0).reset(newspec);
-        ImageBufAlgo::fit((*R)(s, 0), *src, filtername, 0.0f, fillmode, exact);
+        ImageBufAlgo::fit((*R)(s, 0), *src, { filtername, 0.0f }, fillmode,
+                          exact);
         if (highlightcomp) {
             // re-expand the range in place
             ImageBufAlgo::rangeexpand((*R)(s, 0), (*R)(s, 0));


### PR DESCRIPTION
Let's consider this a "design review", or a prototype, as I'm really not sure if this is the right design.

Inspired by Issue #4102.

Here's the gist:

There are a number of ImageBufAlgo functions that need to do filtering, and so need a variety of additional parameters like filtername and width, but sometimes other things, and they don't all keep up wth each other in terms of their parameters. Also, in addition to name/width, they also have additional varieties that take a `Filter2D*`, so that doubles the number of entry points. It's a little confusing. So this PR proposes the following:

* A new helper class FilterOpt that collects the different filtering parameters -- name and width, or Filter2D*, wrap mode, and other params TBD.
* The IBA functions that do filtering get cleaned up and take a FilterOpt& parameter. They have fewer varieties now. The old versions are scheduled for deprecation and moved to the unobtrusive end of imagebufalgo.h. So this doesn't break source compatibility for now, we'll more formally deprecate with warnings later, then for 3.0 remove the old call signatures entirely.
* filter.h cleaned up a bit to give Filter1D and Filter2D a new create_shared static method that returns a shared_ptr.

I think this is a step to making a more uniform and simple API for the IBA functions that take filtering controls. Here are a few examples of how the calls would look.

Old calls:

    // specify filter by name and width
    r = IBA::resize (src, "lanczos3", 6.0f, roi);

    // if we have a Filter2D* already:
    r = IBA::resize (src, filtptr, 6.0f, roi);

New calls, various varieties (all one API signature, I'm essentially showing off the various FilterOpt constructors):

    r = IBA::resize (src, {}, roi); // default filter choice
    r = IBA::resize (src, FilterOpt("lanczos3", 6.0f), roi);  // explicit
    r = IBA::resize (src, "lanczos3", roi); // use name and its default width
    r = IBA::resize (src, filtptr, roi); // constructs from Filter2D*

    r = IBA::resize (src, { .name = "lanczos3", .width = 6.0f }, roi);
    // ^^ This fancy syntax needs C++20 officially, but apparently works
    // in gcc 8+ clang 10+, MSVS 19.21+, Apple clang 12+, and icx 2021.1,
    // all versions we'll have as our minimums relatively shortly.
    // Maybe this is the future, as the closest approximation to named
    // parameter passing we can get in C++?

Does this seem appealing as an API? Maybe some people will love passing a block of related params as a struct, others will hate it?

What happens when we want to add additional options? Can we only do that when it's ok to break ABI and can never backport new fields? Should we use a PIMPL setup to hide the internals of FilerOpt so it's not part of the ABI (at the expense of pointer indirections to access the fields)? Embed a "version" number in the struct and on the library side use that to cast to the right one for the version it represents?

I expect we'll probably iterate on this design quite a bit before we get consensus. There is no rush on this, it's for master / 2.6.

