### PR TITLE
Allow TypeDesc to be used directly in a C API by forcing it to be POD.

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -164,10 +164,7 @@ struct OIIO_UTIL_API TypeDesc {
     TypeDesc (string_view typestring);
 
     /// Copy constructor.
-    OIIO_HOSTDEVICE constexpr TypeDesc (const TypeDesc &t) noexcept
-        : basetype(t.basetype), aggregate(t.aggregate),
-          vecsemantics(t.vecsemantics), reserved(0), arraylen(t.arraylen)
-          { }
+    OIIO_HOSTDEVICE constexpr TypeDesc (const TypeDesc &t) noexcept = default;
 
 
     /// Return the name, for printing and whatnot.  For example,
@@ -365,8 +362,13 @@ struct OIIO_UTIL_API TypeDesc {
 #endif
 };
 
-
-
+// Validate that TypeDesc can be used directly as POD in a C interface.
+static_assert(std::is_default_constructible<TypeDesc>());
+static_assert(std::is_trivially_copyable<TypeDesc>());
+static_assert(std::is_trivially_destructible<TypeDesc>());
+static_assert(std::is_trivially_move_constructible<TypeDesc>());
+static_assert(std::is_trivially_copy_constructible<TypeDesc>());
+static_assert(std::is_trivially_move_assignable<TypeDesc>());
 
 // Static values for commonly used types. Because these are constexpr,
 // they should incur no runtime construction cost and should optimize nicely

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -363,12 +363,12 @@ struct OIIO_UTIL_API TypeDesc {
 };
 
 // Validate that TypeDesc can be used directly as POD in a C interface.
-static_assert(std::is_default_constructible<TypeDesc>());
-static_assert(std::is_trivially_copyable<TypeDesc>());
-static_assert(std::is_trivially_destructible<TypeDesc>());
-static_assert(std::is_trivially_move_constructible<TypeDesc>());
-static_assert(std::is_trivially_copy_constructible<TypeDesc>());
-static_assert(std::is_trivially_move_assignable<TypeDesc>());
+static_assert(std::is_default_constructible<TypeDesc>(), "TypeDesc is not default constructable.");
+static_assert(std::is_trivially_copyable<TypeDesc>(), "TypeDesc is not trivially copyable.");
+static_assert(std::is_trivially_destructible<TypeDesc>(), "TypeDesc is not trivially destructible.");
+static_assert(std::is_trivially_move_constructible<TypeDesc>(), "TypeDesc is not move constructible.");
+static_assert(std::is_trivially_copy_constructible<TypeDesc>(), "TypeDesc is not copy constructible.");
+static_assert(std::is_trivially_move_assignable<TypeDesc>(), "TypeDesc is not move assignable.");
 
 // Static values for commonly used types. Because these are constexpr,
 // they should incur no runtime construction cost and should optimize nicely


### PR DESCRIPTION
Signed-off-by: Scott Wilson <scott@propersquid.com>

<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->
This PR is for allowing the TypeDesc type to be used directly in a C API without indirection, and therefore also in a Rust API without indirection.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->
I added static asserts for the TypeDesc so it should validate if the struct is okay at compile time.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
