### PR TITLE
int(simd.h): Make the simd types trivially_copyable

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -10360,6 +10360,24 @@ template<> struct formatter<OIIO::simd::matrix44>
     : OIIO::pvt::array_formatter<OIIO::simd::matrix44, float, 16> {};
 } // namespace fmt
 
+
+// Allow C++ metaprogramming to understand that the simd types are trivially
+// copyable (i.e. memcpy to copy simd types is fine).
+namespace std {  // not necessary in C++17, just say std::is_trivially_copyable
+template<> struct is_trivially_copyable<OIIO::simd::vbool4> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vint4> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vfloat4> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vfloat3> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::matrix44> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vbool8> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vint8> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vfloat8> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vbool16> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vint16> : std::true_type {};
+template<> struct is_trivially_copyable<OIIO::simd::vfloat16> : std::true_type {};
+}  // namespace std
+
+
 #undef SIMD_DO
 #undef SIMD_CONSTRUCT
 #undef SIMD_CONSTRUCT_PAD

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1939,6 +1939,25 @@ test_matrix()
 
 
 
+static void
+test_trivially_copyable()
+{
+    print("\nTesting trivially_copyable on all SIMD classes\n");
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vbool4>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vint4>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vfloat4>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vfloat3>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<matrix44>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vbool8>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vint8>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vfloat8>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vbool16>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vint16>::value);
+    OIIO_CHECK_ASSERT(std::is_trivially_copyable<vfloat16>::value);
+}
+
+
+
 int
 main(int argc, char* argv[])
 {
@@ -2094,6 +2113,7 @@ main(int argc, char* argv[])
     test_special();
     test_metaprogramming();
     test_matrix();
+    test_trivially_copyable();
 
     std::cout << "\nTotal time: " << Strutil::timeintervalformat(timer())
               << "\n";


### PR DESCRIPTION
Basically, this is a way of saying memcpy of any of these simd types is fine. It doesn't matter a lot for OIIO itself, but it helps quiet some static analysis warnings for OSL.

