### PR TITLE
build: don't fail pybind11 search if python is disabled

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -158,8 +158,9 @@ endif()
 
 # From pythonutils.cmake
 find_python()
-
-checked_find_package (pybind11 REQUIRED VERSION_MIN 2.4.2)
+if (USE_PYTHON)
+    checked_find_package (pybind11 REQUIRED VERSION_MIN 2.4.2)
+endif ()
 
 
 ###########################################################################


### PR DESCRIPTION
Fixes #4135 

Thanks to @OgreTransporter for the suggestion.
