### PR TITLE
feat(oiiotool): Allow decision making about fixnan

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -145,6 +145,8 @@ contents of an expression may be any of:
     (channels are comma-separated)
   * `AVGCOLOR` : the average pixel value of the image (channels are
     comma-separated)
+  * `NONFINITE_COUNT` : the number of pixel values in the image that are
+    either NaN or Inf values. (Added in OIIO 2.5.10.)
   * `META` : a multi-line string containing the full metadata of the image,
     similar to what would be printed with `oiiotool -info -v`.
   * `METABRIEF` : a string containing the brief one-line description,


### PR DESCRIPTION
Added a new bit of pseudo-metadata that can be retrieved by oiiotool's expression substitution: `{TOP.NONFINITE_COUNT}` will be replaced by the count of inf and nan values present in the top image.

Also, the `-fixnan` command now has the side effect of setting a user variable called `NONFINITE_COUNT` to the number of nonfinite values that were detected or repaired.

Between the two of these, it's now easy to solve the following problem that actually came up in production for us.

Sometimes, nans creep into images, and it's easier to repair them than to fix the complicated process that produced them in the first place. For some process in the studio, we had a script that was doing this preemptively on every image it encountered:

    oiiotool image.exr -fixnan black -o image.exr

It was very expensive to repair every image whether it needed it or not, when actually it's only needed once every
many-thousands-of-images. Most of the expense was in outputting the repaired file overtop the original. Now we can do this

    oiiotool image.exr -if "{TOP.NONFINITE_COUNT}" -fixnan black -o image.exr -endif

It still has to read the image and look for NaN values, but since there are almost never any actual NaN's, now for the usual case, it can skip writing the output -- which was the vast majority of time.
