### PR TITLE
fix(heif): Fixes to recent orientation support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,7 +61,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * giflib >= 4.1 (tested through 5.2; 5.0+ is strongly recommended for
        stability and thread safety)
  * If you want support for HEIF/HEIC or AVIF images:
-     * libheif >= 1.3 (1.7 required for AVIF support, tested through 1.17.6)
+     * libheif >= 1.3 (1.7 required for AVIF support, 1.16 required for
+       correct orientation support, tested through 1.17.6)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.
      * Avoid libheif 1.10 on Mac, it is very broken. Libheif 1.11+ is fine.
  * If you want support for DICOM medical image files:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -212,8 +212,8 @@ checked_find_package (GIF
 
 # For HEIF/HEIC/AVIF formats
 checked_find_package (Libheif VERSION_MIN 1.3
-                      RECOMMEND_MIN 1.7
-                      RECOMMEND_MIN_REASON "for AVIF support")
+                      RECOMMEND_MIN 1.16
+                      RECOMMEND_MIN_REASON "for orientation support")
 if (APPLE AND LIBHEIF_VERSION VERSION_GREATER_EQUAL 1.10 AND LIBHEIF_VERSION VERSION_LESS 1.11)
     message (WARNING "Libheif 1.10 on Apple is known to be broken, disabling libheif support")
     set (Libheif_FOUND 0)


### PR DESCRIPTION
We inadvertently started using libheif functions that only became available in their version 1.16.0. Guard against that and now we recommend at least that version (but we aren't yet changing the minimum requirement). This fixes a build break introduced in #4142 (but only breaks for older libheif).
