### PR TITLE
api: prototype using optional keyword/value params for ImageBufAlgo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           # break the ABI. Basically, we will build that version as well as
           # the current one, and compare the resulting libraries.
           - desc: abi check
-            nametag: linux-vfx2023
+            nametag: abi-check
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2023-clang15
             vfxyear: 2023

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.15)
 
-set (OpenImageIO_VERSION "2.6.0.3")
+set (OpenImageIO_VERSION "2.6.1.0")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OpenImageIO_VERSION_OVERRIDE)

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -996,7 +996,7 @@ Shuffling channels
           // Resize the image to 640x480, using the default filter
           ImageBuf Src ("tahoe.exr");
           ROI roi (0, 640, 0, 480, 0, 1, /*chans:*/ 0, Src.nchannels());
-          ImageBuf Dst = ImageBufAlgo::resize (Src, "", 0, roi);
+          ImageBuf Dst = ImageBufAlgo::resize (Src, {}, roi);
 
        .. code-tab:: py
 
@@ -1060,14 +1060,14 @@ Shuffling channels
           // Resize to fit into a max of 640x480, preserving the aspect ratio
           ImageBuf Src ("tahoe.exr");
           ROI roi (0, 640, 0, 480, 0, 1, /*chans:*/ 0, Src.nchannels());
-          ImageBuf Dst = ImageBufAlgo::fit (Src, "", 0, true, roi);
+          ImageBuf Dst = ImageBufAlgo::fit (Src, {}, roi);
 
        .. code-tab:: py
 
           # Resize to fit into a max of 640x480, preserving the aspect ratio
           Src = ImageBuf("tahoe.exr")
           roi = ROI(0, 640, 0, 480, 0, 1, 0, Src.nchannels)
-          Dst = ImageBufAlgo.fit (Src, "", 0, True, roi)
+          Dst = ImageBufAlgo.fit (Src, roi=roi)
 
        .. code-tab:: bash oiiotool
 
@@ -1090,7 +1090,8 @@ Shuffling channels
                          -0.7071068, 0.7071068, 0,
                          20,        -8.284271,  1);
           ImageBuf Src ("tahoe.exr");
-          ImageBuf Dst = ImageBufAlgo::warp (dst, src, M, "lanczos3");
+          ParamValue options[] = { { "filtername", "lanczos3" } };
+          ImageBuf Dst = ImageBufAlgo::warp (dst, src, M, options);
 
        .. code-tab:: py
 
@@ -1098,7 +1099,7 @@ Shuffling channels
                -0.7071068, 0.7071068, 0,
                 20,        -8.284271, 1)
           Src = ImageBuf("tahoe.exr")
-          Dst = ImageBufAlgo.warp (dst, src, M, "lanczos3");
+          Dst = ImageBufAlgo.warp (dst, src, M, filtername="lanczos3");
 
        .. code-tab:: bash oiiotool
 
@@ -1862,7 +1863,9 @@ Image arithmetic
           ImageBuf Compressed = ImageBufAlgo::rangecompress (Src);
       
           // 3. Now do the resize
-          ImageBuf Dst = ImageBufAlgo::resize (Compressed, "lanczos3", 6.0f,
+          ImageBuf Dst = ImageBufAlgo::resize (Compressed,
+                                               { { "filtername", "lanczos3" }
+                                                 { "filterwidth", 6.0f } },
                                                ROI(0, 640, 0, 480));
       
           // 4. Expand range to be linear again (operate in-place)
@@ -1877,7 +1880,8 @@ Image arithmetic
           Compressed = ImageBufAlgo.rangecompress (Src)
       
           # 3. Now do the resize
-          Dst = ImageBufAlgo.resize (Compressed, "lanczos3", 6.0, ROI(0, 640, 0, 480))
+          Dst = ImageBufAlgo.resize (Compressed, filtername="lanczos3",
+                                     filterwidth=6.0, ROI(0, 640, 0, 480))
       
           # 4. Expand range to be linear again (operate in-place)
           ImageBufAlgo.rangeexpand (Dst, Dst)

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -1099,7 +1099,7 @@ Shuffling channels
                -0.7071068, 0.7071068, 0,
                 20,        -8.284271, 1)
           Src = ImageBuf("tahoe.exr")
-          Dst = ImageBufAlgo.warp (dst, src, M, filtername="lanczos3");
+          Dst = ImageBufAlgo.warp (dst, src, M, filtername="lanczos3")
 
        .. code-tab:: bash oiiotool
 

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -52,7 +52,7 @@ public:
 
     /// This static function allocates specific filter implementation for the
     /// name you provide and returns it as a shared_ptr. It will be
