### PR TITLE
fix: certain int->float type conversions in TypeDesc/ParamValueList

### DIFF
--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -363,6 +363,11 @@ test_delegates()
     OIIO_CHECK_EQUAL(pl["Tx"].get<Imath::M44f>(),
                      Imath::M44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 42, 0, 0,
                                  1));
+
+    OIIO_CHECK_EQUAL(pl.get_int("foo"), 42);
+    OIIO_CHECK_EQUAL(pl.get_float("foo"), 42.0f);
+    OIIO_CHECK_EQUAL(pl.get_string("foo"), "42");
+
     std::string s = pl["foo"];
     OIIO_CHECK_EQUAL(s, "42");
 

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -740,6 +740,11 @@ to_floats(TypeDesc srctype, const void* src, T* dst, size_t n = 1)
             dst[i] = T(((const unsigned int*)src)[i]);
         return true;
     }
+    if (srctype.basetype == TypeDesc::INT) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const int*)src)[i]);
+        return true;
+    }
     if (srctype.basetype == TypeDesc::INT16) {
         for (size_t i = 0; i < n; ++i)
             dst[i] = T(((const short*)src)[i]);
@@ -823,7 +828,7 @@ convert_type(TypeDesc srctype, const void* src, TypeDesc dsttype, void* dst,
                               dsttype.basevalues()))
             return true;
     }
-    // N.B. No uint inversion from string
+    // N.B. No uint conversion from string
 
     if (dsttype.basetype == TypeDesc::FLOAT
         && dsttype.basevalues() == srctype.basevalues()) {


### PR DESCRIPTION
We had all along omitted an important 'int' conversion case for an internal to_floats() helper function that's used by the TypeDesc::convert_type utility. Which is in turn used by ParamValue::get_float() and ParamValueList::get_float().

All of these would fail to return the proper float if the underlying data was an int, despite these functions saying that they would have no trouble returning the float equivalent of int data when asked.

I added a test that verifies that it's wrking.
