### PR TITLE
ci: Adjust GHA upload-artifact action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,9 @@ jobs:
         if: matrix.abi_check != ''
         run: |
             src/build-scripts/ci-abicheck.bash ./build abi_standard/build libOpenImageIO libOpenImageIO_Util
-      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        # Note: versions of upload-artifact >= 4.0 can't run on the ASWF
+        # containers because they need a newer glibc than they have.
         if: failure()
         with:
           name: oiio-${{github.job}}-${{matrix.nametag}}


### PR DESCRIPTION
We had picked a version that is too new to run on the ASWF docker containers, so wasn't actually working properly when CI failed and we wanted the artifact uploaded.