-    /// automatically deleted when the last reference do it is released.
+    /// automatically deleted when the last reference to it is released.
     /// Example use:
     ///        auto myfilt = Filter1D::create_shared("box", 1.0f);
     /// If the name is not recognized, return an empty shared_ptr.

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/string_view.h>
@@ -30,6 +32,9 @@ public:
 /// The filters are NOT expected to have their results normalized.
 class OIIO_UTIL_API Filter1D {
 public:
+    /// Alias for a shared pointer to a filter
+    using ref = std::shared_ptr<const Filter1D>;
+
     Filter1D(float width)
         : m_w(width)
     {
@@ -45,12 +50,22 @@ public:
     /// Return the name of the filter, e.g., "box", "gaussian"
     virtual string_view name(void) const = 0;
 
+    /// This static function allocates specific filter implementation for the
+    /// name you provide and returns it as a shared_ptr. It will be
+    /// automatically deleted when the last reference do it is released.
+    /// Example use:
+    ///        auto myfilt = Filter1D::create_shared("box", 1.0f);
+    /// If the name is not recognized, return an empty shared_ptr.
+    static ref create_shared(string_view filtername, float width);
+
     /// This static function allocates and returns an instance of the
     /// specific filter implementation for the name you provide.
     /// Example use:
-    ///        Filter1D *myfilt = Filter1::create ("box", 1);
+    ///        Filter1D *myfilt = Filter1D::create ("box", 1.0f);
     /// The caller is responsible for deleting it when it's done.
     /// If the name is not recognized, return NULL.
+    ///
+    /// Note that the create_shared method is preferred over create().
     static Filter1D* create(string_view filtername, float width);
 
     /// Destroy a filter that was created with create().
@@ -63,7 +78,7 @@ public:
     static const FilterDesc& get_filterdesc(int filternum);
 
 protected:
-    float m_w;
+    const float m_w;
 };
 
 
@@ -72,6 +87,9 @@ protected:
 /// The filters are NOT expected to have their results normalized.
 class OIIO_UTIL_API Filter2D {
 public:
+    /// Alias for a shared pointer to a filter
+    using ref = std::shared_ptr<const Filter2D>;
+
     Filter2D(float width, float height)
         : m_w(width)
         , m_h(height)
@@ -103,16 +121,29 @@ public:
     /// Return the name of the filter, e.g., "box", "gaussian"
     virtual string_view name(void) const = 0;
 
+    /// This static function allocates specific filter implementation for the
+    /// name you provide and returns it as a shared_ptr. It will be
+    /// automatically deleted when the last reference do it is released.
+    /// Example use:
+    ///        auto myfilt = Filter2D::create_shared("box", 1.0f, 1.0f);
+    /// If the name is not recognized, return an empty shared_ptr.
+    static ref create_shared(string_view filtername, float width, float height);
+
     /// This static function allocates and returns an instance of the
     /// specific filter implementation for the name you provide.
     /// Example use:
-    ///        Filter2D *myfilt = Filter2::create ("box", 1, 1);
+    ///        Filter2D *myfilt = Filter2D::create ("box", 1.0f, 1.0f);
     /// The caller is responsible for deleting it when it's done.
     /// If the name is not recognized, return NULL.
+    ///
+    /// Note that the create_shared method is preferred over create().
     static Filter2D* create(string_view filtername, float width, float height);
 
     /// Destroy a filter that was created with create().
     static void destroy(Filter2D* filt);
+
+    /// Don't destroy a filter -- used for non-owning shared_ptr.
+    static void no_destroy(const Filter2D*) {}
 
     /// Get the number of filters supported.
     static int num_filters();
@@ -121,7 +152,7 @@ public:
     static const FilterDesc& get_filterdesc(int filternum);
 
 protected:
-    float m_w, m_h;
+    const float m_w, m_h;
 };
 
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -669,8 +669,8 @@ bool OIIO_API rotate (ImageBuf &dst, const ImageBuf &src,
 ///
 ///     Advanced use: It is also possible to pass a custom reconstruction
 ///     filter as a `Filter2D*`, overriding any filtername and filterwidth
-///     that may also be passed. It needs to be be passed as
-///     `ParamValue("filterptr", OIIO::TypePointer), 1, &raw_filter_ptr)`.
+///     that may also be passed. The easiest way to pass it is as:
+///     `make_pv("filterptr", raw_filter_ptr)`.
 ///     Use with caution!
 ///
 /// The caller may either (a) explicitly pass a reconstruction `filter`, or
@@ -745,8 +745,8 @@ bool OIIO_API resample (ImageBuf &dst, const ImageBuf &src,
 ///
 ///     Advanced use: It is also possible to pass a custom reconstruction
 ///     filter as a `Filter2D*`, overriding any filtername and filterwidth
-///     that may also be passed. It needs to be be passed as
-///     `ParamValue("filterptr", OIIO::TypePointer), 1, &raw_filter_ptr)`.
+///     that may also be passed. The easiest way to pass it is as:
+///     `make_pv("filterptr", raw_filter_ptr)`.
 ///     Use with caution!
 ///
 ///   - "fillmode" : string (default: "letterbox")
@@ -848,8 +848,8 @@ bool OIIO_API fit(ImageBuf &dst, const ImageBuf &src, KWArgs options = {},
 ///
 ///     Advanced use: It is also possible to pass a custom reconstruction
 ///     filter as a `Filter2D*`, overriding any filtername and filterwidth
-///     that may also be passed. It needs to be be passed as
-///     `ParamValue("filterptr", OIIO::TypePointer), 1, &raw_filter_ptr)`.
+///     that may also be passed. The easiest way to pass it is as:
+///     `make_pv("filterptr", raw_filter_ptr)`.
 ///     Use with caution!
 ///
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -191,8 +191,13 @@ private:
 
 
 
-
 namespace ImageBufAlgo {
+
+
+/// IBA::KWArgs is a span of ParamValue, used to pass keyword/value optional
+/// arguments to IBA functions.
+using KWArgs = ParamValueSpan;
+
 
 // old name (DEPRECATED 1.9)
 OIIO_DEPRECATED("use parallel_options (1.9)")
@@ -643,6 +648,31 @@ bool OIIO_API rotate (ImageBuf &dst, const ImageBuf &src,
 /// window of each correspond to each other, regardless of resolution).
 /// If `dst` is not yet initialized, it will be sized according to `roi`.
 ///
+/// The `options` list contains optional ParamValue's that control the
+/// resizing behavior.  The following options are recognized:
+///
+///   - "filtername" : string (default: "")
+///
+///     The type of reconstruction filter used to weight the `src` pixels
+///     falling underneath it for each `dst` pixel.  If the value is the
+///     empty string or not supplied, a reasonable high-quality filter will
+///     be chosen automatically (blackman-harris when upsizing, lanczos3
+///     when downsizing).
+///
+///   - "filterwidth" : float (default: 0)
+///
+///     The width of the reconstruction filter, expressed in pixel units of
+///     the `dst` image. If 0 or not supplied, the default width of the
+///     named filter will be used.
+///
+///   - "filterptr" : pointer to a Filter2D (default: nullptr)
+///
+///     Advanced use: It is also possible to pass a custom reconstruction
+///     filter as a `Filter2D*`, overriding any filtername and filterwidth
+///     that may also be passed. It needs to be be passed as
+///     `ParamValue("filterptr", OIIO::TypePointer), 1, &raw_filter_ptr)`.
+///     Use with caution!
+///
 /// The caller may either (a) explicitly pass a reconstruction `filter`, or
 /// (b) specify one by `filtername` and `filterwidth`. If `filter` is
 /// `nullptr` or if `filtername` is the empty string `resize()` will choose
@@ -651,16 +681,11 @@ bool OIIO_API rotate (ImageBuf &dst, const ImageBuf &src,
 /// pixels falling underneath it for each `dst` pixel; the filter's size is
 /// expressed in pixel units of the `dst` image.
 
-ImageBuf OIIO_API resize (const ImageBuf &src,
-                          string_view filtername = "", float filterwidth=0.0f,
-                          ROI roi={}, int nthreads=0);
-ImageBuf OIIO_API resize (const ImageBuf &src, Filter2D *filter,
-                          ROI roi={}, int nthreads=0);
-bool OIIO_API resize (ImageBuf &dst, const ImageBuf &src,
-                      string_view filtername = "", float filterwidth=0.0f,
-                      ROI roi={}, int nthreads=0);
-bool OIIO_API resize (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
-                      ROI roi={}, int nthreads=0);
+ImageBuf OIIO_API resize(const ImageBuf &src, KWArgs options = {},
+                         ROI roi = {}, int nthreads = 0);
+bool OIIO_API resize(ImageBuf &dst, const ImageBuf &src, KWArgs options = {},
+                     ROI roi = {}, int nthreads=0);
+
 /// @}
 
 
@@ -692,67 +717,67 @@ bool OIIO_API resample (ImageBuf &dst, const ImageBuf &src,
 /// @defgroup fit (fit: resize the image with filtering, into a fixed size)
 /// @{
 ///
-/// Fit src into `dst` (to a size specified by `roi`, if `dst` is not
-/// initialized), resizing but preserving its original aspect ratio. Thus,
-/// it will resize to be the largest size with the same aspect ratio that
-/// can fit inside the region, but will not stretch to completely fill it in
-/// both dimensions.
+/// Resize `src` to fit into `dst` (to a size specified by `roi`, if `dst` is
+/// not initialized), preserving its original aspect ratio. Thus, it will
+/// resize to be the largest size with the same aspect ratio that can fit
+/// inside the region, but will not necessarily completely fill it in both
+/// dimensions if the source and destination image buffers do not have the
+/// same aspect ratio.
 ///
-/// The `fillmode` determines which of several methods will be used to
-/// determine how the image will fill the new frame, if its aspect ratio
-/// does not precisely match the original source aspect ratio:
-///     - "width" exactly fills the width of the new frame, either cropping
-///       or letterboxing the height if it isn't precisely the right size to
-///       preserve the original aspect ratio.
-///     - "height" exactly fills the height of the new frame, either cropping
-///       or letterboxing the width if it isn't precisely the right size to
-///       preserve the original aspect ratio.
-///     - "letterbox" (the default) chooses whichever of "width" or "height"
-///       will maximally fill the new frame with no image data lost (it will
-///       only letterbox, never crop).
+/// The `options` list contains optional ParamValue's that control the
+/// resizing behavior.  The following options are recognized:
 ///
-/// If `exact` is true, will result in an exact match on aspect ratio and
-/// centering (partial pixel shift if necessary), whereas exact=false
-/// will only preserve aspect ratio and centering to the precision of a
-/// whole pixel.
+///   - "filtername" : string (default: "")
 ///
-/// The filter is used to weight the `src` pixels falling underneath it for
-/// each `dst` pixel.  The caller may specify a reconstruction filter by
-/// name and width (expressed in pixels units of the `dst` image), or
-/// `rotate()` will choose a reasonable default high-quality default filter
-/// (lanczos3) if the empty string is passed, and a reasonable filter width
-/// if `filterwidth` is 0. (Note that some filter choices only make sense
-/// with particular width, in which case this filterwidth parameter may be
-/// ignored.)
+///     The type of reconstruction filter used to weight the `src` pixels
+///     falling underneath it for each `dst` pixel.  If the value is the
+///     empty string or not supplied, a reasonable high-quality filter will
+///     be chosen automatically (blackman-harris when upsizing, lanczos3
+///     when downsizing).
 ///
-ImageBuf OIIO_API fit (const ImageBuf &src,
-                       string_view filtername = "", float filterwidth=0.0f,
-                       string_view fillmode="letterbox", bool exact=false,
-                       ROI roi={}, int nthreads=0);
-ImageBuf OIIO_API fit (const ImageBuf &src, Filter2D *filter,
-                       string_view fillmode="letterbox", bool exact=false,
-                       ROI roi={}, int nthreads=0);
-bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src,
-                   string_view filtername = "", float filterwidth=0.0f,
-                   string_view fillmode="letterbox", bool exact=false,
-                   ROI roi={}, int nthreads=0);
-bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
-                   string_view fillmode="letterbox", bool exact=false,
-                   ROI roi={}, int nthreads=0);
+///   - "filterwidth" : float (default: 0)
+///
+///     The width of the reconstruction filter, expressed in pixel units of
+///     the `dst` image. If 0 or not supplied, the default width of the
+///     named filter will be used.
+///
+///   - "filterptr" : pointer to a Filter2D (default: nullptr)
+///
+///     Advanced use: It is also possible to pass a custom reconstruction
+///     filter as a `Filter2D*`, overriding any filtername and filterwidth
+///     that may also be passed. It needs to be be passed as
+///     `ParamValue("filterptr", OIIO::TypePointer), 1, &raw_filter_ptr)`.
+///     Use with caution!
+///
+///   - "fillmode" : string (default: "letterbox")
+///
+///     The `fillmode` determines which of several methods will be used to
+///     determine how the image will fill the new frame, if its aspect ratio
+///     does not precisely match the original source aspect ratio:
+///
+///       - "width" exactly fills the width of the new frame, either cropping
+///         or letterboxing the height if it isn't precisely the right size
+///         to preserve the original aspect ratio.
+///       - "height" exactly fills the height of the new frame, either
+///         cropping or letterboxing the width if it isn't precisely the
+///         right size to preserve the original aspect ratio.
+///       - "letterbox" (the default) chooses whichever of "width" or
+///         "height" will maximally fill the new frame with no image data
+///         lost (it will only letterbox, never crop).
+///
+///   - "exact" : int (default: 0)
+///
+///     If nonzero, will result in an exact match on aspect ratio and
+///     centering (partial pixel shift if necessary), whereas exact=false
+///     will only preserve aspect ratio and centering to the precision of a
+///     whole pixel.
+///
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// DEPRECATED(2.3): old versions lacking the "fillmode" parameter
-ImageBuf OIIO_API fit (const ImageBuf &src,
-                       string_view filtername, float filterwidth,
-                       bool exact, ROI roi={}, int nthreads=0);
-ImageBuf OIIO_API fit (const ImageBuf &src, Filter2D *filter,
-                       bool exact, ROI roi={}, int nthreads=0);
-bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src,
-                   string_view filtername, float filterwidth,
-                   bool exact, ROI roi={}, int nthreads=0);
-bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
-                   bool exact, ROI roi={}, int nthreads=0);
-#endif
+ImageBuf OIIO_API fit(const ImageBuf &src, KWArgs options = {},
+                      ROI roi={}, int nthreads=0);
+bool OIIO_API fit(ImageBuf &dst, const ImageBuf &src, KWArgs options = {},
+                  ROI roi={}, int nthreads=0);
+
 /// @}
 
 
@@ -762,58 +787,77 @@ bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
 /// Warp the `src` image using the supplied 3x3 transformation matrix.
 ///
 /// Only the pixels (and channels) of `dst` that are specified by `roi` will
-/// be copied from the warped `src`; the default roi is to alter all the
-/// pixels in dst. If `dst` is uninitialized, it will be sized to be an
-/// ImageBuf large enough to hold the warped image if recompute_roi is true,
-/// or will have the same ROI as src if recompute_roi is false. It is an
-/// error to pass both an uninitialized `dst` and an undefined `roi`.
+/// be copied from the warped `src`; the default is to alter all the pixels in
+/// `dst`. If `dst` is uninitialized, it will be sized to be an ImageBuf large
+/// enough to hold the warped image if recompute_roi is true, or will have the
+/// same ROI as src if recompute_roi is false. It is an error to pass both an
+/// uninitialized `dst` and an undefined `roi`.
 ///
-/// The caller may explicitly pass a reconstruction filter, or specify one
-/// by name and size, or if the name is the empty string `resize()` will
-/// choose a reasonable high-quality default if `nullptr` is passed.  The
-/// filter is used to weight the `src` pixels falling underneath it for each
-/// `dst` pixel; the filter's size is expressed in pixel units of the `dst`
-/// image.
+/// @param dst
+///         The output ImageBuf. If not already initialized, it will be sized
+///         based on `roi` (which itself will default to the size of `src`,
+///         if not specified).
+/// @param src
+///         The source ImageBuf.
+/// @param M
+///         A 3x3 matrix describing the desired spatial transformation
+///         of destination pixel coordinates to source pixel coordinates.
+/// @param roi
+///         The region of `dst` that will receive transformed pixels. If
+///         not specified, it will be all the pixels of `dst`.
+/// @param options
+///         Optional ParamValue's that may control the filtering and
+///         reconstruction.
+///
+/// The `options` list contains optional ParamValue's that may control the
+/// filtering and reconstruction.  The following options are recognized:
+///
+///   - "filtername" : string (default: "")
+///
+///     The type of reconstruction filter used to weight the `src` pixels
+///     falling underneath it for each `dst` pixel.  If the value is the
+///     empty string or not supplied, a reasonable high-quality filter will
+///     be chosen automatically.
+///
+///   - "filterwidth" : float (default: 0)
+///
+///     The width of the reconstruction filter, expressed in pixel units of
+///     the `dst` image. If 0 or not supplied, the default width of the
+///     named filter will be used.
+///
+///   - "wrap" : string (default: "black")
+///
+///     The wrap mode controlling the value of pixel lookups that need to
+///     occur beyond the boundary of the `src` image. (Could be one of:
+///     black, clamp, periodic, mirror.)
+///
+///   - "edgeclamp" : int (default: 0)
+///
+///     If nonzero, will enable special edge clamp behavior to reduce
+///     artifacts at the image edges (experimental).
+///
+///   - "recompute_roi" : int (default: 0)
+///
+///     If nonzero and `dst` is not yet initialized, the result image
+///     will be sized to be large enough to hold the warped image. If
+///     zero (the default), the `dst` image will have the same ROI as
+///     `src`. If the `dst` image already is initialized, its size will
+///     not be chaned and this option will be ignored.
+///
+///   - "filterptr" : pointer to a Filter2D (default: nullptr)
+///
+///     Advanced use: It is also possible to pass a custom reconstruction
+///     filter as a `Filter2D*`, overriding any filtername and filterwidth
+///     that may also be passed. It needs to be be passed as
+///     `ParamValue("filterptr", OIIO::TypePointer), 1, &raw_filter_ptr)`.
+///     Use with caution!
+///
 
-ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
-                        string_view filtername = string_view(),
-                        float filterwidth = 0.0f, bool recompute_roi = false,
-                        ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
-                        ROI roi={}, int nthreads=0);
-ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
-                        const Filter2D *filter, bool recompute_roi = false,
-                        ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
-                        ROI roi = {}, int nthreads=0);
-bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
-                    string_view filtername = string_view(),
-                    float filterwidth = 0.0f, bool recompute_roi = false,
-                    ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
-                    ROI roi={}, int nthreads=0);
-bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
-                    const Filter2D *filter, bool recompute_roi = false,
-                    ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
-                    ROI roi = {}, int nthreads=0);
+ImageBuf OIIO_API warp(const ImageBuf &src, M33fParam M,
+                       KWArgs options = {}, ROI roi = {}, int nthreads = 0);
+bool OIIO_API warp(ImageBuf &dst, const ImageBuf &src, M33fParam M,
+                   KWArgs options = {}, ROI roi = {}, int nthreads = 0);
 
-#ifdef OIIO_INTERNAL  /* experimental -- not part of public API yet */
-ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
-                        string_view filtername,
-                        float filterwidth, bool recompute_roi,
-                        ImageBuf::WrapMode wrap, bool edgeclamp,
-                        ROI roi={}, int nthreads=0);
-ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
-                        const Filter2D *filter, bool recompute_roi,
-                        ImageBuf::WrapMode wrap, bool edgeclamp,
-                        ROI roi = {}, int nthreads=0);
-bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
-                    string_view filtername,
-                    float filterwidth, bool recompute_roi,
-                    ImageBuf::WrapMode wrap, bool edgeclamp,
-                    ROI roi={}, int nthreads=0);
-bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
-                    const Filter2D *filter, bool recompute_roi,
-                    ImageBuf::WrapMode wrap, bool edgeclamp,
-                    ROI roi = {}, int nthreads=0);
-#endif  // OIIO_INTERNAL
 /// @}
 
 
