### PR TITLE
Remove boost from strutil.cpp

### DIFF
--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -464,12 +464,16 @@ test_comparisons()
     OIIO_CHECK_EQUAL(Strutil::ifind("abcdeabcde", "BC"), 1);
     OIIO_CHECK_EQUAL(Strutil::ifind("abcdeabcde", "ac"), std::string::npos);
     OIIO_CHECK_EQUAL(Strutil::ifind("abcdeabcde", ""), 0);
+    OIIO_CHECK_EQUAL(Strutil::ifind("Xabcdeabcde", "x"), 0);
+    OIIO_CHECK_EQUAL(Strutil::ifind("abcdeabcdeX", "x"), 10);
     OIIO_CHECK_EQUAL(Strutil::ifind("", "abc"), std::string::npos);
     OIIO_CHECK_EQUAL(Strutil::ifind("", ""), std::string::npos);
     OIIO_CHECK_EQUAL(Strutil::irfind("abcdeabcde", "bc"), 6);
     OIIO_CHECK_EQUAL(Strutil::irfind("abcdeabcde", "BC"), 6);
     OIIO_CHECK_EQUAL(Strutil::irfind("abcdeabcde", "ac"), std::string::npos);
     OIIO_CHECK_EQUAL(Strutil::irfind("abcdeabcde", ""), 10);
+    OIIO_CHECK_EQUAL(Strutil::irfind("Xabcdeabcde", "x"), 0);
+    OIIO_CHECK_EQUAL(Strutil::irfind("abcdeabcdeX", "x"), 10);
     OIIO_CHECK_EQUAL(Strutil::irfind("", "abc"), std::string::npos);
     OIIO_CHECK_EQUAL(Strutil::irfind("", ""), std::string::npos);
 


### PR DESCRIPTION
## Description
Remove boost from `Strutil`. Use existing mechanisms and STL features instead. 

Relates to #4158

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