@@ -1572,10 +1616,12 @@ bool OIIO_API histogram_draw (ImageBuf &dst,
 /// Make a 1-channel `float` image of the named kernel. The size of the
 /// image will be big enough to contain the kernel given its size (`width` x
 /// `height`) and rounded up to odd resolution so that the center of the
-/// kernel can be at the center of the middle pixel.  The kernel image will
-/// be offset so that its center is at the (0,0) coordinate.  If `normalize`
-/// is true, the values will be normalized so that they sum to 1.0. If
-/// `depth` > 1, a volumetric kernel will be created.  Use with caution!
+/// kernel can be at the center of the middle pixel.  If width an height
+/// are 0, the natural size of the named filter will be chosen. The kernel
+/// image will be offset so that its center is at the (0,0) coordinate.  If
+/// `normalize` is true, the values will be normalized so that they sum to
+/// 1.0. If `depth` > 1, a volumetric kernel will be created.  Use with
+/// caution!
 ///
 /// Kernel names can be: "gaussian", "sharp-gaussian", "box",
 /// "triangle", "blackman-harris", "mitchell", "b-spline", "catmull-rom",
@@ -2520,11 +2566,13 @@ bool OIIO_API deep_holdout (ImageBuf &dst, const ImageBuf &src,
 
 
 ///////////////////////////////////////////////////////////////////////
+// DEPRECATED functions follow:
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
 // DEPRECATED(1.9): These are all functions that take raw pointers,
 // which we are deprecating as of 1.9, replaced by new versions that
 // take span<> for length safety.
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool fill (ImageBuf &dst, const float *values,
@@ -2670,6 +2718,87 @@ inline bool render_text (ImageBuf &dst, int x, int y, string_view text,
     return render_text (dst, x, y, text, fontsize, fontname,
                         {textcolor, textcolor?dst.nchannels():0});
 }
+
+
+// DEPRECATED(2.6) versions of functions that previously directly took a
+// filter name and width, or a raw pointer to a Filter2D, and sometimes a
+// separate wrap mode. These have been replaced by the versions that use a
+// KWArgs for options including all the filtering parameters.
+ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
+                        string_view filtername, float filterwidth = 0.0f,
+                        bool recompute_roi = false,
+                        ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
+                        ROI roi={}, int nthreads=0);
+ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
+                        const Filter2D *filter, bool recompute_roi = false,
+                        ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
+                        ROI roi = {}, int nthreads=0);
+bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
+                    string_view filtername, float filterwidth = 0.0f,
+                    bool recompute_roi = false,
+                    ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
+                    ROI roi={}, int nthreads=0);
+bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
+                    const Filter2D *filter, bool recompute_roi = false,
+                    ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
+                    ROI roi = {}, int nthreads=0);
+ImageBuf OIIO_API resize (const ImageBuf &src,
+                          string_view filtername, float filterwidth=0.0f,
+                          ROI roi={}, int nthreads=0);
+ImageBuf OIIO_API resize (const ImageBuf &src, Filter2D *filter,
+                          ROI roi={}, int nthreads=0);
+bool OIIO_API resize (ImageBuf &dst, const ImageBuf &src,
+                      string_view filtername, float filterwidth=0.0f,
+                      ROI roi={}, int nthreads=0);
+bool OIIO_API resize (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
+                      ROI roi={}, int nthreads=0);
+#ifdef OIIO_INTERNAL  /* experimental -- not part of public API yet */
+ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
+                        string_view filtername,
+                        float filterwidth, bool recompute_roi,
+                        ImageBuf::WrapMode wrap, bool edgeclamp,
+                        ROI roi={}, int nthreads=0);
+ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
+                        const Filter2D *filter, bool recompute_roi,
+                        ImageBuf::WrapMode wrap, bool edgeclamp,
+                        ROI roi = {}, int nthreads=0);
+bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
+                    string_view filtername,
+                    float filterwidth, bool recompute_roi,
+                    ImageBuf::WrapMode wrap, bool edgeclamp,
+                    ROI roi={}, int nthreads=0);
+bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
+                    const Filter2D *filter, bool recompute_roi,
+                    ImageBuf::WrapMode wrap, bool edgeclamp,
+                    ROI roi = {}, int nthreads=0);
+#endif  // OIIO_INTERNAL
+
+ImageBuf OIIO_API fit (const ImageBuf &src,
+                       string_view filtername = "", float filterwidth=0.0f,
+                       string_view fillmode="letterbox", bool exact=false,
+                       ROI roi={}, int nthreads=0);
+ImageBuf OIIO_API fit (const ImageBuf &src, Filter2D *filter,
+                       string_view fillmode="letterbox", bool exact=false,
+                       ROI roi={}, int nthreads=0);
+bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src,
+                   string_view filtername = "", float filterwidth=0.0f,
+                   string_view fillmode="letterbox", bool exact=false,
+                   ROI roi={}, int nthreads=0);
+bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
+                   string_view fillmode="letterbox", bool exact=false,
+                   ROI roi={}, int nthreads=0);
+
+// DEPRECATED(2.3): old versions lacking the "fillmode" parameter
+ImageBuf OIIO_API fit (const ImageBuf &src,
+                       string_view filtername, float filterwidth,
+                       bool exact, ROI roi={}, int nthreads=0);
+ImageBuf OIIO_API fit (const ImageBuf &src, Filter2D *filter,
+                       bool exact, ROI roi={}, int nthreads=0);
+bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src,
+                   string_view filtername, float filterwidth,
+                   bool exact, ROI roi={}, int nthreads=0);
+bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
+                   bool exact, ROI roi={}, int nthreads=0);
 
 #endif  // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -842,7 +842,7 @@ bool OIIO_API fit(ImageBuf &dst, const ImageBuf &src, KWArgs options = {},
 ///     will be sized to be large enough to hold the warped image. If
 ///     zero (the default), the `dst` image will have the same ROI as
 ///     `src`. If the `dst` image already is initialized, its size will
-///     not be chaned and this option will be ignored.
+///     not be changed and this option will be ignored.
 ///
 ///   - "filterptr" : pointer to a Filter2D (default: nullptr)
 ///

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1616,7 +1616,7 @@ bool OIIO_API histogram_draw (ImageBuf &dst,
 /// Make a 1-channel `float` image of the named kernel. The size of the
 /// image will be big enough to contain the kernel given its size (`width` x
 /// `height`) and rounded up to odd resolution so that the center of the
-/// kernel can be at the center of the middle pixel.  If width an height
+/// kernel can be at the center of the middle pixel.  If width and height
 /// are 0, the natural size of the named filter will be chosen. The kernel
 /// image will be offset so that its center is at the (0,0) coordinate.  If
 /// `normalize` is true, the values will be normalized so that they sum to

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -526,7 +526,7 @@ public:
     {
     }
 
-    /// Construct an span from an initializer_list.
+    /// Construct a span from an initializer_list.
     constexpr ParamValueSpan(std::initializer_list<ParamValue> il)
         : cspan<ParamValue>(il.begin(), il.size())
     {

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -58,12 +58,12 @@ OIIO_NAMESPACE_BEGIN
 ///
 ///     // Single int:
 ///     int my_int = 42;
-///     ParamValue A("foo", TypeDesc::INT, 1, &my_int); 
+///     ParamValue A("foo", TypeDesc::INT, 1, &my_int);
 ///     // Three int values (say, one per vertex of a triangle):
 ///     int my_int_array[3] = { 1, 2, 3 };
-///     ParamValue B("foo", TypeDesc::INT, 1, &my_int_array); 
+///     ParamValue B("foo", TypeDesc::INT, 1, &my_int_array);
 ///     // A single value which is an array of 3 ints:
-///     ParamValue C("foo", TypeDesc(TypeDesc::INT, 3), 1, &my_int_array); 
+///     ParamValue C("foo", TypeDesc(TypeDesc::INT, 3), 1, &my_int_array);
 ///     // A string -- note the trick about treating it as an array:
 ///     const char* my_string = "hello";
 ///     ParamValue D("foo", TypeDesc::STRING, 1, &my_string);
@@ -333,7 +333,9 @@ private:
 /// Factory for a ParamValue that holds a single value of any type supported
 /// by a corresponding ParamValue constructor (such as int, float, string).
 template<typename T>
-static ParamValue make_pv(string_view name, const T& val) {
+static ParamValue
+make_pv(string_view name, const T& val)
+{
     return ParamValue(name, val);
 }
 
@@ -341,7 +343,9 @@ static ParamValue make_pv(string_view name, const T& val) {
 /// will be interpreted as a C string (TypeString), but all other pointer
 /// types will just get stored as an opaque pointer (TypePointer).
 template<typename T>
-static ParamValue make_pv(string_view name, T* val) {
+static ParamValue
+make_pv(string_view name, T* val)
+{
     return ParamValue(name, BaseTypeFromC<T*>::value, 1, &val);
 }
 

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -394,17 +394,17 @@ public:
         return f != cend() ? &(*f) : nullptr;
     }
 
-    /// Case insensitive search for an integer, with default if not found.
-    /// Automatically will return an int even if the data is really
-    /// unsigned, short, or byte, but not float. It will retrieve from a
-    /// string, but only if the string is entirely a valid int format.
+    /// Search for an integer, with default if not found. Automatically will
+    /// return an int even if the data is really unsigned, short, or byte, but
+    /// not float. It will retrieve from a string, but only if the string is
+    /// entirely a valid int format.
     int get_int(string_view name, int defaultval = 0,
                 bool casesensitive = false, bool convert = true) const;
 
-    /// Case insensitive search for a float, with default if not found.
-    /// Automatically will return a float even if the data is really double
-    /// or half. It will retrieve from a string, but only if the string is
-    /// entirely a valid float format.
+    /// Search for a float, with default if not found. Automatically will
+    /// return a float even if the data is really double or half. It will
+    /// retrieve from a string, but only if the string is entirely a valid
+    /// float format.
     float get_float(string_view name, float defaultval = 0,
                     bool casesensitive = false, bool convert = true) const;
 
@@ -611,51 +611,51 @@ public:
     }
 
     const_iterator find(string_view name, TypeDesc type = TypeUnknown,
-                        bool casesensitive = true) const;
+                        bool casesensitive = false) const;
     const_iterator find(ustring name, TypeDesc type = TypeUnknown,
-                        bool casesensitive = true) const;
+                        bool casesensitive = false) const;
 
-    /// Case insensitive search for an integer, with default if not found.
-    /// Automatically will return an int even if the data is really
-    /// unsigned, short, or byte, but not float. It will retrieve from a
-    /// string, but only if the string is entirely a valid int format.
-    int get_int(string_view name, int defaultval = 0, bool casesensitive = true,
-                bool convert = true) const;
-    int get_int(ustring name, int defaultval = 0, bool casesensitive = true,
+    /// Search for an integer, with default if not found. Automatically will
+    /// return an int even if the data is really unsigned, short, or byte, but
+    /// not float. It will retrieve from a string, but only if the string is
+    /// entirely a valid int format.
+    int get_int(string_view name, int defaultval = 0,
+                bool casesensitive = false, bool convert = true) const;
+    int get_int(ustring name, int defaultval = 0, bool casesensitive = false,
                 bool convert = true) const;
 
-    /// Case insensitive search for a float, with default if not found.
-    /// Automatically will return a float even if the data is really double
-    /// or half. It will retrieve from a string, but only if the string is
-    /// entirely a valid float format.
+    /// Search for a float, with default if not found. Automatically will
+    /// return a float even if the data is really double or half. It will
+    /// retrieve from a string, but only if the string is entirely a valid
+    /// float format.
     float get_float(string_view name, float defaultval = 0,
-                    bool casesensitive = true, bool convert = true) const;
+                    bool casesensitive = false, bool convert = true) const;
     float get_float(ustring name, float defaultval = 0,
-                    bool casesensitive = true, bool convert = true) const;
+                    bool casesensitive = false, bool convert = true) const;
 
     /// Simple way to get a string attribute, with default provided.
     /// If the value is another type, it will be turned into a string.
     string_view get_string(string_view name,
                            string_view defaultval = string_view(),
-                           bool casesensitive     = true,
+                           bool casesensitive     = false,
                            bool convert           = true) const;
     string_view get_string(ustring name, string_view defaultval = string_view(),
-                           bool casesensitive = true,
+                           bool casesensitive = false,
                            bool convert       = true) const;
     ustring get_ustring(string_view name,
                         string_view defaultval = string_view(),
-                        bool casesensitive = true, bool convert = true) const;
+                        bool casesensitive = false, bool convert = true) const;
     ustring get_ustring(ustring name, string_view defaultval = string_view(),
-                        bool casesensitive = true, bool convert = true) const;
+                        bool casesensitive = false, bool convert = true) const;
 
     /// Does the span contain the named attribute?
     bool contains(string_view name, TypeDesc type = TypeUnknown,
-                  bool casesensitive = true) const
+                  bool casesensitive = false) const
     {
         return (find(name, type, casesensitive) != end());
     }
     bool contains(ustring name, TypeDesc type = TypeUnknown,
-                  bool casesensitive = true) const
+                  bool casesensitive = false) const
     {
         return (find(name, type, casesensitive) != end());
     }

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -604,7 +604,7 @@ public:
         return p != cend() ? p->type() : TypeUnknown;
     }
 
-    /// Retrieve from list: If found its data type is reasonably convertible
+    /// Retrieve from list: If found and its data type is reasonably convertible
     /// to `type`, copy/convert the value into val[...] and return true.
     /// Otherwise, return false and don't modify what val points to.
     bool getattribute(string_view name, TypeDesc type, void* value,

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -212,11 +212,19 @@ public:
     constexpr const_iterator cbegin() const noexcept { return m_data; }
     constexpr const_iterator cend() const noexcept { return m_data + m_size; }
 
-    constexpr reverse_iterator rbegin() const noexcept { return m_data + m_size - 1; }
-    constexpr reverse_iterator rend() const noexcept { return m_data - 1; }
+    constexpr reverse_iterator rbegin() const noexcept {
+        return reverse_iterator(m_data + m_size - 1);
+    }
+    constexpr reverse_iterator rend() const noexcept {
+        return reverse_iterator(m_data - 1);
+    }
 
-    constexpr const_reverse_iterator crbegin() const noexcept { return m_data + m_size - 1; }
-    constexpr const_reverse_iterator crend() const noexcept { return m_data - 1; }
+    constexpr const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator(m_data + m_size - 1);
+    }
+    constexpr const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator(m_data - 1);
+    }
 
 private:
     pointer     m_data = nullptr;

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -445,7 +445,7 @@ class ustring;
 template<> struct BaseTypeFromC<ustring> { static const TypeDesc::BASETYPE value = TypeDesc::STRING; };
 template<size_t S> struct BaseTypeFromC<char[S]> { static const TypeDesc::BASETYPE value = TypeDesc::STRING; };
 template<size_t S> struct BaseTypeFromC<const char[S]> { static const TypeDesc::BASETYPE value = TypeDesc::STRING; };
-
+template<typename P> struct BaseTypeFromC<P*> { static const TypeDesc::BASETYPE value = TypeDesc::PTR; };
 
 /// A template mechanism for getting the TypeDesc from a C type.
 /// The default for simple types is just the TypeDesc based on BaseTypeFromC.
@@ -462,8 +462,12 @@ template<> struct TypeDescFromC<float> { static const constexpr TypeDesc value()
 template<> struct TypeDescFromC<half> { static const constexpr TypeDesc value() { return TypeDesc::HALF; } };
 #endif
 template<> struct TypeDescFromC<double> { static const constexpr TypeDesc value() { return TypeDesc::DOUBLE; } };
+template<> struct TypeDescFromC<char*> { static const constexpr TypeDesc value() { return TypeDesc::STRING; } };
+template<> struct TypeDescFromC<const char*> { static const constexpr TypeDesc value() { return TypeDesc::STRING; } };
 template<size_t S> struct TypeDescFromC<char[S]> { static const constexpr TypeDesc value() { return TypeDesc::STRING; } };
 template<size_t S> struct TypeDescFromC<const char[S]> { static const constexpr TypeDesc value() { return TypeDesc::STRING; } };
+template<> struct TypeDescFromC<ustring> { static const constexpr TypeDesc value() { return TypeDesc::STRING; } };
+template<typename T> struct TypeDescFromC<T*> { static const constexpr TypeDesc value() { return TypeDesc::PTR; } };
 #ifdef INCLUDED_IMATHVEC_H
 template<> struct TypeDescFromC<Imath::V3f> { static const constexpr TypeDesc value() { return TypeVector; } };
 template<> struct TypeDescFromC<Imath::V2f> { static const constexpr TypeDesc value() { return TypeVector2; } };

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -452,6 +452,18 @@ ImageBuf
 ImageBufAlgo::make_kernel(string_view name, float width, float height,
                           float depth, bool normalize)
 {
+    auto filter = Filter2D::create_shared(name, width, height);
+    if (filter) {
+        if (width == 0.0f)
+            width = filter->width();
+        if (height == 0.0f)
+            height = filter->height();
+    } else {
+        if (width == 0.0f)
+            width = 4.0f;
+        if (height == 0.0f)
+            height = 4.0f;
+    }
     int w = std::max(1, (int)ceilf(width));
     int h = std::max(1, (int)ceilf(height));
     int d = std::max(1, (int)ceilf(depth));
@@ -472,7 +484,6 @@ ImageBufAlgo::make_kernel(string_view name, float width, float height,
     spec.full_depth  = spec.depth;
     ImageBuf dst(spec);
 
-    std::unique_ptr<Filter2D> filter(Filter2D::create(name, width, height));
     if (filter) {
         // Named continuous filter from filter.h
         for (ImageBuf::Iterator<float> p(dst); !p.done(); ++p)

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -445,7 +445,7 @@ bool
 ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, M33fParam M,
                    KWArgs options, ROI roi, int nthreads)
 {
-    static ustring recognized[] = { "filtername"_us,    "filterwidth"_us,
+    static const ustring recognized[] = { "filtername"_us,    "filterwidth"_us,
                                     "wrap"_us,          "edgeclamp"_us,
                                     "recompute_roi"_us, "filterptr"_us };
     IBA_check_optional(options, recognized);

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -30,6 +30,107 @@ OIIO_NAMESPACE_BEGIN
 
 namespace {
 
+#if 0
+// I'm not sure if I want to keep this and/or make it public. Just let it
+// sit here for a while.
+
+/// Helper class that is used for passing filtering options to IBA functions.
+/// A `FilterOpt` may specify filtering options one of several ways:
+///
+/// * Default constructor / empty FilterOpt: The IBA function will pick a
+///   reasonable default filter.
+/// * Filter name and width: Use the named filter with the given width.
+/// * Filter name only: Use the named filter with that filter's default width.
+/// * shared_ptr<Filter2D>: Use the filter object directly with shared
+///   ownership.
+/// * Raw `const Filter2D*` pointer: Use the filter object directly, and
+///   it is owned by the caller (i.e., nothing in FilterOpt nor the IBA
+///   function will free it).
+///
+class FilterOpt {
+public:
+    using shared_filter = std::shared_ptr<const Filter2D>;
+
+    std::string name;    ///< Name of the filter to use.
+    float width = 0.0f;  ///< Width of the filter (0 = default width).
+
+    /// Default constructor
+    FilterOpt() = default;
+
+    /// Copy constructor
+    FilterOpt(const FilterOpt& f) = default;
+
+    /// Construct from a filter name and optional width. If the width is not
+    /// supplied, the default width for that filter will be used.
+    FilterOpt(string_view name, float width = 0.0f)
+        : name(name), width(width) {}
+
+    /// Construct from a shared_ptr to a Filter2D object.
+    FilterOpt(shared_filter& filter)
+        : m_filter(filter) {}
+
+    /// Construct from a pointer to a caller-owned Filter2D.
+    FilterOpt(const Filter2D* filter)
+        : m_filter(shared_filter(filter, [](const Filter2D*){ })) {}
+    // Note: this works by constructing a shared_ptr with a custom deleter
+    // that does nothing.
+
+    /// Retrieve a shared_ptr holding the Filter2D.
+    const shared_filter& filter() const { return m_filter; }
+    /// Retrieve a raw pointer to the Filter2D, or nullptr if none has been
+    /// assigned.
+    const Filter2D* filterptr() const { return m_filter.get(); }
+
+    FilterOpt& operator= (const FilterOpt& f) = default;
+
+    // Helper: Fill in the additional fields: If name and width were
+    // specified, set up the actual Filter2D; if the Filter2D was supplied,
+    // make sure the name and width are set. If none were set, use the
+    // defaults passed (or, if none is passed, pick a reasonable default).
+    // Return true for success, false for error (such as unknown filter name).
+    OIIO_API bool resolve(string_view default_filtername = "",
+                          float default_width = 0.0f);
+
+private:
+    shared_filter m_filter;  ///< Shared ptr to Filter2D
+};
+
+
+
+bool
+FilterOpt::resolve(string_view default_filtername, float default_width)
+{
+    if (m_filter) {
+        // If the filter was specified, make sure the name+width match.
+        name  = m_filter->name();
+        width = m_filter->width();
+    } else {
+        // No filter was specfied. Get one.
+        if (name.empty()) {
+            // If no name was specified, use the default filtername as passed,
+            // or blackman-harris is a good all-purpose guess.
+            if (default_filtername.empty())
+                name = "blackman-harris";
+            else
+                name = default_filtername;
+            width = default_width;
+        }
+        // Look for a matching filter name. Use its preferred width if none
+        // was specified by the user.
+        for (int i = 0, e = Filter2D::num_filters(); i < e; ++i) {
+            const FilterDesc& fd(Filter2D::get_filterdesc(i));
+            if (fd.name == name) {
+                float w  = width > 0.0f ? width : fd.width;
+                m_filter = Filter2D::create_shared(name, w, w);
+                break;
+            }
+        }
+    }
+    return filterptr() ? true : false;
+}
+#endif
+
+
 // Define a templated Accumulator type that's float, except in the case
 // of double input, in which case it's double.
 template<typename T> struct Accum_t {
@@ -120,7 +221,7 @@ robust_multVecMatrix(const Imath::M33f& M, const Dual2& x, const Dual2& y,
 
 
 // Transform an ROI by an affine matrix.
-ROI
+static ROI
 transform(const Imath::M33f& M, ROI roi)
 {
     Imath::V2f ul(roi.xbegin + 0.5f, roi.ybegin + 0.5f);
@@ -214,12 +315,12 @@ filtered_sample(const ImageBuf& src, float s, float t, float dsdx, float dtdx,
 
 
 
-static std::shared_ptr<Filter2D>
+static std::shared_ptr<const Filter2D>
 get_warp_filter(string_view filtername_, float filterwidth, ImageBuf& dst)
 {
     // Set up a shared pointer with custom deleter to make sure any
     // filter we allocate here is properly destroyed.
-    std::shared_ptr<Filter2D> filter((Filter2D*)nullptr, Filter2D::destroy);
+    Filter2D::ref filter((Filter2D*)nullptr, Filter2D::destroy);
     std::string filtername = filtername_.size() ? filtername_ : "lanczos3";
     for (int i = 0, e = Filter2D::num_filters(); i < e; ++i) {
         FilterDesc fd;
@@ -307,13 +408,92 @@ warp_impl(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
 
 
 
+// Is the PV `option` in the `recognized` list? If so, return true.
+// Is it in the `obsolete` list? If so, return false.
+// Is it in neither? Return false.
+static bool
+IBA_find_optional(const ParamValue& option, cspan<ustring> recognized,
+                  cspan<ustring> obsolete = {})
+{
+    for (auto&& r : recognized)
+        if (option.name() == r)
+            return true;
+    for (auto&& o : obsolete)
+        if (option.name() == o)
+            return false;
+    return false;
+}
+
+
+
+// Given list of `options`, check if any are unrecognized or obsolete.
+// Return true if all are fine, false if not.
+static bool
+IBA_check_optional(ImageBufAlgo::KWArgs options, cspan<ustring> recognized,
+                   cspan<ustring> obsolete = {})
+{
+    bool ok = true;
+    for (auto&& pv : options) {
+        ok &= IBA_find_optional(pv, recognized, obsolete);
+    }
+    return ok;
+}
+
+
+
+bool
+ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, M33fParam M,
+                   KWArgs options, ROI roi, int nthreads)
+{
+    static ustring recognized[] = { "filtername"_us,    "filterwidth"_us,
+                                    "wrap"_us,          "edgeclamp"_us,
+                                    "recompute_roi"_us, "filterptr"_us };
+    IBA_check_optional(options, recognized);
+
+    Filter2D::ref filterref;
+    if (options.contains("filterptr", TypePointer)) {
+        auto f = options.find("filterptr", TypePointer);
+        OIIO_DASSERT(f != options.cend());
+        filterref = Filter2D::ref(f->get<const Filter2D*>(),
+                                  Filter2D::no_destroy);
+    } else {
+        filterref = get_warp_filter(options.get_string("filtername"),
+                                    options.get_float("filterwidth"), dst);
+        if (!filterref)
+            return false;  // error issued in get_warp_filter
+    }
+    if (!filterref) {
+        dst.errorfmt("Invalid filter");
+        return false;
+    }
+
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode::WrapDefault;
+    auto wrapparam          = options.find("wrap");
+    if (wrapparam != options.end()) {
+        if (wrapparam->type() == TypeString)
+            wrap = ImageBuf::WrapMode_from_string(wrapparam->get_ustring());
+        else
+            wrap = (ImageBuf::WrapMode)wrapparam->get_int();
+    }
+    bool recompute_roi = options.get_int("recompute_roi", 0);
+    bool edgeclamp     = options.get_int("edgeclamp", 0);
+
+    return warp_impl(dst, src, M, filterref.get(), recompute_roi, wrap,
+                     edgeclamp, roi, nthreads);
+}
+
+
+
 bool
 ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, M33fParam M,
                    const Filter2D* filter, bool recompute_roi,
                    ImageBuf::WrapMode wrap, ROI roi, int nthreads)
 {
-    return warp_impl(dst, src, M, filter, recompute_roi, wrap,
-                     false /*edgeclamp*/, roi, nthreads);
+    return warp(dst, src, M,
+                { { "filterptr", TypePointer, 1, &filter },
+                  { "recompute_roi", int(recompute_roi) },
+                  { "wrap", int(wrap) } },
+                roi, nthreads);
 }
 
 
@@ -324,13 +504,12 @@ ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, M33fParam M,
                    bool recompute_roi, ImageBuf::WrapMode wrap, ROI roi,
                    int nthreads)
 {
-    // Set up a shared pointer with custom deleter to make sure any
-    // filter we allocate here is properly destroyed.
-    auto filter = get_warp_filter(filtername, filterwidth, dst);
-    if (!filter) {
-        return false;  // error issued in get_warp_filter
-    }
-    return warp(dst, src, M, filter.get(), recompute_roi, wrap, roi, nthreads);
+    return warp(dst, src, M,
+                { { "filtername", filtername },
+                  { "filterwidth", filterwidth },
+                  { "recompute_roi", int(recompute_roi) },
+                  { "wrap", int(wrap) } },
+                roi, nthreads);
 }
 
 
@@ -443,7 +622,7 @@ ImageBufAlgo::rotate(ImageBuf& dst, const ImageBuf& src, float angle,
 
 template<typename DSTTYPE, typename SRCTYPE>
 static bool
-resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
+resize_(ImageBuf& dst, const ImageBuf& src, const Filter2D* filter, ROI roi,
         int nthreads)
 {
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
@@ -681,7 +860,7 @@ get_resize_filter(string_view filtername, float fwidth, ImageBuf& dst,
 {
     // Set up a shared pointer with custom deleter to make sure any
     // filter we allocate here is properly destroyed.
-    std::shared_ptr<Filter2D> filter((Filter2D*)nullptr, Filter2D::destroy);
+    std::shared_ptr<Filter2D> filter;
     if (filtername.empty()) {
         // No filter name supplied -- pick a good default
         if (wratio > 1.0f || hratio > 1.0f)
@@ -710,61 +889,98 @@ get_resize_filter(string_view filtername, float fwidth, ImageBuf& dst,
 
 
 bool
-ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
+ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, KWArgs options,
                      ROI roi, int nthreads)
 {
     pvt::LoggedTimer logtime("IBA::resize");
-    if (!IBAprep(roi, &dst, &src,
-                 IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
-        return false;
 
-    // Set up a shared pointer with custom deleter to make sure any
-    // filter we allocate here is properly destroyed.
-    std::shared_ptr<Filter2D> filterptr((Filter2D*)NULL, Filter2D::destroy);
-    if (!filter) {
-        // If no filter was provided, punt and just linearly interpolate.
-        const ImageSpec& srcspec(src.spec());
-        const ImageSpec& dstspec(dst.spec());
-        float wratio = float(dstspec.full_width) / float(srcspec.full_width);
-        float hratio = float(dstspec.full_height) / float(srcspec.full_height);
-        float w      = 2.0f * std::max(1.0f, wratio);
-        float h      = 2.0f * std::max(1.0f, hratio);
-        filter       = Filter2D::create("triangle", w, h);
-        filterptr.reset(filter);
-    }
+    static ustring recognized[] = {
+        "filtername"_us,
+        "filterwidth"_us,
+        "filterptr"_us,
+#if 0 /* Not currently recognized */
+        "wrap"_us,
+        "edgeclamp"_us,
+        "recompute_roi"_us,
+#endif
+    };
+    IBA_check_optional(options, recognized);
 
-    bool ok;
-    OIIO_DISPATCH_COMMON_TYPES2(ok, "resize", resize_, dst.spec().format,
-                                src.spec().format, dst, src, filter, roi,
-                                nthreads);
-    return ok;
-}
-
-
-
-bool
-ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, string_view filtername,
-                     float fwidth, ROI roi, int nthreads)
-{
-    pvt::LoggedTimer logtime("IBA::resize");
     if (!IBAprep(roi, &dst, &src,
                  IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
         return false;
     const ImageSpec& srcspec(src.spec());
     const ImageSpec& dstspec(dst.spec());
 
-    // Resize ratios
-    float wratio = float(dstspec.full_width) / float(srcspec.full_width);
-    float hratio = float(dstspec.full_height) / float(srcspec.full_height);
+    Filter2D::ref filterptr;
+    if (options.contains("filterptr", TypePointer)) {
+        auto f = options.find("filterptr", TypePointer);
+        OIIO_DASSERT(f != options.cend());
+        filterptr = Filter2D::ref(f->get<const Filter2D*>(),
+                                  Filter2D::no_destroy);
+    }
+    if (!filterptr) {
+        // Resize ratios
+        float wratio = float(dstspec.full_width) / float(srcspec.full_width);
+        float hratio = float(dstspec.full_height) / float(srcspec.full_height);
+        filterptr    = get_resize_filter(options.get_string("filtername"),
+                                         options.get_float("filterwidth"), dst,
+                                         wratio, hratio);
+        if (!filterptr)
+            return false;  // error issued in get_resize_filter
+    }
 
-    // Set up a shared pointer with custom deleter to make sure any
-    // filter we allocate here is properly destroyed.
-    auto filter = get_resize_filter(filtername, fwidth, dst, wratio, hratio);
-    if (!filter)
-        return false;  // error issued in get_resize_filter
+#if 0 /* These aren't currently reconized */
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode::WrapDefault;
+    auto wrapparam          = options.find("wrap");
+    if (wrapparam != options.end()) {
+        if (wrapparam->type() == TypeString)
+            wrap = ImageBuf::WrapMode_from_string(wrapparam->get_ustring());
+        else
+            wrap = (ImageBuf::WrapMode)wrapparam->get_int();
+    }
+    bool recompute_roi = options.get_int("recompute_roi", 0);
+    bool edgeclamp     = options.get_int("edgeclamp", 0);
+#endif
 
-    logtime.stop();  // it will be picked up again by the next call...
-    return resize(dst, src, filter.get(), roi, nthreads);
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES2(ok, "resize", resize_, dst.spec().format,
+                                src.spec().format, dst, src, filterptr.get(),
+                                roi, nthreads);
+    return ok;
+}
+
+
+
+ImageBuf
+ImageBufAlgo::resize(const ImageBuf& src, KWArgs options, ROI roi, int nthreads)
+{
+    ImageBuf result;
+    bool ok = resize(result, src, options, roi, nthreads);
+    if (!ok && !result.has_error())
+        result.errorfmt("ImageBufAlgo::resize() error");
+    return result;
+}
+
+
+bool
+ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
+                     ROI roi, int nthreads)
+{
+    return resize(dst, src, { { "filterptr", TypePointer, 1, &filter } }, roi,
+                  nthreads);
+}
+
+
+
+bool
+ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, string_view filtername,
+                     float filterwidth, ROI roi, int nthreads)
+{
+    return resize(dst, src,
+                  { { "filtername", filtername },
+                    { "filterwidth", filterwidth } },
+                  roi, nthreads);
 }
 
 
@@ -773,11 +989,8 @@ ImageBuf
 ImageBufAlgo::resize(const ImageBuf& src, Filter2D* filter, ROI roi,
                      int nthreads)
 {
-    ImageBuf result;
-    bool ok = resize(result, src, filter, roi, nthreads);
-    if (!ok && !result.has_error())
-        result.errorfmt("ImageBufAlgo::resize() error");
-    return result;
+    return resize(src, { { "filterptr", TypePointer, 1, &filter } }, roi,
+                  nthreads);
 }
 
 
@@ -785,24 +998,39 @@ ImageBuf
 ImageBufAlgo::resize(const ImageBuf& src, string_view filtername,
                      float filterwidth, ROI roi, int nthreads)
 {
-    ImageBuf result;
-    bool ok = resize(result, src, filtername, filterwidth, roi, nthreads);
-    if (!ok && !result.has_error())
-        result.errorfmt("ImageBufAlgo::resize() error");
-    return result;
+    return resize(src,
+                  { { "filtername", filtername },
+                    { "filterwidth", filterwidth } },
+                  roi, nthreads);
 }
 
 
 
 bool
-ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
-                  string_view fillmode, bool exact, ROI roi, int nthreads)
+ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, KWArgs options, ROI roi,
+                  int nthreads)
 {
     pvt::LoggedTimer logtime("IBA::fit");
+
+    static ustring recognized[] = {
+        "filtername"_us,
+        "filterwidth"_us,
+        "filterptr"_us,
+        "fillmode"_us,
+        "exact"_us,
+#if 0 /* Not currently recognized */
+        "wrap"_us,
+        "edgeclamp"_us,
+#endif
+    };
+    IBA_check_optional(options, recognized);
     // No time logging, it will be accounted in the underlying warp/resize
     if (!IBAprep(roi, &dst, &src,
                  IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
         return false;
+
+    string_view fillmode = options.get_string("fillmode", "letterbox");
+    int exact            = options.get_int("exact");
 
     const ImageSpec& srcspec(src.spec());
 
@@ -850,15 +1078,23 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
     //           << " into " << newroi << "\n";
     // std::cout << "  Fit scale factor " << scale << "\n";
 
-    // Set up a shared pointer with custom deleter to make sure any
-    // filter we allocate here is properly destroyed.
-    std::shared_ptr<Filter2D> filterptr((Filter2D*)NULL, Filter2D::destroy);
-    if (!filter) {
+    Filter2D::ref filterptr;
+    if (options.contains("filterptr", TypePointer)) {
+        auto f = options.find("filterptr", TypePointer);
+        OIIO_DASSERT(f != options.cend());
+        filterptr = Filter2D::ref(f->get<const Filter2D*>(),
+                                  Filter2D::no_destroy);
+    }
+
+    if (!filterptr) {
         // If no filter was provided, punt and just linearly interpolate.
         float wratio = float(resize_full_width) / float(srcspec.full_width);
         float hratio = float(resize_full_height) / float(srcspec.full_height);
-        filterptr    = get_resize_filter("", 0.0f, dst, wratio, hratio);
-        filter       = filterptr.get();
+        filterptr    = get_resize_filter(options.get_string("filtername"),
+                                         options.get_float("filterwidth"), dst,
+                                         wratio, hratio);
+        if (!filterptr)
+            return false;  // error issued in get_resize_filter
     }
 
     bool ok = true;
@@ -874,7 +1110,8 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
         newspec.set_roi_full(newroi);
         dst.reset(newspec);
         ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string("black");
-        ok &= warp_impl(dst, src, M, filter, false, wrap, true, {}, nthreads);
+        ok &= warp_impl(dst, src, M, filterptr.get(), /*recompute_roi*/ false,
+                        wrap, /*edgeclamp*/ true, /*roi*/ {}, nthreads);
     } else {
         // Full pixel resize -- gives the sharpest result, but for odd-sized
         // destination resolution, may not be exactly centered and will only
@@ -890,7 +1127,11 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
             newspec.set_roi_full(resizeroi);
             dst.reset(newspec);
             logtime.stop();  // it will be picked up again by the next call...
-            ok &= ImageBufAlgo::resize(dst, src, filter, resizeroi, nthreads);
+            const Filter2D* filterraw = filterptr.get();
+            ok &= ImageBufAlgo::resize(dst, src,
+                                       { { "filterptr", TypePointer, 1,
+                                           &filterraw } },
+                                       resizeroi, nthreads);
         } else {
             ok &= dst.copy(src);  // no resize is necessary
         }
@@ -906,59 +1147,73 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
 
 
 
+ImageBuf
+ImageBufAlgo::fit(const ImageBuf& src, KWArgs options, ROI roi, int nthreads)
+{
+    ImageBuf result;
+    bool ok = fit(result, src, options, roi, nthreads);
+    if (!ok && !result.has_error())
+        result.errorfmt("ImageBufAlgo::fit() error");
+    return result;
+}
+
+
+
+// DEPRECATED(2.6) versions without the "options" parameter
+bool
+ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
+                  string_view fillmode, bool exact, ROI roi, int nthreads)
+{
+    return fit(dst, src,
+               { { "filterptr", TypePointer, 1, &filter },
+                 { "fillmode", fillmode },
+                 { "exact", int(exact) } },
+               roi, nthreads);
+}
+
+
+
+// DEPRECATED(2.6) versions without the "options" parameter
 bool
 ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, string_view filtername,
                   float fwidth, string_view fillmode, bool exact, ROI roi,
                   int nthreads)
 {
-    if (filtername.empty() && fwidth == 0.0f)
-        return fit(dst, src, nullptr, fillmode, exact, roi, nthreads);
-
-    pvt::LoggedTimer logtime("IBA::fit");
-    if (!IBAprep(roi, &dst, &src,
-                 IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
-        return false;
-    const ImageSpec& srcspec(src.spec());
-    const ImageSpec& dstspec(dst.spec());
-    // Resize ratios
-    float wratio = float(dstspec.full_width) / float(srcspec.full_width);
-    float hratio = float(dstspec.full_height) / float(srcspec.full_height);
-
-    // Set up a shared pointer with custom deleter to make sure any
-    // filter we allocate here is properly destroyed.
-    auto filter = get_resize_filter(filtername, fwidth, dst, wratio, hratio);
-    if (!filter)
-        return false;  // error issued in get_resize_filter
-
-    logtime.stop();  // it will be picked up again by the next call...
-    return fit(dst, src, filter.get(), fillmode, exact, roi, nthreads);
+    return fit(dst, src,
+               { { "filtername", filtername },
+                 { "filterwidth", fwidth },
+                 { "fillmode", fillmode },
+                 { "exact", int(exact) } },
+               roi, nthreads);
 }
 
 
 
+// DEPRECATED(2.6) versions without the "options" parameter
 ImageBuf
 ImageBufAlgo::fit(const ImageBuf& src, Filter2D* filter, string_view fillmode,
                   bool exact, ROI roi, int nthreads)
 {
-    ImageBuf result;
-    bool ok = fit(result, src, filter, fillmode, exact, roi, nthreads);
-    if (!ok && !result.has_error())
-        result.errorfmt("ImageBufAlgo::fit() error");
-    return result;
+    return fit(src,
+               { { "filterptr", TypePointer, 1, &filter },
+                 { "fillmode", fillmode },
+                 { "exact", int(exact) } },
+               roi, nthreads);
 }
 
 
+// DEPRECATED(2.6) versions without the "options" parameter
 ImageBuf
 ImageBufAlgo::fit(const ImageBuf& src, string_view filtername,
                   float filterwidth, string_view fillmode, bool exact, ROI roi,
                   int nthreads)
 {
-    ImageBuf result;
-    bool ok = fit(result, src, filtername, filterwidth, fillmode, exact, roi,
-                  nthreads);
-    if (!ok && !result.has_error())
-        result.errorfmt("ImageBufAlgo::fit() error");
-    return result;
+    return fit(src,
+               { { "filtername", filtername },
+                 { "filterwidth", filterwidth },
+                 { "fillmode", fillmode },
+                 { "exact", int(exact) } },
+               roi, nthreads);
 }
 
 
@@ -971,6 +1226,7 @@ ImageBufAlgo::fit(const ImageBuf& src, string_view filtername,
     return fit(src, filtername, filterwidth, "letterbox", exact, roi, nthreads);
 }
 
+// DEPRECATED(2.3) versions without the "mode" parameter
 ImageBuf
 ImageBufAlgo::fit(const ImageBuf& src, Filter2D* filter, bool exact, ROI roi,
                   int nthreads)
@@ -978,6 +1234,7 @@ ImageBufAlgo::fit(const ImageBuf& src, Filter2D* filter, bool exact, ROI roi,
     return fit(src, filter, "letterbox", exact, roi, nthreads);
 }
 
+// DEPRECATED(2.3) versions without the "mode" parameter
 bool
 ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, string_view filtername,
                   float filterwidth, bool exact, ROI roi, int nthreads)
@@ -986,6 +1243,7 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, string_view filtername,
                nthreads);
 }
 
+// DEPRECATED(2.3) versions without the "mode" parameter
 bool
 ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
                   bool exact, ROI roi, int nthreads)

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -509,7 +509,7 @@ ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, M33fParam M,
                    ImageBuf::WrapMode wrap, ROI roi, int nthreads)
 {
     return warp(dst, src, M,
-                { { filterptr_us, TypePointer, 1, &filter },
+                { make_pv(filterptr_us, filter),
                   { recompute_roi_us, int(recompute_roi) },
                   { wrap_us, int(wrap) } },
                 roi, nthreads);
@@ -980,8 +980,7 @@ bool
 ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
                      ROI roi, int nthreads)
 {
-    return resize(dst, src, { { filterptr_us, TypePointer, 1, &filter } }, roi,
-                  nthreads);
+    return resize(dst, src, { make_pv(filterptr_us, filter) }, roi, nthreads);
 }
 
 
@@ -1002,8 +1001,7 @@ ImageBuf
 ImageBufAlgo::resize(const ImageBuf& src, Filter2D* filter, ROI roi,
                      int nthreads)
 {
-    return resize(src, { { filterptr_us, TypePointer, 1, &filter } }, roi,
-                  nthreads);
+    return resize(src, { make_pv(filterptr_us, filter) }, roi, nthreads);
 }
 
 
@@ -1135,8 +1133,7 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, KWArgs options, ROI roi,
             logtime.stop();  // it will be picked up again by the next call...
             const Filter2D* filterraw = filterptr.get();
             ok &= ImageBufAlgo::resize(dst, src,
-                                       { { filterptr_us, TypePointer, 1,
-                                           &filterraw } },
+                                       { make_pv(filterptr_us, filterraw) },
                                        resizeroi, nthreads);
         } else {
             ok &= dst.copy(src);  // no resize is necessary
@@ -1171,7 +1168,7 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
                   string_view fillmode, bool exact, ROI roi, int nthreads)
 {
     return fit(dst, src,
-               { { filterptr_us, TypePointer, 1, &filter },
+               { make_pv(filterptr_us, filter),
                  { fillmode_us, fillmode },
                  { exact_us, int(exact) } },
                roi, nthreads);
@@ -1201,7 +1198,7 @@ ImageBufAlgo::fit(const ImageBuf& src, Filter2D* filter, string_view fillmode,
                   bool exact, ROI roi, int nthreads)
 {
     return fit(src,
-               { { filterptr_us, TypePointer, 1, &filter },
+               { make_pv(filterptr_us, filter),
                  { fillmode_us, fillmode },
                  { exact_us, int(exact) } },
                roi, nthreads);

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -42,7 +42,7 @@ OIIO_NAMESPACE_BEGIN
 class FilterBox1D final : public Filter1D {
 public:
     FilterBox1D(float width)
-        : Filter1D(width)
+        : Filter1D(width > 0.0f ? width : 1.0f)
     {
     }
     ~FilterBox1D() override {}
@@ -58,7 +58,7 @@ public:
 class FilterBox2D final : public Filter2D {
 public:
     FilterBox2D(float width, float height)
-        : Filter2D(width, height)
+        : Filter2D(width > 0.0f ? width : 1.0f, height > 0.0f ? height : 1.0f)
     {
     }
     ~FilterBox2D() override {}
@@ -83,8 +83,8 @@ public:
 class FilterTriangle1D final : public Filter1D {
 public:
     FilterTriangle1D(float width)
-        : Filter1D(width)
-        , m_rad_inv(2.0f / width)
+        : Filter1D(width > 0.0f ? width : 2.0f)
+        , m_rad_inv(2.0f / m_w)
     {
     }
     ~FilterTriangle1D() override {}
@@ -98,7 +98,7 @@ public:
     }
 
 private:
-    float m_rad_inv;
+    const float m_rad_inv;
 };
 
 
@@ -106,9 +106,9 @@ private:
 class FilterTriangle2D final : public Filter2D {
 public:
     FilterTriangle2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wrad_inv(2.0f / width)
-        , m_hrad_inv(2.0f / height)
+        : Filter2D(width > 0.0f ? width : 2.0f, height > 0.0f ? height : 2.0f)
+        , m_wrad_inv(2.0f / m_w)
+        , m_hrad_inv(2.0f / m_h)
     {
     }
     ~FilterTriangle2D() override {}
@@ -129,7 +129,7 @@ public:
     string_view name() const override { return "triangle"; }
 
 private:
-    float m_wrad_inv, m_hrad_inv;
+    const float m_wrad_inv, m_hrad_inv;
 };
 
 
@@ -137,8 +137,8 @@ private:
 class FilterGaussian1D final : public Filter1D {
 public:
     FilterGaussian1D(float width)
-        : Filter1D(width)
-        , m_rad_inv(2.0f / width)
+        : Filter1D(width > 0.0f ? width : 3.0f)
+        , m_rad_inv(2.0f / m_w)
     {
     }
     ~FilterGaussian1D() override {}
@@ -159,9 +159,9 @@ private:
 class FilterGaussian2D final : public Filter2D {
 public:
     FilterGaussian2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wrad_inv(2.0f / width)
-        , m_hrad_inv(2.0f / height)
+        : Filter2D(width > 0.0f ? width : 3.0f, height > 0.0f ? height : 3.0f)
+        , m_wrad_inv(2.0f / m_w)
+        , m_hrad_inv(2.0f / m_h)
     {
     }
     ~FilterGaussian2D() override {}
@@ -182,7 +182,7 @@ public:
     string_view name() const override { return "gaussian"; }
 
 private:
-    float m_wrad_inv, m_hrad_inv;
+    const float m_wrad_inv, m_hrad_inv;
 };
 
 
@@ -190,8 +190,8 @@ private:
 class FilterSharpGaussian1D final : public Filter1D {
 public:
     FilterSharpGaussian1D(float width)
-        : Filter1D(width)
-        , m_rad_inv(2.0f / width)
+        : Filter1D(width > 0.0f ? width : 2.0f)
+        , m_rad_inv(2.0f / m_w)
     {
     }
     ~FilterSharpGaussian1D() override {}
@@ -204,7 +204,7 @@ public:
     string_view name() const override { return "gaussian"; }
 
 private:
-    float m_rad_inv;
+    const float m_rad_inv;
 };
 
 
@@ -212,9 +212,9 @@ private:
 class FilterSharpGaussian2D final : public Filter2D {
 public:
     FilterSharpGaussian2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wrad_inv(2.0f / width)
-        , m_hrad_inv(2.0f / height)
+        : Filter2D(width > 0.0f ? width : 2.0f, height > 0.0f ? height : 2.0f)
+        , m_wrad_inv(2.0f / m_w)
+        , m_hrad_inv(2.0f / m_h)
     {
     }
     ~FilterSharpGaussian2D() override {}
@@ -235,7 +235,7 @@ public:
     string_view name() const override { return "gaussian"; }
 
 private:
-    float m_wrad_inv, m_hrad_inv;
+    const float m_wrad_inv, m_hrad_inv;
 };
 
 
@@ -244,7 +244,7 @@ class FilterCatmullRom1D final : public Filter1D {
 public:
     FilterCatmullRom1D(float width)
         : Filter1D(4.0f)
-        , m_scale(4.0f / width)
+        , m_scale(4.0f / (width > 0.0f ? width : 4.0f))
     {
     }
     ~FilterCatmullRom1D() override {}
@@ -262,7 +262,7 @@ public:
     }
 
 private:
-    float m_scale;
+    const float m_scale;
 };
 
 
@@ -270,9 +270,9 @@ private:
 class FilterCatmullRom2D final : public Filter2D {
 public:
     FilterCatmullRom2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wscale(4.0f / width)
-        , m_hscale(4.0f / height)
+        : Filter2D(width > 0.0f ? width : 4.0f, height > 0.0f ? height : 4.0f)
+        , m_wscale(4.0f / m_w)
+        , m_hscale(4.0f / m_h)
     {
     }
     ~FilterCatmullRom2D() override {}
@@ -293,7 +293,7 @@ public:
     string_view name() const override { return "catmull-rom"; }
 
 private:
-    float m_wscale, m_hscale;
+    const float m_wscale, m_hscale;
 };
 
 
@@ -301,8 +301,8 @@ private:
 class FilterBlackmanHarris1D final : public Filter1D {
 public:
     FilterBlackmanHarris1D(float width)
-        : Filter1D(width)
-        , m_rad_inv(2.0f / width)
+        : Filter1D(width > 0.0f ? width : 3.0f)
+        , m_rad_inv(2.0f / m_w)
     {
     }
     ~FilterBlackmanHarris1D() override {}
@@ -337,7 +337,7 @@ public:
     }
 
 private:
-    float m_rad_inv;
+    const float m_rad_inv;
 };
 
 
@@ -345,9 +345,9 @@ private:
 class FilterBlackmanHarris2D final : public Filter2D {
 public:
     FilterBlackmanHarris2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wrad_inv(2.0f / width)
-        , m_hrad_inv(2.0f / height)
+        : Filter2D(width > 0.0f ? width : 3.0f, height > 0.0f ? height : 3.0f)
+        , m_wrad_inv(2.0f / m_w)
+        , m_hrad_inv(2.0f / m_h)
     {
     }
     ~FilterBlackmanHarris2D() override {}
@@ -368,7 +368,7 @@ public:
     string_view name() const override { return "blackman-harris"; }
 
 private:
-    float m_wrad_inv, m_hrad_inv;
+    const float m_wrad_inv, m_hrad_inv;
 };
 
 
@@ -376,8 +376,8 @@ private:
 class FilterSinc1D final : public Filter1D {
 public:
     FilterSinc1D(float width)
-        : Filter1D(width)
-        , m_rad(width / 2.0f)
+        : Filter1D(width > 0.0f ? width : 4.0f)
+        , m_rad(m_w / 2.0f)
     {
     }
     ~FilterSinc1D() override {}
@@ -394,7 +394,7 @@ public:
     }
 
 private:
-    float m_rad;
+    const float m_rad;
 };
 
 
@@ -402,9 +402,9 @@ private:
 class FilterSinc2D final : public Filter2D {
 public:
     FilterSinc2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wrad(width / 2.0f)
-        , m_hrad(height / 2.0f)
+        : Filter2D(width > 0.0f ? width : 4.0f, height > 0.0f ? height : 4.0f)
+        , m_wrad(m_w / 2.0f)
+        , m_hrad(m_h / 2.0f)
     {
     }
     ~FilterSinc2D() override {}
@@ -425,7 +425,7 @@ public:
     string_view name() const override { return "sinc"; }
 
 private:
-    float m_wrad, m_hrad;
+    const float m_wrad, m_hrad;
 };
 
 
@@ -433,8 +433,8 @@ private:
 class FilterLanczos3_1D final : public Filter1D {
 public:
     FilterLanczos3_1D(float width)
-        : Filter1D(width)
-        , m_scale(6.0f / width)
+        : Filter1D(width > 0.0f ? width : 6.0f)
+        , m_scale(6.0f / m_w)
     {
     }
     ~FilterLanczos3_1D() override {}
@@ -474,7 +474,7 @@ public:
     }
 
 private:
-    float m_scale;
+    const float m_scale;
 };
 
 
@@ -482,9 +482,9 @@ private:
 class FilterLanczos3_2D final : public Filter2D {
 public:
     FilterLanczos3_2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wscale(6.0f / width)
-        , m_hscale(6.0f / height)
+        : Filter2D(width > 0.0f ? width : 6.0f, height > 0.0f ? height : 6.0f)
+        , m_wscale(6.0f / m_w)
+        , m_hscale(6.0f / m_h)
     {
     }
     ~FilterLanczos3_2D() override {}
@@ -505,7 +505,7 @@ public:
     string_view name() const override { return "lanczos3"; }
 
 protected:
-    float m_wscale, m_hscale;
+    const float m_wscale, m_hscale;
 };
 
 
@@ -513,9 +513,9 @@ protected:
 class FilterRadialLanczos3_2D final : public Filter2D {
 public:
     FilterRadialLanczos3_2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wscale(6.0f / width)
-        , m_hscale(6.0f / height)
+        : Filter2D(width > 0.0f ? width : 6.0f, height > 0.0f ? height : 6.0f)
+        , m_wscale(6.0f / m_w)
+        , m_hscale(6.0f / m_h)
     {
     }
     float operator()(float x, float y) const override
@@ -536,7 +536,7 @@ public:
     string_view name() const override { return "radial-lanczos3"; }
 
 protected:
-    float m_wscale, m_hscale;
+    const float m_wscale, m_hscale;
 };
 
 
@@ -544,8 +544,8 @@ protected:
 class FilterMitchell1D final : public Filter1D {
 public:
     FilterMitchell1D(float width)
-        : Filter1D(width)
-        , m_rad_inv(2.0f / width)
+        : Filter1D(width > 0.0f ? width : 4.0f)
+        , m_rad_inv(2.0f / m_w)
     {
     }
     ~FilterMitchell1D() override {}
@@ -578,7 +578,7 @@ public:
     }
 
 private:
-    float m_rad_inv;
+    const float m_rad_inv;
 };
 
 
@@ -586,9 +586,9 @@ private:
 class FilterMitchell2D final : public Filter2D {
 public:
     FilterMitchell2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wrad_inv(2.0f / width)
-        , m_hrad_inv(2.0f / height)
+        : Filter2D(width > 0.0f ? width : 4.0f, height > 0.0f ? height : 4.0f)
+        , m_wrad_inv(2.0f / m_w)
+        , m_hrad_inv(2.0f / m_h)
     {
     }
     ~FilterMitchell2D() override {}
@@ -609,7 +609,7 @@ public:
     string_view name() const override { return "mitchell"; }
 
 private:
-    float m_wrad_inv, m_hrad_inv;
+    const float m_wrad_inv, m_hrad_inv;
 };
 
 
@@ -618,8 +618,8 @@ private:
 class FilterBSpline1D final : public Filter1D {
 public:
     FilterBSpline1D(float width)
-        : Filter1D(width)
-        , m_wscale(4.0f / width)
+        : Filter1D(width > 0.0f ? width : 4.0f)
+        , m_wscale(4.0f / m_w)
     {
     }
     ~FilterBSpline1D() override {}
@@ -638,7 +638,7 @@ public:
     }
 
 private:
-    float m_wscale;  // width scale factor
+    const float m_wscale;  // width scale factor
     static float b0(float t) { return t * t * t / 6.0f; }
     static float b1(float t)
     {
@@ -651,9 +651,9 @@ private:
 class FilterBSpline2D final : public Filter2D {
 public:
     FilterBSpline2D(float width, float height)
-        : Filter2D(width, height)
-        , m_wscale(4.0f / width)
-        , m_hscale(4.0f / height)
+        : Filter2D(width > 0.0f ? width : 4.0f, height > 0.0f ? height : 4.0f)
+        , m_wscale(4.0f / m_w)
+        , m_hscale(4.0f / m_h)
     {
     }
     ~FilterBSpline2D() override {}
@@ -674,7 +674,7 @@ public:
     string_view name() const override { return "b-spline"; }
 
 private:
-    float m_wscale, m_hscale;
+    const float m_wscale, m_hscale;
 };
 
 
@@ -682,7 +682,7 @@ private:
 class FilterDisk2D final : public Filter2D {
 public:
     FilterDisk2D(float width, float height)
-        : Filter2D(width, height)
+        : Filter2D(width > 0.0f ? width : 1.0f, height > 0.0f ? height : 1.0f)
     {
     }
     ~FilterDisk2D() override {}
@@ -698,10 +698,10 @@ public:
 
 class FilterCubic1D : public Filter1D {
 public:
-    FilterCubic1D(float width)
-        : Filter1D(width)
-        , m_a(0.0f)
-        , m_rad_inv(2.0f / width)
+    FilterCubic1D(float width, float a = 0.0f)
+        : Filter1D(width > 0.0f ? width : 4.0f)
+        , m_a(a)
+        , m_rad_inv(2.0f / m_w)
     {
     }
     ~FilterCubic1D() override {}
@@ -729,19 +729,19 @@ public:
     string_view name() const override { return "cubic"; }
 
 protected:
-    float m_a;
-    float m_rad_inv;
+    const float m_a;
+    const float m_rad_inv;
 };
 
 
 
 class FilterCubic2D : public Filter2D {
 public:
-    FilterCubic2D(float width, float height)
-        : Filter2D(width, height)
-        , m_a(0.0f)
-        , m_wrad_inv(2.0f / width)
-        , m_hrad_inv(2.0f / height)
+    FilterCubic2D(float width, float height, float a = 0.0f)
+        : Filter2D(width > 0.0f ? width : 4.0f, height > 0.0f ? height : 4.0f)
+        , m_a(a)
+        , m_wrad_inv(2.0f / m_w)
+        , m_hrad_inv(2.0f / m_h)
     {
     }
     ~FilterCubic2D() override {}
@@ -762,8 +762,8 @@ public:
     string_view name() const override { return "cubic"; }
 
 protected:
-    float m_a;
-    float m_wrad_inv, m_hrad_inv;
+    const float m_a;
+    const float m_wrad_inv, m_hrad_inv;
 };
 
 
@@ -771,9 +771,8 @@ protected:
 class FilterKeys1D final : public FilterCubic1D {
 public:
     FilterKeys1D(float width)
-        : FilterCubic1D(width)
+        : FilterCubic1D(width, -0.5f)
     {
-        m_a = -0.5f;
     }
     ~FilterKeys1D() override {}
     string_view name() const override { return "keys"; }
@@ -783,9 +782,8 @@ public:
 class FilterKeys2D final : public FilterCubic2D {
 public:
     FilterKeys2D(float width, float height)
-        : FilterCubic2D(width, height)
+        : FilterCubic2D(width, height, -0.5f)
     {
-        m_a = -0.5f;
     }
     ~FilterKeys2D() override {}
     string_view name() const override { return "keys"; }
@@ -796,9 +794,8 @@ public:
 class FilterSimon1D final : public FilterCubic1D {
 public:
     FilterSimon1D(float width)
-        : FilterCubic1D(width)
+        : FilterCubic1D(width, -0.75f)
     {
-        m_a = -0.75f;
     }
     ~FilterSimon1D() override {}
     string_view name() const override { return "simon"; }
@@ -808,9 +805,8 @@ public:
 class FilterSimon2D final : public FilterCubic2D {
 public:
     FilterSimon2D(float width, float height)
-        : FilterCubic2D(width, height)
+        : FilterCubic2D(width, height, -0.75f)
     {
-        m_a = -0.75f;
     }
     ~FilterSimon2D() override {}
     string_view name() const override { return "simon"; }
@@ -821,9 +817,8 @@ public:
 class FilterRifman1D final : public FilterCubic1D {
 public:
     FilterRifman1D(float width)
-        : FilterCubic1D(width)
+        : FilterCubic1D(width, -1.0f)
     {
-        m_a = -1.0f;
     }
     ~FilterRifman1D() override {}
     string_view name() const override { return "rifman"; }
@@ -833,9 +828,8 @@ public:
 class FilterRifman2D final : public FilterCubic2D {
 public:
     FilterRifman2D(float width, float height)
-        : FilterCubic2D(width, height)
+        : FilterCubic2D(width, height, -1.0f)
     {
-        m_a = -1.0f;
     }
     ~FilterRifman2D() override {}
     string_view name() const override { return "rifman"; }
@@ -883,6 +877,15 @@ void
 Filter1D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 {
     *filterdesc = get_filterdesc(filternum);
+}
+
+
+
+std::shared_ptr<const Filter1D>
+Filter1D::create_shared(string_view filtername, float width)
+{
+    return std::shared_ptr<const Filter1D>(create(filtername, width),
+                                           Filter1D::destroy);
 }
 
 
@@ -980,6 +983,15 @@ Filter2D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 
 
 
+std::shared_ptr<const Filter2D>
+Filter2D::create_shared(string_view filtername, float width, float height)
+{
+    return std::shared_ptr<const Filter2D>(create(filtername, width, height),
+                                           Filter2D::destroy);
+}
+
+
+
 // Filter2D::create is the static method that, given a filter name,
 // width, and height, returns an allocated and instantiated filter of
 // the correct implementation.  If the name is not recognized, return
@@ -988,6 +1000,8 @@ Filter2D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 Filter2D*
 Filter2D::create(string_view filtername, float width, float height)
 {
+    if (height <= 0.0f)
+        height = width;
     if (filtername == "box")
         return new FilterBox2D(width, height);
     if (filtername == "triangle")

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -654,4 +654,198 @@ ParamValueList::merge(const ParamValueList& other, bool override)
     }
 }
 
+
+
+ParamValueSpan::const_iterator
+ParamValueSpan::find(ustring name, TypeDesc type, bool casesensitive) const
+{
+    if (casesensitive) {
+        for (const_iterator i = cbegin(), e = cend(); i != e; ++i) {
+            if (i->name() == name && (type == TypeUnknown || type == i->type()))
+                return i;
+        }
+    } else {
+        for (const_iterator i = cbegin(), e = cend(); i != e; ++i) {
+            if (Strutil::iequals(i->name(), name)
+                && (type == TypeUnknown || type == i->type()))
+                return i;
+        }
+    }
+    return cend();
+}
+
+
+
+ParamValueSpan::const_iterator
+ParamValueSpan::find(string_view name, TypeDesc type, bool casesensitive) const
+{
+    if (casesensitive) {
+        return find(ustring(name), type, casesensitive);
+    } else {
+        for (const_iterator i = cbegin(), e = cend(); i != e; ++i) {
+            if (Strutil::iequals(i->name(), name)
+                && (type == TypeUnknown || type == i->type()))
+                return i;
+        }
+    }
+    return cend();
+}
+
+
+
+int
+ParamValueSpan::get_int(ustring name, int defaultval, bool casesensitive,
+                        bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeInt, casesensitive);
+    return (p == cend()) ? defaultval : p->get_int(defaultval);
+}
+
+
+
+int
+ParamValueSpan::get_int(string_view name, int defaultval, bool casesensitive,
+                        bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeInt, casesensitive);
+    return (p == cend()) ? defaultval : p->get_int(defaultval);
+}
+
+
+
+float
+ParamValueSpan::get_float(string_view name, float defaultval,
+                          bool casesensitive, bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeFloat, casesensitive);
+    return (p == cend()) ? defaultval : p->get_float(defaultval);
+}
+
+
+
+float
+ParamValueSpan::get_float(ustring name, float defaultval, bool casesensitive,
+                          bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeFloat, casesensitive);
+    return (p == cend()) ? defaultval : p->get_float(defaultval);
+}
+
+
+
+string_view
+ParamValueSpan::get_string(string_view name, string_view defaultval,
+                           bool casesensitive, bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeString, casesensitive);
+    return (p == cend()) ? defaultval : string_view(p->get_ustring());
+}
+
+
+
+string_view
+ParamValueSpan::get_string(ustring name, string_view defaultval,
+                           bool casesensitive, bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeString, casesensitive);
+    return (p == cend()) ? defaultval : string_view(p->get_ustring());
+}
+
+
+
+ustring
+ParamValueSpan::get_ustring(string_view name, string_view defaultval,
+                            bool casesensitive, bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeString, casesensitive);
+    return (p == cend()) ? ustring(defaultval) : p->get_ustring();
+}
+
+
+
+ustring
+ParamValueSpan::get_ustring(ustring name, string_view defaultval,
+                            bool casesensitive, bool convert) const
+{
+    auto p = find(name, convert ? TypeUnknown : TypeString, casesensitive);
+    return (p == cend()) ? ustring(defaultval) : p->get_ustring();
+}
+
+
+
+bool
+ParamValueSpan::getattribute(string_view name, TypeDesc type, void* value,
+                             bool casesensitive) const
+{
+    auto p = find(name, TypeUnknown, casesensitive);
+    if (p != cend()) {
+        return convert_type(p->type(), p->data(), type, value);
+    } else {
+        return false;
+    }
+}
+
+
+
+bool
+ParamValueSpan::getattribute(string_view name, std::string& value,
+                             bool casesensitive) const
+{
+    auto p = find(name, TypeUnknown, casesensitive);
+    if (p != cend()) {
+        ustring s;
+        bool ok = convert_type(p->type(), p->data(), TypeString, &s);
+        if (ok)
+            value = s.string();
+        return ok;
+    } else {
+        return false;
+    }
+}
+
+
+
+bool
+ParamValueSpan::getattribute_indexed(string_view name, int index, TypeDesc type,
+                                     void* value, bool casesensitive) const
+{
+    auto p = find(name, TypeUnknown, casesensitive);
+    if (p != cend()) {
+        if (index >= int(p->type().basevalues()))
+            return false;
+        TypeDesc basetype = p->type().scalartype();
+        return convert_type(basetype,
+                            (const char*)p->data() + index * basetype.size(),
+                            type, value);
+    } else {
+        return false;
+    }
+}
+
+
+
+bool
+ParamValueSpan::getattribute_indexed(string_view name, int index,
+                                     std::string& value,
+                                     bool casesensitive) const
+{
+    auto p = find(name, TypeUnknown, casesensitive);
+    if (p != cend()) {
+        if (index >= int(p->type().basevalues()))
+            return false;
+        TypeDesc basetype = p->type().scalartype();
+        ustring s;
+        bool ok = convert_type(basetype,
+                               (const char*)p->data() + index * basetype.size(),
+                               TypeString, &s);
+        if (ok)
+            value = s.string();
+        return ok;
+    } else {
+        return false;
+    }
+}
+
+
+
 OIIO_NAMESPACE_END

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -423,7 +423,7 @@ test_paramlistspan()
     OIIO_CHECK_EQUAL(pl.get_string("bar"), "barbarbar?");
     OIIO_CHECK_EQUAL(pl.get_string("foo"), "42");
     OIIO_CHECK_ASSERT(pl.find("foo") != pl.cend());
-    OIIO_CHECK_ASSERT(pl.find("Foo") == pl.cend());
+    OIIO_CHECK_ASSERT(pl.find("Foo", TypeUnknown, true) == pl.cend());
     OIIO_CHECK_ASSERT(pl.find("Foo", TypeDesc::UNKNOWN, false) != pl.cend());
     OIIO_CHECK_ASSERT(pl.find("Foo", TypeDesc::UNKNOWN, true) == pl.cend());
     OIIO_CHECK_ASSERT(pl.find("foo", TypeDesc::INT) != pl.cend());

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -206,6 +206,20 @@ test_value_types()
         OIIO_CHECK_EQUAL(p.get_string(), "1/2");
     }
 
+    // Test ptr
+    {
+        int* ptr = (int*)0xdeadbeef;
+        ParamValue p = make_pv("name", ptr);
+        OIIO_CHECK_EQUAL(p.type(), TypePointer);
+        OIIO_CHECK_EQUAL(p.get<int*>(), ptr);
+    }
+    {
+        const char* str = "foobar";
+        ParamValue p = make_pv("name", str);
+        OIIO_CHECK_EQUAL(p.type(), TypeString);
+        OIIO_CHECK_EQUAL(p.get_string(), str);
+    }
+
     // Double check that short data are "local", long data are allocated
     ParamValue pvint("", TypeInt, 1, nullptr);
     OIIO_CHECK_ASSERT(pvint.datasize() == 4);

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -208,14 +208,14 @@ test_value_types()
 
     // Test ptr
     {
-        int* ptr = (int*)0xdeadbeef;
+        int* ptr     = (int*)0xdeadbeef;
         ParamValue p = make_pv("name", ptr);
         OIIO_CHECK_EQUAL(p.type(), TypePointer);
         OIIO_CHECK_EQUAL(p.get<int*>(), ptr);
     }
     {
         const char* str = "foobar";
-        ParamValue p = make_pv("name", str);
+        ParamValue p    = make_pv("name", str);
         OIIO_CHECK_EQUAL(p.type(), TypeString);
         OIIO_CHECK_EQUAL(p.get_string(), str);
     }

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -85,12 +85,37 @@ test_type(string_view textrep, TypeDesc constructed,
 
 
 
+static void
+test_templates()
+{
+    print("Testing templates\n");
+    OIIO_CHECK_EQUAL(BaseTypeFromC<float>::value, TypeDesc::FLOAT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<int>::value, TypeDesc::INT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<char*>::value, TypeDesc::STRING);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<ustring>::value, TypeDesc::STRING);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<void*>::value, TypeDesc::PTR);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<int*>::value, TypeDesc::PTR);
+
+    OIIO_CHECK_EQUAL(TypeDescFromC<float>::value(), TypeFloat);
+    OIIO_CHECK_EQUAL(TypeDescFromC<int>::value(), TypeInt);
+    OIIO_CHECK_EQUAL(TypeDescFromC<ustring>::value(), TypeString);
+    OIIO_CHECK_EQUAL(TypeDescFromC<char*>::value(), TypeString);
+    OIIO_CHECK_EQUAL(TypeDescFromC<const char*>::value(), TypeString);
+    OIIO_CHECK_EQUAL(TypeDescFromC<void*>::value(), TypePointer);
+    OIIO_CHECK_EQUAL(TypeDescFromC<const void*>::value(), TypePointer);
+    OIIO_CHECK_EQUAL(TypeDescFromC<int*>::value(), TypePointer);
+}
+
+
+
 int
 main(int /*argc*/, char* /*argv*/[])
 {
     std::cout << "TypeDesc size = " << sizeof(TypeDesc) << "\n";
     // We expect a TypeDesc to be the same size as a 64 bit int
     OIIO_CHECK_EQUAL(sizeof(TypeDesc), sizeof(uint64_t));
+
+    test_templates();
 
     test_type<float>("float", TypeDesc(TypeDesc::FLOAT), TypeFloat, 1.5f,
                      "1.5");


### PR DESCRIPTION
Many IBA functions take lots of optional parameters, which are from time to time augmented, leaving us with a clutter of semi-deprecated versions.

This PR prototypes a new approach, which is to make IBA functions have explicit parameters for their core/necessary controls, and the minor optional behavioral control parameters are passed as keyword/value argument lists. I think this has a few really big advantages over explicit parameter lists with ever-growing optional parameters:

1. It makes the call sites very readable, since the keywords document what the parameters do.

2. It allows us to add (or deprecate) optional parameters without ABI breaking changes, and without proliferation of many versions of each function.

A new class is added: ParamValueSpan, which as the name implies, is simply a `span` of ParamValue structs (actually, it's a subclass that inherits from `span<const ParamValue>`, and adds a bunch of helper methods).  Within the IBA namespace, this is aliased to KWArgs, to make a short and self-documenting name to pass this collection of optional parameters. This leads to IBA declarations that look like this:

    ImageBuf OIIO_API resize(const ImageBuf &src, KWArgs options = {},
                             ROI roi = {}, int nthreads = 0);

and calls that looks like this:

    resize(dst, src, { { "filtername", "lanczos3" },
                       { "filterwidth", 6.0f } });

In this first stab, I have converted IBA::resize(), fit(), and warp(). That seems like enough to evaluate whether we like the direction this is going. If so, we'll tackle more IBA functions over time. I believe I've done this all in a way that preserves API and ABI compatibility for now

A few other odds and ends that come along for the ride:

* Filter1D and Filter2D have a new create_shared static method that returns a shared_ptr instead of raw pointer.

* Make all filter ctrs ok with 0 default filter width value, which means to use the natural default width for that filter.

* IBA::make_kernel is extended so that if you pass 0 for width or hight, it selects the a resolution using the default size for the named filter kernel. This way, the caller doesn't need to know the correct extents of the kernel, just the name.
