### PR TITLE
chore: more convertion to new string formatting

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -512,12 +512,12 @@ void cineon::IndustryHeader::FilmEdgeCode(char *edge, size_t size) const
             && this->count == 0xffffffff)
                 *edge = 0;
         else {
-                std::string e = OIIO::Strutil::sprintf(
-                    "%02u%02u%02u%06u%04u",
-                    (unsigned int)this->filmManufacturingIdCode,
-                    (unsigned int)this->filmType,
-                    (unsigned int)this->perfsOffset, this->prefix, this->count);
-                OIIO::Strutil::safe_strcpy(edge, e, size);
+            std::string e = OIIO::Strutil::fmt::format(
+                "{:02}{:02}{:02}{:06}{:04}",
+                (unsigned int)this->filmManufacturingIdCode,
+                (unsigned int)this->filmType, (unsigned int)this->perfsOffset,
+                this->prefix, this->count);
+            OIIO::Strutil::safe_strcpy(edge, e, size);
         }
 }
 

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -269,7 +269,8 @@ DICOMInput::read_metadata()
             std::string tagname = tag.getTagName();
             if (ignore_tags.find(tagname) != ignore_tags.end())
                 continue;
-            std::string name = Strutil::sprintf("dicom:%s", tag.getTagName());
+            std::string name = Strutil::fmt::format("dicom:{}",
+                                                    tag.getTagName());
             DcmEVR evr       = tag.getEVR();
             // VR codes explained:
             // http://dicom.nema.org/Dicom/2013/output/chtml/part05/sect_6.2.html

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -286,7 +286,7 @@ DPXInput::seek_subimage(int subimage, int miplevel)
     default: {
         for (int i = 0; i < m_dpx.header.ImageElementComponentCount(subimage);
              i++) {
-            std::string ch = Strutil::sprintf("channel%d", i);
+            std::string ch = Strutil::fmt::format("channel{}", i);
             m_spec.channelnames.push_back(ch);
         }
     }
@@ -319,7 +319,7 @@ DPXInput::seek_subimage(int subimage, int miplevel)
         if (!std::isnan(m_dpx.header.Gamma()) && m_dpx.header.Gamma() != 0) {
             float g = float(m_dpx.header.Gamma());
             m_spec.attribute("oiio:ColorSpace",
-                             Strutil::sprintf("Gamma%.2g", g));
+                             Strutil::fmt::format("Gamma{:.2}", g));
             m_spec.attribute("oiio:Gamma", g);
             break;
         }
@@ -537,7 +537,8 @@ DPXInput::seek_subimage(int subimage, int miplevel)
         // don't set the attribute at all
         break;
     default:
-        tmpstr = Strutil::sprintf("Undefined %d", (int)m_dpx.header.Signal());
+        tmpstr = Strutil::fmt::format("Undefined {}",
+                                      (int)m_dpx.header.Signal());
         break;
     }
     if (!tmpstr.empty())

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -40,6 +40,7 @@
 #include <ctime>
 #include <limits>
 
+#include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
 
 #include "DPXHeader.h"
@@ -685,25 +686,27 @@ void dpx::IndustryHeader::SetFileEdgeCode(const char *edge)
 }
 
 
-void dpx::IndustryHeader::TimeCode(char *str) const
+void dpx::IndustryHeader::TimeCode(char* str) const
 {
-	U32 tc = this->timeCode;
-	::snprintf(str, 12, "%c%c:%c%c:%c%c:%c%c", 
-		Hex((tc & 0xf0000000) >> 28),  Hex((tc & 0xf000000) >> 24),
-		Hex((tc & 0xf00000) >> 20),  Hex((tc & 0xf0000) >> 16),
-		Hex((tc & 0xf000) >> 12),  Hex((tc & 0xf00) >> 8),
-		Hex((tc & 0xf0) >> 4),  Hex(tc & 0xf));
+    using OIIO::Strutil::format_to_n;
+    U32 tc = this->timeCode;
+    format_to_n(str, 12, "{:c}{:c}:{:c}{:c}:{:c}{:c}:{:c}{:c}",
+                Hex((tc & 0xf0000000) >> 28), Hex((tc & 0xf000000) >> 24),
+                Hex((tc & 0xf00000) >> 20), Hex((tc & 0xf0000) >> 16),
+                Hex((tc & 0xf000) >> 12), Hex((tc & 0xf00) >> 8),
+                Hex((tc & 0xf0) >> 4), Hex(tc & 0xf));
 }
 
 
-void dpx::IndustryHeader::UserBits(char *str) const
+void dpx::IndustryHeader::UserBits(char* str) const
 {
-	U32 ub = this->userBits;
-	::snprintf(str, 12, "%c%c:%c%c:%c%c:%c%c",
-		Hex((ub & 0xf0000000) >> 28),  Hex((ub & 0xf000000) >> 24),
-		Hex((ub & 0xf00000) >> 20),  Hex((ub & 0xf0000) >> 16),
-		Hex((ub & 0xf000) >> 12),  Hex((ub & 0xf00) >> 8),
-		Hex((ub & 0xf0) >> 4),  Hex(ub & 0xf));
+    using OIIO::Strutil::format_to_n;
+    U32 ub = this->userBits;
+    format_to_n(str, 12, "{c}{c}:{c}{c}:{c}{c}:{c}{c}",
+                Hex((ub & 0xf0000000) >> 28), Hex((ub & 0xf000000) >> 24),
+                Hex((ub & 0xf00000) >> 20), Hex((ub & 0xf0000) >> 16),
+                Hex((ub & 0xf000) >> 12), Hex((ub & 0xf00) >> 8),
+                Hex((ub & 0xf0) >> 4), Hex(ub & 0xf));
 }
 
 

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -702,7 +702,7 @@ void dpx::IndustryHeader::UserBits(char* str) const
 {
     using OIIO::Strutil::format_to_n;
     U32 ub = this->userBits;
-    format_to_n(str, 12, "{c}{c}:{c}{c}:{c}{c}:{c}{c}",
+    format_to_n(str, 12, "{:c}{:c}:{:c}{:c}:{:c}{:c}:{:c}{:c}",
                 Hex((ub & 0xf0000000) >> 28), Hex((ub & 0xf000000) >> 24),
                 Hex((ub & 0xf00000) >> 20), Hex((ub & 0xf0000) >> 16),
                 Hex((ub & 0xf000) >> 12), Hex((ub & 0xf00) >> 8),

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -414,18 +414,20 @@ FitsInput::convert_date(const std::string& date)
     std::string ndate;
     if (date[4] == '-') {
         // YYYY-MM-DDThh:mm:ss convention is used since 1 January 2000
-        ndate = Strutil::sprintf("%04u:%02u:%02u", stoi(&date[0]),
-                                 stoi(&date[5]), stoi(&date[8]));
+        ndate = Strutil::fmt::format("{:04d}:{:02d}:{:02d}", stoi(&date[0]),
+                                     stoi(&date[5]), stoi(&date[8]));
         if (date.size() >= 11 && date[10] == 'T')
-            ndate += Strutil::sprintf(" %02u:%02u:%02u", stoi(&date[11]),
-                                      stoi(&date[14]), stoi(&date[17]));
+            ndate += Strutil::fmt::format(" {:02d}:{:02d}:{:02d}",
+                                          stoi(&date[11]), stoi(&date[14]),
+                                          stoi(&date[17]));
         return ndate;
     }
 
     if (date[2] == '/') {
         // DD/MM/YY convention was used before 1 January 2000
-        ndate = Strutil::sprintf("19%02u:%02u:%02u 00:00:00", stoi(&date[6]),
-                                 stoi(&date[3]), stoi(&date[0]));
+        ndate = Strutil::fmt::format("19{:02d}:{:02d}:{:02d} 00:00:00",
+                                     stoi(&date[6]), stoi(&date[3]),
+                                     stoi(&date[0]));
         return ndate;
     }
     // unrecognized format

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -199,10 +199,10 @@ FitsOutput::create_fits_header(void)
         if (keyname == "DateTime") {
             using Strutil::stoi;
             keyname = "Date";
-            value   = Strutil::sprintf("%04u-%02u-%02uT%02u:%02u:%02u",
-                                       stoi(&value[0]), stoi(&value[5]),
-                                       stoi(&value[8]), stoi(&value[11]),
-                                       stoi(&value[14]), stoi(&value[17]));
+            value = Strutil::fmt::format("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+                                         stoi(&value[0]), stoi(&value[5]),
+                                         stoi(&value[8]), stoi(&value[11]),
+                                         stoi(&value[14]), stoi(&value[17]));
         }
 
         header += create_card(keyname, value);

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -315,7 +315,7 @@ HdrInput::RGBE_ReadHeader()
                 m_spec.attribute("oiio:ColorSpace", "linear");
             else
                 m_spec.attribute("oiio:ColorSpace",
-                                 Strutil::sprintf("Gamma%.2g", g));
+                                 Strutil::fmt::format("Gamma{:.2g}", g));
 
         } else if (Strutil::parse_values(line,
                                          "EXPOSURE=", span<float>(tempf))) {

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -159,6 +159,10 @@ using old::format;
 #endif
 
 
+// format_to comes from fmt library
+using ::fmt::format_to;
+using ::fmt::format_to_n;
+
 
 /// Strutil::printf (fmt, ...)
 /// Strutil::fprintf (FILE*, fmt, ...)

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1085,24 +1085,24 @@ ImageViewer::updateStatusBar()
         return;
     }
     std::string message;
-    message = Strutil::sprintf("(%d/%d) : ", m_current_image + 1,
-                               (int)m_images.size());
+    message = Strutil::fmt::format("({}/{}) : ", m_current_image + 1,
+                                   (int)m_images.size());
     message += cur()->shortinfo();
     statusImgInfo->setText(message.c_str());
 
     message.clear();
     switch (m_color_mode) {
     case RGBA:
-        message = Strutil::sprintf("RGBA (%d-%d)", m_current_channel,
-                                   m_current_channel + 3);
+        message = Strutil::fmt::format("RGBA ({}-{})", m_current_channel,
+                                       m_current_channel + 3);
         break;
     case RGB:
-        message = Strutil::sprintf("RGB (%d-%d)", m_current_channel,
-                                   m_current_channel + 2);
+        message = Strutil::fmt::format("RGB ({}-{})", m_current_channel,
+                                       m_current_channel + 2);
         break;
     case LUMINANCE:
-        message = Strutil::sprintf("Lum (%d-%d)", m_current_channel,
-                                   m_current_channel + 2);
+        message = Strutil::fmt::format("Lum ({}-{})", m_current_channel,
+                                       m_current_channel + 2);
         break;
     case HEATMAP: message = "Heat ";
     case SINGLE_CHANNEL:
@@ -1110,29 +1110,30 @@ ImageViewer::updateStatusBar()
             && spec->channelnames[m_current_channel].size())
             message += spec->channelnames[m_current_channel];
         else if (m_color_mode == HEATMAP) {
-            message += Strutil::sprintf("%d", m_current_channel);
+            message += Strutil::fmt::format("{}", m_current_channel);
         } else {
-            message = Strutil::sprintf("chan %d", m_current_channel);
+            message = Strutil::fmt::format("chan {}", m_current_channel);
         }
         break;
     }
-    message += Strutil::sprintf("  %g:%g  exp %+.1f  gam %.2f",
-                                zoom() >= 1 ? zoom() : 1.0f,
-                                zoom() >= 1 ? 1.0f : 1.0f / zoom(),
-                                cur()->exposure(), cur()->gamma());
+    message += Strutil::fmt::format("  {}:{}  exp {:+.1f}  gam {:.2f}",
+                                    zoom() >= 1 ? zoom() : 1.0f,
+                                    zoom() >= 1 ? 1.0f : 1.0f / zoom(),
+                                    cur()->exposure(), cur()->gamma());
     if (cur()->nsubimages() > 1) {
         if (cur()->auto_subimage()) {
-            message += Strutil::sprintf("  subimg AUTO (%d/%d)",
-                                        cur()->subimage() + 1,
-                                        cur()->nsubimages());
+            message += Strutil::fmt::format("  subimg AUTO ({}/{})",
+                                            cur()->subimage() + 1,
+                                            cur()->nsubimages());
         } else {
-            message += Strutil::sprintf("  subimg %d/%d", cur()->subimage() + 1,
-                                        cur()->nsubimages());
+            message += Strutil::fmt::format("  subimg {}/{}",
+                                            cur()->subimage() + 1,
+                                            cur()->nsubimages());
         }
     }
     if (cur()->nmiplevels() > 1) {
-        message += Strutil::sprintf("  MIP %d/%d", cur()->miplevel() + 1,
-                                    cur()->nmiplevels());
+        message += Strutil::fmt::format("  MIP {}/{}", cur()->miplevel() + 1,
+                                        cur()->nmiplevels());
     }
 
     statusViewInfo->setText(message.c_str());  // tr("iv status"));

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -866,8 +866,8 @@ IvGL::paint_pixelview()
                 texty = closeupsize + yspacing;
             }
         }
-        std::string s = Strutil::sprintf("(%d, %d)", (int)real_xp + spec.x,
-                                         (int)real_yp + spec.y);
+        std::string s = Strutil::fmt::format("({}, {})", (int)real_xp + spec.x,
+                                             (int)real_yp + spec.y);
         shadowed_text(textx, texty, 0.0f, s, font);
         texty += yspacing;
         img->getpixel((int)real_xp + spec.x, (int)real_yp + spec.y, fpixel);
@@ -876,20 +876,20 @@ IvGL::paint_pixelview()
             case TypeDesc::UINT8: {
                 ImageBuf::ConstIterator<unsigned char, unsigned char> p(
                     *img, (int)real_xp + spec.x, (int)real_yp + spec.y);
-                s = Strutil::sprintf("%s: %3d  (%5.3f)",
-                                     spec.channelnames[i].c_str(), (int)(p[i]),
-                                     fpixel[i]);
+                s = Strutil::fmt::format("{}: {:3}  ({:5.3f})",
+                                         spec.channelnames[i], int(p[i]),
+                                         fpixel[i]);
             } break;
             case TypeDesc::UINT16: {
                 ImageBuf::ConstIterator<unsigned short, unsigned short> p(
                     *img, (int)real_xp + spec.x, (int)real_yp + spec.y);
-                s = Strutil::sprintf("%s: %3d  (%5.3f)",
-                                     spec.channelnames[i].c_str(), (int)(p[i]),
-                                     fpixel[i]);
+                s = Strutil::fmt::format("{}: {:3}  ({:5.3f})",
+                                         spec.channelnames[i], int(p[i]),
+                                         fpixel[i]);
             } break;
             default:  // everything else, treat as float
-                s = Strutil::sprintf("%s: %5.3f", spec.channelnames[i].c_str(),
-                                     fpixel[i]);
+                s = Strutil::fmt::format("{}: {:5.3f}", spec.channelnames[i],
+                                         fpixel[i]);
             }
             shadowed_text(textx, texty, 0.0f, s, font);
             texty += yspacing;

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -105,27 +105,12 @@ IvImage::shortinfo() const
 
 
 // Format name/value pairs as HTML table entries.
-std::string
-html_table_row(const char* name, const std::string& value)
+template<typename T>
+inline std::string
+html_table_row(string_view name, const T& value)
 {
-    std::string line = Strutil::sprintf("<tr><td><i>%s</i> : &nbsp;&nbsp;</td>",
-                                        name);
-    line += Strutil::sprintf("<td>%s</td></tr>\n", value.c_str());
-    return line;
-}
-
-
-std::string
-html_table_row(const char* name, int value)
-{
-    return html_table_row(name, Strutil::sprintf("%d", value));
-}
-
-
-std::string
-html_table_row(const char* name, float value)
-{
-    return html_table_row(name, Strutil::sprintf("%g", value));
+    return Strutil::fmt::format(
+        "<tr><td><i>{}</i> : &nbsp;&nbsp;</td><td>{}</td></tr>\n", name, value);
 }
 
 
@@ -136,19 +121,18 @@ IvImage::longinfo() const
     if (m_longinfo.empty()) {
         const ImageSpec& m_spec(nativespec());
         m_longinfo += "<table>";
-        //        m_longinfo += html_table_row (Strutil::sprintf("<b>%s</b>", m_name.c_str()).c_str(),
+        //        m_longinfo += html_table_row (Strutil::fmt::format("<b>{}</b>", m_name.c_str()).c_str(),
         //                                std::string());
         if (m_spec.depth <= 1)
             m_longinfo += html_table_row("Dimensions",
-                                         Strutil::sprintf("%d x %d pixels",
-                                                          m_spec.width,
-                                                          m_spec.height));
+                                         Strutil::fmt::format("{} x {} pixels",
+                                                              m_spec.width,
+                                                              m_spec.height));
         else
-            m_longinfo += html_table_row("Dimensions",
-                                         Strutil::sprintf("%d x %d x %d pixels",
-                                                          m_spec.width,
-                                                          m_spec.height,
-                                                          m_spec.depth));
+            m_longinfo += html_table_row(
+                "Dimensions",
+                Strutil::fmt::format("{} x {} x {} pixels", m_spec.width,
+                                     m_spec.height, m_spec.depth));
         m_longinfo += html_table_row("Channels", m_spec.nchannels);
         std::string chanlist;
         for (int i = 0; i < m_spec.nchannels; ++i) {
@@ -159,27 +143,30 @@ IvImage::longinfo() const
         m_longinfo += html_table_row("Channel list", chanlist);
         m_longinfo += html_table_row("File format", file_format_name());
         m_longinfo += html_table_row("Data format", m_file_dataformat.c_str());
-        m_longinfo += html_table_row(
-            "Data size", Strutil::sprintf("%.2f MB", (float)m_spec.image_bytes()
-                                                         / (1024.0 * 1024.0)));
-        m_longinfo += html_table_row("Image origin",
-                                     Strutil::sprintf("%d, %d, %d", m_spec.x,
-                                                      m_spec.y, m_spec.z));
-        m_longinfo += html_table_row("Full/display size",
-                                     Strutil::sprintf("%d x %d x %d",
-                                                      m_spec.full_width,
-                                                      m_spec.full_height,
-                                                      m_spec.full_depth));
         m_longinfo
-            += html_table_row("Full/display origin",
-                              Strutil::sprintf("%d, %d, %d", m_spec.full_x,
-                                               m_spec.full_y, m_spec.full_z));
+            += html_table_row("Data size",
+                              Strutil::fmt::format("{:.2f} MB",
+                                                   (float)m_spec.image_bytes()
+                                                       / (1024.0 * 1024.0)));
+        m_longinfo += html_table_row("Image origin",
+                                     Strutil::fmt::format("{}, {}, {}",
+                                                          m_spec.x, m_spec.y,
+                                                          m_spec.z));
+        m_longinfo += html_table_row("Full/display size",
+                                     Strutil::fmt::format("{} x {} x {}",
+                                                          m_spec.full_width,
+                                                          m_spec.full_height,
+                                                          m_spec.full_depth));
+        m_longinfo += html_table_row("Full/display origin",
+                                     Strutil::fmt::format("{}, {}, {}",
+                                                          m_spec.full_x,
+                                                          m_spec.full_y,
+                                                          m_spec.full_z));
         if (m_spec.tile_width)
-            m_longinfo += html_table_row("Scanline/tile",
-                                         Strutil::sprintf("tiled %d x %d x %d",
-                                                          m_spec.tile_width,
-                                                          m_spec.tile_height,
-                                                          m_spec.tile_depth));
+            m_longinfo += html_table_row(
+                "Scanline/tile",
+                Strutil::fmt::format("tiled {} x {} x {}", m_spec.tile_width,
+                                     m_spec.tile_height, m_spec.tile_depth));
         else
             m_longinfo += html_table_row("Scanline/tile", "scanline");
         if (m_spec.alpha_channel >= 0)
@@ -194,7 +181,7 @@ IvImage::longinfo() const
         attribs.sort(false /* sort case-insensitively */);
         for (auto&& p : attribs) {
             std::string s = m_spec.metadata_val(p, true);
-            m_longinfo += html_table_row(p.name().c_str(), s);
+            m_longinfo += html_table_row(p.name(), s);
         }
 
         m_longinfo += "</table>";

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -234,9 +234,9 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--allgpus", &allgpus)

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -473,19 +473,21 @@ ImageSpec::find_attribute(string_view name, ParamValue& tmpparam,
     // some special cases -- assemblies of multiple fields or attributes
     if (MATCH("geom", TypeString)) {
         ustring s = (depth <= 1 && full_depth <= 1)
-                        ? ustring::sprintf("%dx%d%+d%+d", width, height, x, y)
-                        : ustring::sprintf("%dx%dx%d%+d%+d%+d", width, height,
-                                           depth, x, y, z);
+                        ? ustring::fmtformat("{}x{}{:+d}{:+d}", width, height,
+                                             x, y)
+                        : ustring::fmtformat("{}x{}x{}{:+d}{:+d}{:+d}", width,
+                                             height, depth, x, y, z);
         tmpparam.init("geom", TypeString, 1, &s);
         return &tmpparam;
     }
     if (MATCH("full_geom", TypeString)) {
         ustring s = (depth <= 1 && full_depth <= 1)
-                        ? ustring::sprintf("%dx%d%+d%+d", full_width,
-                                           full_height, full_x, full_y)
-                        : ustring::sprintf("%dx%dx%d%+d%+d%+d", full_width,
-                                           full_height, full_depth, full_x,
-                                           full_y, full_z);
+                        ? ustring::fmtformat("{}x{}{:+d}{:+d}", full_width,
+                                             full_height, full_x, full_y)
+                        : ustring::fmtformat("{}x{}x{}{:+d}{:+d}{:+d}",
+                                             full_width, full_height,
+                                             full_depth, full_x, full_y,
+                                             full_z);
         tmpparam.init("full_geom", TypeString, 1, &s);
         return &tmpparam;
     }
@@ -641,7 +643,8 @@ static std::string
 explain_apertureapex(const ParamValue& p, const void* /*extradata*/)
 {
     if (p.type() == TypeDesc::FLOAT)
-        return Strutil::sprintf("f/%2.1f", powf(2.0f, *(float*)p.data() / 2.0f));
+        return Strutil::fmt::format("f/{:2.1f}",
+                                    powf(2.0f, *(float*)p.data() / 2.0f));
     return std::string();
 }
 
@@ -649,15 +652,15 @@ static std::string
 explain_ExifFlash(const ParamValue& p, const void* /*extradata*/)
 {
     int val = p.get_int();
-    return Strutil::sprintf("%s%s%s%s%s%s%s%s",
-                           (val & 1) ? "flash fired" : "no flash",
-                           (val & 6) == 4 ? ", no strobe return" : "",
-                           (val & 6) == 6 ? ", strobe return" : "",
-                           (val & 24) == 8 ? ", compulsory flash" : "",
-                           (val & 24) == 16 ? ", flash suppression" : "",
-                           (val & 24) == 24 ? ", auto flash" : "",
-                           (val & 32) ? ", no flash available" : "",
-                           (val & 64) ? ", red-eye reduction" : "");
+    return Strutil::fmt::format("{}{}{}{}{}{}{}{}",
+                                (val & 1) ? "flash fired" : "no flash",
+                                (val & 6) == 4 ? ", no strobe return" : "",
+                                (val & 6) == 6 ? ", strobe return" : "",
+                                (val & 24) == 8 ? ", compulsory flash" : "",
+                                (val & 24) == 16 ? ", flash suppression" : "",
+                                (val & 24) == 24 ? ", auto flash" : "",
+                                (val & 32) ? ", no flash available" : "",
+                                (val & 64) ? ", red-eye reduction" : "");
 }
 
 static LabelIndex ExifExposureProgram_table[] = {
@@ -853,7 +856,7 @@ ImageSpec::metadata_val(const ParamValue& p, bool human)
     // strings, so we need to correct for that here.
     TypeDesc ptype = p.type();
     if (ptype == TypeString && p.nvalues() == 1)
-        out = Strutil::sprintf("\"%s\"", Strutil::escape_chars(out));
+        out = Strutil::fmt::format("\"{}\"", Strutil::escape_chars(out));
     if (human) {
         const ExplanationTableEntry* exp = nullptr;
         for (const auto& e : explanation)
@@ -873,7 +876,8 @@ ImageSpec::metadata_val(const ParamValue& p, bool human)
                     nice += ", ";
                 int num = p.get<int>(2 * i + 0), den = p.get<int>(2 * i + 1);
                 if (den)
-                    nice += Strutil::sprintf("%g", float(num) / float(den));
+                    nice += Strutil::fmt::format("{:g}",
+                                                 float(num) / float(den));
                 else
                     nice += "inf";
             }
@@ -948,10 +952,10 @@ extended_format_name(TypeDesc type, int bits)
         // file than the data type we are passing.
         if (type == TypeDesc::UINT8 || type == TypeDesc::UINT16
             || type == TypeDesc::UINT32 || type == TypeDesc::UINT64)
-            return ustring::sprintf("uint%d", bits).c_str();
+            return ustring::fmtformat("uint{}", bits).c_str();
         if (type == TypeDesc::INT8 || type == TypeDesc::INT16
             || type == TypeDesc::INT32 || type == TypeDesc::INT64)
-            return ustring::sprintf("int%d", bits).c_str();
+            return ustring::fmtformat("int{}", bits).c_str();
     }
     return type.c_str();  // use the name implied by type
 }
@@ -961,16 +965,16 @@ extended_format_name(TypeDesc type, int bits)
 inline std::string
 format_res(const ImageSpec& spec, int w, int h, int d)
 {
-    return (spec.depth > 1) ? Strutil::sprintf("%d x %d x %d", w, h, d)
-                            : Strutil::sprintf("%d x %d", w, h);
+    return (spec.depth > 1) ? Strutil::fmt::format("{} x {} x {}", w, h, d)
+                            : Strutil::fmt::format("{} x {}", w, h);
 }
 
 
 inline std::string
 format_offset(const ImageSpec& spec, int x, int y, int z)
 {
-    return (spec.depth > 1) ? Strutil::sprintf("%d, %d, %d", x, y, z)
-                            : Strutil::sprintf("%d, %d", x, y);
+    return (spec.depth > 1) ? Strutil::fmt::format("{}, {}, {}", x, y, z)
+                            : Strutil::fmt::format("{}, {}", x, y);
 }
 
 
@@ -1051,55 +1055,54 @@ ImageSpec::serialize(SerialFormat fmt, SerialVerbose verbose) const
     // Text case:
     //
 
-    using Strutil::sprintf;
+    using Strutil::fmt::format;
     std::stringstream out;
 
-    out << ((depth > 1) ? sprintf("%4d x %4d x %4d", width, height, depth)
-                        : sprintf("%4d x %4d", width, height));
-    out << sprintf(", %d channel, %s%s", nchannels, deep ? "deep " : "",
-                   depth > 1 ? "volume " : "");
+    if (depth > 1)
+        print(out, "{:4} x {:4} x {:4}", width, height, depth);
+    else
+        print(out, "{:4} x {:4}", width, height);
+    print(out, ", {} channel, {}{}", nchannels, deep ? "deep " : "",
+          depth > 1 ? "volume " : "");
     if (channelformats.size()) {
         for (size_t c = 0; c < channelformats.size(); ++c)
-            out << sprintf("%s%s", c ? "/" : "", channelformats[c].c_str());
+            print(out, "{}{}", c ? "/" : "", channelformats[c]);
     } else {
         int bits = get_int_attribute("oiio:BitsPerSample", 0);
-        out << extended_format_name(this->format, bits);
+        print(out, "{}", extended_format_name(this->format, bits));
     }
-    out << '\n';
+    print(out, "\n");
 
     if (verbose >= SerialDetailed) {
-        out << "    channel list: ";
+        print(out, "    channel list: ");
         for (int i = 0; i < nchannels; ++i) {
             if (i < (int)channelnames.size())
-                out << channelnames[i];
+                print(out, "{}", channelnames[i]);
             else
-                out << "unknown";
+                print(out, "unknown");
             if (i < (int)channelformats.size())
-                out << " (" << channelformats[i] << ")";
+                print(out, " ({})", channelformats[i]);
             if (i < nchannels - 1)
-                out << ", ";
+                print(out, ", ");
         }
-        out << '\n';
+        print(out, "\n");
         if (x || y || z) {
-            out << "    pixel data origin: "
-                << ((depth > 1) ? sprintf("x=%d, y=%d, z=%d", x, y, z)
-                                : sprintf("x=%d, y=%d", x, y))
-                << '\n';
+            print(out, "    pixel data origin: {}\n",
+                  ((depth > 1) ? format("x={}, y={}, z={}", x, y, z)
+                               : format("x={}, y={}", x, y)));
         }
         if (full_x || full_y || full_z
             || (full_width != width && full_width != 0)
             || (full_height != height && full_height != 0)
             || (full_depth != depth && full_depth != 0)) {
-            out << "    full/display size: "
-                << format_res(*this, full_width, full_height, full_depth)
-                << '\n';
-            out << "    full/display origin: "
-                << format_offset(*this, full_x, full_y, full_z) << '\n';
+            print(out, "    full/display size: {}\n",
+                  format_res(*this, full_width, full_height, full_depth));
+            print(out, "    full/display origin: {}\n",
+                  format_offset(*this, full_x, full_y, full_z));
         }
         if (tile_width) {
-            out << "    tile size: "
-                << format_res(*this, tile_width, tile_height, tile_depth)
-                << '\n';
+            print(out, "    tile size: {}\n",
+                  format_res(*this, tile_width, tile_height, tile_depth));
         }
 
         // Sort the metadata alphabetically, case-insensitive, but making
@@ -1109,11 +1112,11 @@ ImageSpec::serialize(SerialFormat fmt, SerialVerbose verbose) const
         attribs.sort(false /* sort case-insensitively */);
 
         for (auto&& p : attribs) {
-            Strutil::print(out, "    {}: ", p.name());
+            print(out, "    {}: ", p.name());
             std::string s = metadata_val(p, verbose == SerialDetailedHuman);
             if (s == "1.#INF")
                 s = "inf";
-            out << s << '\n';
+            print(out, "{}\n", s);
         }
     }
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1208,7 +1208,7 @@ ImageBufAlgo::fillholes_pushpull(ImageBuf& dst, const ImageBuf& src, ROI roi,
         ImageBufAlgo::resize(*small, *pyramid.back(), "triangle");
         divide_by_alpha(*small, get_roi(smallspec), nthreads);
         pyramid.emplace_back(small);
-        // small->write(Strutil::sprintf("push%04d.exr", small->spec().width));
+        // small->write(Strutil::fmt::format("push{:04d}.exr", small->spec().width));
     }
 
     // Now pull back up the pyramid by doing an alpha composite of level
@@ -1221,7 +1221,7 @@ ImageBufAlgo::fillholes_pushpull(ImageBuf& dst, const ImageBuf& src, ROI roi,
         ImageBuf blowup(big.spec());
         ImageBufAlgo::resize(blowup, small, "triangle");
         ImageBufAlgo::over(big, big, blowup);
-        // big.write(Strutil::sprintf("pull%04d.exr", big.spec().width));
+        // big.write(Strutil::sprintf("pull{:04}.exr", big.spec().width));
     }
 
     // Now copy the completed base layer of the pyramid back to the

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -433,11 +433,11 @@ ImageBufAlgo::capture_image(int cameranum, TypeDesc convert)
         time(&now);
         struct tm tmtime;
         Sysutil::get_local_time(&now, &tmtime);
-        std::string datetime = Strutil::sprintf("%4d:%02d:%02d %02d:%02d:%02d",
-                                                tmtime.tm_year + 1900,
-                                                tmtime.tm_mon + 1,
-                                                tmtime.tm_mday, tmtime.tm_hour,
-                                                tmtime.tm_min, tmtime.tm_sec);
+        std::string datetime
+            = Strutil::sprintf("{:4d}:{:02d}:{:02d} {:02d}:{:02d}:{:02d}",
+                               tmtime.tm_year + 1900, tmtime.tm_mon + 1,
+                               tmtime.tm_mday, tmtime.tm_hour, tmtime.tm_min,
+                               tmtime.tm_sec);
         dst.specmod().attribute("DateTime", datetime);
     }
 #else

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -52,9 +52,9 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--wedge", &wedge)
@@ -1034,11 +1034,10 @@ void
 benchmark_parallel_image(int res, int iters)
 {
     using namespace ImageBufAlgo;
-    std::cout << "\nTime old parallel_image for " << res << "x" << res
-              << std::endl;
+    print("\nTime old parallel_image for {}x{}\n", res, res);
 
-    std::cout << "  threads time    rate   (best of " << ntrials << ")\n";
-    std::cout << "  ------- ------- -------\n";
+    print("  threads time    rate   (best of {})\n", ntrials);
+    print("  ------- ------- -------\n");
     ImageSpec spec(res, res, 3, TypeDesc::FLOAT);
     ImageBuf X(spec), Y(spec);
     float one[] = { 1, 1, 1 };
@@ -1063,16 +1062,16 @@ benchmark_parallel_image(int res, int iters)
         };
         double range;
         double t = time_trial(func, ntrials, iters, &range) / iters;
-        std::cout << Strutil::sprintf("  %4d   %7.3f ms  %5.1f Mpels/s\n", nt,
-                                      t * 1000, double(res * res) / t / 1.0e6);
+        print("  {:4}   {:7.3f} ms  {:5.1f} Mpels/s\n", nt, t * 1000,
+              double(res * res) / t / 1.0e6);
         if (!wedge)
             break;  // don't loop if we're not wedging
     }
 
-    std::cout << "\nTime new parallel_image for " << res << "x" << res << "\n";
+    print("\nTime new parallel_image for {}x{}\n", res, res);
 
-    std::cout << "  threads time    rate   (best of " << ntrials << ")\n";
-    std::cout << "  ------- ------- -------\n";
+    print("  threads time    rate   (best of {})\n", ntrials);
+    print("  ------- ------- -------\n");
     for (int i = 0; threadcounts[i] <= numthreads; ++i) {
         int nt = wedge ? threadcounts[i] : numthreads;
         // default_thread_pool()->resize (nt);
@@ -1080,8 +1079,8 @@ benchmark_parallel_image(int res, int iters)
         auto func = [&]() { parallel_image(Y.roi(), nt, exercise); };
         double range;
         double t = time_trial(func, ntrials, iters, &range) / iters;
-        std::cout << Strutil::sprintf("  %4d   %6.2f ms  %5.1f Mpels/s\n", nt,
-                                      t * 1000, double(res * res) / t / 1.0e6);
+        print("  {:4}   {:6.2f} ms  {:5.1f} Mpels/s\n", nt, t * 1000,
+              double(res * res) / t / 1.0e6);
         if (!wedge)
             break;  // don't loop if we're not wedging
     }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -115,10 +115,9 @@ public:
             double time         = item.second.first;
             double percall      = time / ncalls;
             bool use_ms_percall = (percall < 0.1);
-            out << Strutil::sprintf("%-25s%6d %7.3fs  (avg %6.2f%s)\n",
-                                    item.first, ncalls, time,
-                                    percall * (use_ms_percall ? 1000.0 : 1.0),
-                                    use_ms_percall ? "ms" : "s");
+            print(out, "{:25s}{:6d} {:7.3f}s  (avg {:6.2f}{})\n", item.first,
+                  ncalls, time, percall * (use_ms_percall ? 1000.0 : 1.0),
+                  use_ms_percall ? "ms" : "s");
         }
         return out.str();
     }

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -48,8 +48,8 @@ static std::vector<ustring> format_list_vector;
 // Which format names and extensions are procedural (not reading from files)
 static std::set<std::string> procedural_plugins;
 
-static std::string pattern = Strutil::sprintf(".imageio.%s",
-                                              Plugin::plugin_extension());
+static std::string pattern = Strutil::fmt::format(".imageio.{}",
+                                                  Plugin::plugin_extension());
 
 
 inline void
@@ -135,7 +135,7 @@ declare_imageio_format_locked(const std::string& format_name,
         format_library_versions[format_name] = lib_version;
         if (library_list.length())
             library_list += std::string(";");
-        library_list += Strutil::sprintf("%s:%s", format_name, lib_version);
+        library_list += Strutil::fmt::format("{}:{}", format_name, lib_version);
         // std::cout << format_name << ": " << lib_version << "\n";
     }
 }

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -54,13 +54,13 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--autotile %d", &autotile_size)
-      .help(Strutil::sprintf("Autotile size (when used; default: %d)", autotile_size));
+      .help(Strutil::fmt::format("Autotile size (when used; default: {})", autotile_size));
     ap.arg("--iteronly", &iter_only)
       .help("Run ImageBuf iteration tests only (not read tests)");
     ap.arg("--noiter", &no_iter)
@@ -172,10 +172,8 @@ test_read(const std::string& explanation, void (*func)(), int autotile = 64,
     imagecache->attribute("autoscanline", autoscanline);
     double t    = time_trial(func, ntrials);
     double rate = double(total_image_pixels) / t;
-    std::cout << "  " << explanation << ": "
-              << Strutil::timeintervalformat(t, 2) << " = "
-              << Strutil::sprintf("%5.1f", rate / 1.0e6) << " Mpel/s"
-              << std::endl;
+    print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
+          Strutil::timeintervalformat(t, 2), rate / 1.0e6);
 }
 
 
@@ -299,10 +297,8 @@ test_write(const std::string& explanation, void (*func)(), int tilesize = 0)
     outspec.tile_depth  = 1;
     double t            = time_trial(func, ntrials);
     double rate         = double(total_image_pixels) / t;
-    std::cout << "  " << explanation << ": "
-              << Strutil::timeintervalformat(t, 2) << " = "
-              << Strutil::sprintf("%5.1f", rate / 1.0e6) << " Mpel/s"
-              << std::endl;
+    print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
+          Strutil::timeintervalformat(t, 2), rate / 1.0e6);
 }
 
 
@@ -448,10 +444,8 @@ test_pixel_iteration(const std::string& explanation,
     ib.read(0, 0, preload, TypeFloat);
     double t    = time_trial(std::bind(func, std::ref(ib), iters), ntrials);
     double rate = double(ib.spec().image_pixels()) / (t / iters);
-    std::cout << "  " << explanation << ": "
-              << Strutil::timeintervalformat(t / iters, 3) << " = "
-              << Strutil::sprintf("%5.1f", rate / 1.0e6) << " Mpel/s"
-              << std::endl;
+    print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
+          Strutil::timeintervalformat(t / iters, 3), rate / 1.0e6);
 }
 
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -128,9 +128,10 @@ datestring(time_t t)
 {
     struct tm mytm;
     Sysutil::get_local_time(&t, &mytm);
-    return Strutil::sprintf("%4d:%02d:%02d %02d:%02d:%02d", mytm.tm_year + 1900,
-                            mytm.tm_mon + 1, mytm.tm_mday, mytm.tm_hour,
-                            mytm.tm_min, mytm.tm_sec);
+    return Strutil::fmt::format("{:4d}:{:02d}:{:02d} {:02d}:{:02d}:{:02d}",
+                                mytm.tm_year + 1900, mytm.tm_mon + 1,
+                                mytm.tm_mday, mytm.tm_hour, mytm.tm_min,
+                                mytm.tm_sec);
 }
 
 

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -592,26 +592,26 @@ decode_xmp(string_view xml, ImageSpec& spec)
 // Turn one ParamValue (whose xmp info we know) into a properly
 // serialized xmp string.
 static std::string
-stringize(const ParamValueList::const_iterator& p, const XMPtag& xmptag)
+stringize(const ParamValue& p, const XMPtag& xmptag)
 {
-    if (p->type() == TypeDesc::STRING) {
+    if (p.type() == TypeDesc::STRING) {
         if (xmptag.special & DateConversion) {
             // FIXME -- convert to yyyy-mm-ddThh:mm:ss.sTZD
             // return std::string();
         }
-        return std::string(*(const char**)p->data());
-    } else if (p->type() == TypeDesc::INT) {
+        return p.get_string();
+    } else if (p.type() == TypeDesc::INT) {
         if (xmptag.special & IsBool)
-            return *(const int*)p->data() ? "True" : "False";
+            return *(const int*)p.data() ? "True" : "False";
         else  // ordinary int
-            return Strutil::sprintf("%d", *(const int*)p->data());
-    } else if (p->type() == TypeDesc::FLOAT) {
+            return p.get_string();
+    } else if (p.type() == TypeDesc::FLOAT) {
         if (xmptag.special & Rational) {
             unsigned int num, den;
-            float_to_rational(*(const float*)p->data(), num, den);
-            return Strutil::sprintf("%d/%d", num, den);
+            float_to_rational(p.get<float>(), num, den);
+            return Strutil::fmt::format("{}/{}", num, den);
         } else {
-            return Strutil::sprintf("%g", *(const float*)p->data());
+            return p.get_string();
         }
     }
     return std::string();
@@ -624,13 +624,12 @@ gather_xmp_attribs(const ImageSpec& spec,
                    std::vector<std::pair<const XMPtag*, std::string>>& list)
 {
     // Loop over all params...
-    for (ParamValueList::const_iterator p = spec.extra_attribs.begin();
-         p != spec.extra_attribs.end(); ++p) {
+    for (const auto& p : spec.extra_attribs) {
         // For this param, see if there's a table entry with a matching
         // name, where the xmp name is in the right category.
-        const XMPtag* tag = xmp_tagmap_ref().find(p->name());
+        const XMPtag* tag = xmp_tagmap_ref().find(p.name());
         if (tag) {
-            if (!Strutil::iequals(p->name(), tag->oiioname))
+            if (!Strutil::iequals(p.name(), tag->oiioname))
                 continue;  // Name doesn't match
             if (tag->special & Suppress) {
                 break;  // Purposely suppressing
@@ -689,20 +688,20 @@ encode_xmp_category(std::vector<std::pair<const XMPtag*, std::string>>& list,
         if (Strutil::istarts_with(xmpname, pattern)) {
             std::string x;
             if (control == XMP_attribs)
-                x = Strutil::sprintf("%s=\"%s\"", xmpname, val);
+                x = Strutil::fmt::format("{}=\"{}\"", xmpname, val);
             else if (control == XMP_AltList || control == XMP_BagList) {
                 std::vector<std::string> vals;
                 Strutil::split(val, vals, ";");
                 for (auto& val : vals) {
                     val = Strutil::strip(val);
-                    x += Strutil::sprintf("<rdf:li>%s</rdf:li>", val);
+                    x += Strutil::fmt::format("<rdf:li>{}</rdf:li>", val);
                 }
             } else
-                x = Strutil::sprintf("<%s>%s</%s>", xmpname, val, xmpname);
+                x = Strutil::fmt::format("<{}>{}</{}>", xmpname, val, xmpname);
             if (!x.empty() && control != XMP_suppress) {
                 if (!found) {
                     // if (nodename && nodename[0]) {
-                    //    x = Strutil::sprintf("<%s ", nodename);
+                    //    x = Strutil::fmt::format("<{} ", nodename);
                     // }
                 }
                 if (minimal
@@ -735,29 +734,29 @@ encode_xmp_category(std::vector<std::pair<const XMPtag*, std::string>>& list,
 #if 1
     if (xmp.length()) {
         if (control == XMP_BagList)
-            xmp = Strutil::sprintf("<%s><rdf:Bag> %s </rdf:Bag></%s>",
-                                   nodename ? nodename : xmlnamespace, xmp,
-                                   nodename ? nodename : xmlnamespace);
+            xmp = Strutil::fmt::format("<{}><rdf:Bag> {} </rdf:Bag></{}>",
+                                       nodename ? nodename : xmlnamespace, xmp,
+                                       nodename ? nodename : xmlnamespace);
         else if (control == XMP_SeqList)
-            xmp = Strutil::sprintf("<%s><rdf:Seq> %s </rdf:Seq></%s>",
-                                   nodename ? nodename : xmlnamespace, xmp,
-                                   nodename ? nodename : xmlnamespace);
+            xmp = Strutil::fmt::format("<{}><rdf:Seq> {} </rdf:Seq></{}>",
+                                       nodename ? nodename : xmlnamespace, xmp,
+                                       nodename ? nodename : xmlnamespace);
         else if (control == XMP_AltList)
-            xmp = Strutil::sprintf("<%s><rdf:Alt> %s </rdf:Alt></%s>",
-                                   nodename ? nodename : xmlnamespace, xmp,
-                                   nodename ? nodename : xmlnamespace);
+            xmp = Strutil::fmt::format("<{}><rdf:Alt> {} </rdf:Alt></{}>",
+                                       nodename ? nodename : xmlnamespace, xmp,
+                                       nodename ? nodename : xmlnamespace);
 #    if 0
         else if (control == XMP_nodes)
-            xmp = Strutil::sprintf("<%s>%s</%s>",
+            xmp = Strutil::fmt::format("<{}>{}</{}>",
                                    nodename ? nodename : xmlnamespace, xmp,
                                    nodename ? nodename : xmlnamespace);
 #    endif
 
         std::string r;
-        r += Strutil::sprintf("<rdf:Description rdf:about=\"\" "
-                              "xmlns:%s=\"%s\"%s",
-                              xmlnamespace, url,
-                              (control == XMP_attribs) ? " " : ">");
+        r += Strutil::fmt::format("<rdf:Description rdf:about=\"\" "
+                                  "xmlns:{}=\"{}\"{}",
+                                  xmlnamespace, url,
+                                  (control == XMP_attribs) ? " " : ">");
         r += xmp;
         if (control == XMP_attribs)
             r += "/> ";  // end the <rdf:Description...

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -185,9 +185,9 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--wedge", &wedge)

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -142,35 +142,33 @@ operator<<(std::ostream& out, const Benchmarker& bench)
     range *= scale;
 
     if (bench.indent())
-        out << std::string(bench.indent(), ' ');
+        print(out, "{}", std::string(bench.indent(), ' '));
     if (unit == int(Benchmarker::Unit::s))
-        out << Strutil::sprintf("%-16s: %s", bench.m_name,
-                                Strutil::timeintervalformat(avg, 2));
+        print(out, "{:16}: {}", bench.m_name,
+              Strutil::timeintervalformat(avg, 2));
     else
-        out << Strutil::sprintf("%-16s: %6.1f %s (+/-%4.1f%s), ", bench.name(),
-                                avg, unitname, stddev, unitname);
+        print(out, "{:16}: {:6.1} {} (+/-{:4.1}{}), ", bench.name(), avg,
+              unitname, stddev, unitname);
     if (bench.avg() < 0.25e-9) {
         // Less than 1/4 ns iteration time is probably an error
-        out << "unreliable";
+        print(out, "unreliable");
         return out;
     }
     if (bench.work() == 1)
-        out << Strutil::sprintf("%6.1f %c/s", (1.0f / ratescale) / bench.avg(),
-                                rateunit);
+        print(out, "{:6.1} {:c}/s", (1.0f / ratescale) / bench.avg(), rateunit);
     else
-        out << Strutil::sprintf("%6.1f %cvals/s, %.1f %ccalls/s",
-                                (bench.work() / ratescale) / bench.avg(),
-                                rateunit, (1.0f / ratescale) / bench.avg(),
-                                rateunit);
+        print(out, "{:6.1} {:c}vals/s, {:.1} {:c}calls/s",
+              (bench.work() / ratescale) / bench.avg(), rateunit,
+              (1.0f / ratescale) / bench.avg(), rateunit);
     if (bench.verbose() >= 2)
-        out << Strutil::sprintf(" (%dx%d, rng=%.1f%%, med=%.1f)",
-                                bench.trials(), bench.iterations(), unitname,
-                                (range / avg) * 100.0, bench.median() * scale);
+        print(out, " ({}x{}, rng={:.1}%, med={:.1})", bench.trials(),
+              bench.iterations(), unitname, (range / avg) * 100.0,
+              bench.median() * scale);
 #if 0
     if (range > avg/10.0) {
         for (auto v : bench.m_times)
-            std::cout << v*scale/bench.iterations() << ' ';
-        std::cout << "\n";
+            print(out, "{} ", v*scale/bench.iterations());
+        print(out, "\n");
     }
 #endif
     return out;

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -927,7 +927,7 @@ Filesystem::parse_pattern(const char* pattern_, int framepadding_override,
         }
         if (framepadding_override > 0)
             padding = framepadding_override;
-        fmt = Strutil::sprintf("%%0%dd", padding);
+        fmt = Strutil::fmt::format("%0{}d", padding);
     }
 
     // std::cout << "Format: '" << fmt << "'\n";

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -509,7 +509,7 @@ test_scan_sequences()
     std::vector<std::string> filenames;
 
     for (size_t i = 1; i <= 5; i++) {
-        std::string fn = Strutil::sprintf("foo.%04d.exr", i);
+        std::string fn = Strutil::fmt::format("foo.{:04d}.exr", i);
         filenames.push_back(fn);
         create_test_file(fn);
     }
@@ -528,7 +528,8 @@ test_scan_sequences()
     Filesystem::create_directory("left/l");
 
     for (size_t i = 1; i <= 5; i++) {
-        std::string fn = Strutil::sprintf("left/l/foo_left_l.%04d.exr", i);
+        std::string fn = Strutil::fmt::format("left/l/foo_left_l.{:04d}.exr",
+                                              i);
         filenames.push_back(fn);
         create_test_file(fn);
     }

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -39,7 +39,7 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     // ap.arg("--threads %d", &numthreads)
-    //   .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    //   .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
       .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -42,7 +42,7 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     // clang-format on

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -39,9 +39,9 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--wedge", &wedge)

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -44,7 +44,7 @@ getargs(int argc, char* argv[])
       .usage("simd_test [options]");
 
     ap.arg("--iterations %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
 
@@ -529,7 +529,8 @@ void test_conversion_loadstore_int ()
 template<typename VEC>
 void test_vint_to_uint16s ()
 {
-    test_heading (Strutil::sprintf("test converting %s to uint16", VEC::type_name()));
+    test_heading (Strutil::fmt::format("test converting {} to uint16",
+                                       VEC::type_name()));
     VEC ival = VEC::Iota (0xffff0000);
     unsigned short buf[VEC::elements];
     ival.store (buf);
@@ -545,7 +546,8 @@ void test_vint_to_uint16s ()
 template<typename VEC>
 void test_vint_to_uint8s ()
 {
-    test_heading (Strutil::sprintf("test converting %s to uint8", VEC::type_name()));
+    test_heading (Strutil::fmt::format("test converting {} to uint8",
+                                       VEC::type_name()));
     VEC ival = VEC::Iota (0xffffff00);
     unsigned char buf[VEC::elements];
     ival.store (buf);

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -85,13 +85,16 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})",
+                                 numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})",
+                                 iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--rwratio %d", &read_write_ratio)
-       .help(Strutil::sprintf("Reader::writer ratio (default: %d)", read_write_ratio));
+       .help(Strutil::fmt::format("Reader::writer ratio (default: {})",
+                                 read_write_ratio));
     ap.arg("--wedge", &wedge)
       .help("Do a wedge test");
     // clang-format on

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -100,9 +100,9 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--wedge", &wedge)

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -516,7 +516,7 @@ Term::ansi_fgcolor(int r, int g, int b)
         r   = std::max(0, std::min(255, r));
         g   = std::max(0, std::min(255, g));
         b   = std::max(0, std::min(255, b));
-        ret = Strutil::sprintf("\033[38;2;%d;%d;%dm", r, g, b);
+        ret = Strutil::fmt::format("\033[38;2;{};{};{}m", r, g, b);
     }
     return ret;
 }
@@ -531,7 +531,7 @@ Term::ansi_bgcolor(int r, int g, int b)
         r   = std::max(0, std::min(255, r));
         g   = std::max(0, std::min(255, g));
         b   = std::max(0, std::min(255, b));
-        ret = Strutil::sprintf("\033[48;2;%d;%d;%dm", r, g, b);
+        ret = Strutil::fmt::format("\033[48;2;{};{};{}m", r, g, b);
     }
     return ret;
 }

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -38,9 +38,9 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--wedge", &wedge)
@@ -94,9 +94,9 @@ time_thread_group()
 void
 time_thread_pool()
 {
-    std::cout << "\nTiming how long it takes to launch from thread_pool:\n";
-    std::cout << "threads\ttime (best of " << ntrials << ")\n";
-    std::cout << "-------\t----------\n";
+    print("\nTiming how long it takes to launch from thread_pool:\n");
+    print("threads\ttime (best of {})\n", ntrials);
+    print("-------\t----------\n");
     thread_pool* pool(default_thread_pool());
     for (int i = 0; threadcounts[i] <= numthreads; ++i) {
         int nt = wedge ? threadcounts[i] : numthreads;
@@ -117,8 +117,8 @@ time_thread_pool()
         double range;
         double t = time_trial(func, ntrials, its, &range);
 
-        std::cout << Strutil::sprintf("%2d\t%5.1f   launch %8.1f threads/sec\n",
-                                      nt, t, (nt * its) / t);
+        print("{:2}\t{:5.1f}   launch {:8.1f} threads/sec\n", nt, t,
+              (nt * its) / t);
         if (!wedge)
             break;  // don't loop if we're not wedging
     }

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -230,7 +230,7 @@ TypeDesc::c_str() const
         alen   = arraylen > 2 ? (arraylen / 2) : (arraylen < 0 ? -1 : 0);
     }
     if (alen > 0)
-        result += Strutil::sprintf("[%d]", alen);
+        result += Strutil::fmt::format("[{}]", alen);
     else if (alen < 0)
         result += "[]";
     return ustring(result).c_str();
@@ -565,7 +565,7 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
             for (size_t i = 0, e = type.numelements(); i < e; ++i, val += 2) {
                 if (i)
                     out += ", ";
-                out += Strutil::sprintf("%u/%u", val[0], val[1]);
+                out += Strutil::fmt::format("{}/{}", val[0], val[1]);
             }
             return out;
         } else if (type == TypeTimeCode) {
@@ -576,8 +576,8 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
             int minutes    = bcdToBinary(bitField(t, 16, 22));
             int seconds    = bcdToBinary(bitField(t, 8, 14));
             int frame      = bcdToBinary(bitField(t, 0, 5));
-            return Strutil::sprintf("%02d:%02d:%02d:%02d", hours, minutes,
-                                    seconds, frame);
+            return Strutil::fmt::format("{:02d}:{:02d}:{:02d}:{:02d}", hours,
+                                        minutes, seconds, frame);
         }
         return fmt.use_sprintf
                    ? sprint_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
@@ -591,7 +591,7 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
             for (size_t i = 0, e = type.numelements(); i < e; ++i, val += 2) {
                 if (i)
                     out += ", ";
-                out += Strutil::sprintf("%d/%d", val[0], val[1]);
+                out += Strutil::fmt::format("{}/{}", val[0], val[1]);
             }
             return out;
         }
@@ -642,9 +642,9 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
     }
     default:
 #ifndef NDEBUG
-        return Strutil::sprintf("<unknown data type> (base %d, agg %d vec %d)",
-                                type.basetype, type.aggregate,
-                                type.vecsemantics);
+        return Strutil::fmt::format(
+            "<unknown data type> (base {}, agg {} vec {})", type.basetype,
+            type.aggregate, type.vecsemantics);
 #endif
         break;
     }

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -48,9 +48,9 @@ getargs(int argc, char* argv[])
     ap.arg("-v", &verbose)
       .help("Verbose mode");
     ap.arg("--threads %d", &numthreads)
-      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+      .help(Strutil::fmt::format("Number of threads (default: {})", numthreads));
     ap.arg("--iters %d", &iterations)
-      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
     ap.arg("--wedge", &wedge)

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -448,8 +448,8 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     configspec.attribute("maketx:cdfbits", cdfbits);
 
     std::string cmdline
-        = Strutil::sprintf("OpenImageIO %s : %s", OIIO_VERSION_STRING,
-                           command_line_string(argc, argv, sansattrib));
+        = Strutil::fmt::format("OpenImageIO {} : {}", OIIO_VERSION_STRING,
+                               command_line_string(argc, argv, sansattrib));
     configspec.attribute("Software", cmdline);
     configspec.attribute("maketx:full_command_line", cmdline);
 

--- a/src/nuke/txWriter/txWriter.cpp
+++ b/src/nuke/txWriter/txWriter.cpp
@@ -325,9 +325,10 @@ public:
         destSpec.attribute("maketx:checknan", (int)checkNan_);
         destSpec.attribute("maketx:verbose", (int)verbose_);
 
-        std::string software = Strutil::sprintf("OpenImageIO %s, Nuke %s",
-                                                OIIO_VERSION_STRING,
-                                                applicationVersion().string());
+        std::string software
+            = Strutil::fmt::format("OpenImageIO {}, Nuke {}",
+                                   OIIO_VERSION_STRING,
+                                   applicationVersion().string());
         destSpec.attribute("Software", software);
 
         if (aborted())

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -698,8 +698,9 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     spec.channelnames.resize(spec.nchannels);
     for (int c = 0; c < spec.nchannels; ++c) {
         if (spec.channelnames[c].empty())
-            spec.channelnames[c] = (c < 4) ? default_chan_names[c]
-                                           : Strutil::sprintf("unknown %d", c);
+            spec.channelnames[c] = (c < 4)
+                                       ? default_chan_names[c]
+                                       : Strutil::fmt::format("unknown {}", c);
         // Hint to lossy compression methods that indicates whether
         // human perception of the quantity represented by this channel
         // is closer to linear or closer to logarithmic.  Compression
@@ -754,11 +755,11 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
         time(&now);
         struct tm mytm;
         Sysutil::get_local_time(&now, &mytm);
-        std::string date = Strutil::sprintf("%4d:%02d:%02d %02d:%02d:%02d",
-                                            mytm.tm_year + 1900,
-                                            mytm.tm_mon + 1, mytm.tm_mday,
-                                            mytm.tm_hour, mytm.tm_min,
-                                            mytm.tm_sec);
+        std::string date
+            = Strutil::fmt::format("{:4d}:{:02d}:{:02d} {:02d}:{:02d}:{:02d}",
+                                   mytm.tm_year + 1900, mytm.tm_mon + 1,
+                                   mytm.tm_mday, mytm.tm_hour, mytm.tm_min,
+                                   mytm.tm_sec);
         spec.attribute("DateTime", date);
     }
 
@@ -803,7 +804,7 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     // Multi-part EXR files required to have a name. Make one up if not
     // supplied.
     if (m_nsubimages > 1 && !header.hasName()) {
-        std::string n = Strutil::sprintf("subimage%02d", subimage);
+        std::string n = Strutil::fmt::format("subimage{:02d}", subimage);
         header.insert("name", Imf::StringAttribute(n));
     }
 
@@ -1304,7 +1305,7 @@ OpenEXROutput::sanity_check_channelnames()
                 // Duplicate or missing channel name! We don't want
                 // libIlmImf to drop the channel (as it will do for
                 // duplicates), so rename it and hope for the best.
-                m_spec.channelnames[c] = Strutil::sprintf("channel%d", c);
+                m_spec.channelnames[c] = Strutil::fmt::format("channel{}", c);
                 break;
             }
         }

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -235,7 +235,8 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
         if (g == 1.0f)
             spec.attribute("oiio:ColorSpace", "linear");
         else
-            spec.attribute("oiio:ColorSpace", Strutil::sprintf("Gamma%.2g", g));
+            spec.attribute("oiio:ColorSpace",
+                           Strutil::fmt::format("Gamma{:.2g}", g));
     } else {
         // If there's no info at all, assume sRGB.
         spec.attribute("oiio:ColorSpace", "sRGB");
@@ -270,10 +271,11 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
 
     png_timep mod_time;
     if (png_get_tIME(sp, ip, &mod_time)) {
-        std::string date = Strutil::sprintf("%4d:%02d:%02d %02d:%02d:%02d",
-                                            mod_time->year, mod_time->month,
-                                            mod_time->day, mod_time->hour,
-                                            mod_time->minute, mod_time->second);
+        std::string date
+            = Strutil::fmt::format("{:4d}:{:02d}:{:02d} {:02d}:{:02d}:{:02d}",
+                                   mod_time->year, mod_time->month,
+                                   mod_time->day, mod_time->hour,
+                                   mod_time->minute, mod_time->second);
         spec.attribute("DateTime", date);
     }
 
@@ -429,9 +431,9 @@ create_write_struct(png_structp& sp, png_infop& ip, int& color_type,
 {
     // Check for things this format doesn't support
     if (spec.width < 1 || spec.height < 1)
-        return Strutil::sprintf("Image resolution must be at least 1x1, "
-                                "you asked for %d x %d",
-                                spec.width, spec.height);
+        return Strutil::fmt::format("Image resolution must be at least 1x1, "
+                                    "you asked for {} x {}",
+                                    spec.width, spec.height);
     if (spec.depth < 1)
         spec.depth = 1;
     if (spec.depth > 1)
@@ -455,8 +457,8 @@ create_write_struct(png_structp& sp, png_infop& ip, int& color_type,
         spec.alpha_channel = 3;
         break;
     default:
-        return Strutil::sprintf("PNG only supports 1-4 channels, not %d",
-                                spec.nchannels);
+        return Strutil::fmt::format("PNG only supports 1-4 channels, not {}",
+                                    spec.nchannels);
     }
     // N.B. PNG is very rigid about the meaning of the channels, so enforce
     // which channel is alpha, that's the only way PNG can do it.
@@ -640,11 +642,11 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
         time(&now);
         struct tm mytm;
         Sysutil::get_local_time(&now, &mytm);
-        std::string date = Strutil::sprintf("%4d:%02d:%02d %02d:%02d:%02d",
-                                            mytm.tm_year + 1900,
-                                            mytm.tm_mon + 1, mytm.tm_mday,
-                                            mytm.tm_hour, mytm.tm_min,
-                                            mytm.tm_sec);
+        std::string date
+            = Strutil::fmt::format("{:4d}:{:02d}:{:02d} {:02d}:{:02d}:{:02d}",
+                                   mytm.tm_year + 1900, mytm.tm_mon + 1,
+                                   mytm.tm_mday, mytm.tm_hour, mytm.tm_min,
+                                   mytm.tm_sec);
         spec.attribute("DateTime", date);
     }
 

--- a/src/rla.imageio/rla_pvt.h
+++ b/src/rla.imageio/rla_pvt.h
@@ -150,13 +150,24 @@ rla_type(TypeDesc t)
 
 
 
-/// Version of snprintf that is type safe and locale independent.
-template<typename... Args>
-inline int
-safe_snprintf(char* str, size_t size, const char* fmt, const Args&... args)
+// Formatted string into a fixed-length char array whose length we can't
+// exceed.
+template<size_t N, typename... Args>
+inline void
+safe_format_to(char (&str)[N], const char* fmt, const Args&... args)
 {
-    std::string s = Strutil::sprintf(fmt, args...);
-    return snprintf(str, size, "%s", s.c_str());
+    std::string s = Strutil::fmt::format(fmt, args...);
+    Strutil::safe_strcpy(str, s, N);
+}
+
+
+// Formatted string into an array whose length (passed) we can't exceed.
+template<typename... Args>
+inline void
+safe_format_to(char str[], size_t N, const char* fmt, const Args&... args)
+{
+    std::string s = Strutil::fmt::format(fmt, args...);
+    Strutil::safe_strcpy(str, s, N);
 }
 
 

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -110,10 +110,10 @@ private:
             swap_endian(s, 2);
             swap_endian(&i);
         }
-        out << Strutil::sprintf("%d/%u %d/%u %d/%u %d/%u (%d %d) (%u)\n",
-                                u.c[0], ((char*)u.c)[0], u.c[1],
-                                ((char*)u.c)[1], u.c[2], ((char*)u.c)[2],
-                                u.c[3], ((char*)u.c)[3], s[0], s[1], i);
+        print(out,
+              "{:d}/{:d} {:d}/{:d} {:d}/{:d} {:d}/{:d} ({:d} {:d}) ({:d})\n",
+              u.c[0], ((char*)u.c)[0], u.c[1], ((char*)u.c)[1], u.c[2],
+              ((char*)u.c)[2], u.c[3], ((char*)u.c)[3], s[0], s[1], i);
         ioseek(pos);
     }
 };

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -266,7 +266,7 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
         float g = Strutil::from_string<float>(colorspace);
         if (!(g >= 0.01f && g <= 10.0f /* sanity check */))
             g = m_spec.get_float_attribute("oiio:Gamma", 1.f);
-        safe_snprintf(m_rla.Gamma, sizeof(m_rla.Gamma), "%.10f", g);
+        safe_format_to(m_rla.Gamma, "{:.10}", g);
     }
 
     const ParamValue* p;
@@ -313,7 +313,7 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
     STRING_FIELD(Aspect, "rla:Aspect");
 
     float aspect = m_spec.get_float_attribute("PixelAspectRatio", 1.f);
-    safe_snprintf(m_rla.AspectRatio, sizeof(m_rla.AspectRatio), "%.6f", aspect);
+    safe_format_to(m_rla.AspectRatio, "{:.6}", aspect);
     Strutil::safe_strcpy(m_rla.ColorChannel,
                          m_spec.get_string_attribute("rla:ColorChannel", "rgb"),
                          sizeof(m_rla.ColorChannel));
@@ -349,13 +349,15 @@ RLAOutput::set_chromaticity(const ParamValue* p, char* dst, size_t field_size,
     if (p && p->type().basetype == TypeDesc::FLOAT) {
         switch (p->type().aggregate) {
         case TypeDesc::VEC2:
-            safe_snprintf(dst, field_size, "%.4f %.4f", ((float*)p->data())[0],
-                          ((float*)p->data())[1]);
+            safe_format_to(dst, field_size, "{:.4} {:.4}",
+                           ((const float*)p->data())[0],
+                           ((const float*)p->data())[1]);
             break;
         case TypeDesc::VEC3:
-            safe_snprintf(dst, field_size, "%.4f %.4f %.4f",
-                          ((float*)p->data())[0], ((float*)p->data())[1],
-                          ((float*)p->data())[2]);
+            safe_format_to(dst, field_size, "{:.4} {:.4} {:.4}",
+                           ((const float*)p->data())[0],
+                           ((const float*)p->data())[1],
+                           ((const float*)p->data())[2]);
             break;
         }
     } else

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1157,7 +1157,8 @@ TIFFInput::readspec(bool read_meta)
                 // This extra channel is not alpha at all.  Undo any
                 // assumptions we previously made about this channel.
                 if (m_spec.alpha_channel == c) {
-                    m_spec.channelnames[c] = Strutil::sprintf("channel%d", c);
+                    m_spec.channelnames[c] = Strutil::fmt::format("channel{}",
+                                                                  c);
                     m_spec.alpha_channel   = -1;
                 }
             }
@@ -1414,7 +1415,8 @@ TIFFInput::readspec_photometric()
             }
             // No ink names. Make it up.
             for (int i = numberofinks; i < m_spec.nchannels; ++i)
-                m_spec.channelnames.emplace_back(Strutil::sprintf("ink%d", i));
+                m_spec.channelnames.emplace_back(
+                    Strutil::fmt::format("ink{}", i));
         }
         break;
     }

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -748,7 +748,7 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
                                         m_spec.channelnames[i]);
                     else
                         inknames.insert(inknames.size(),
-                                        Strutil::sprintf("ink%d", i));
+                                        Strutil::fmt::format("ink{}", i));
                 }
                 TIFFSetField(m_tif, TIFFTAG_INKNAMES, int(inknames.size() + 1),
                              &inknames[0]);
@@ -852,11 +852,11 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
         time(&now);
         struct tm mytm;
         Sysutil::get_local_time(&now, &mytm);
-        std::string date = Strutil::sprintf("%4d:%02d:%02d %02d:%02d:%02d",
-                                            mytm.tm_year + 1900,
-                                            mytm.tm_mon + 1, mytm.tm_mday,
-                                            mytm.tm_hour, mytm.tm_min,
-                                            mytm.tm_sec);
+        std::string date
+            = Strutil::fmt::format("{:4d}:{:02d}:{:02d} {:02d}:{:02d}:{:02d}",
+                                   mytm.tm_year + 1900, mytm.tm_mon + 1,
+                                   mytm.tm_mday, mytm.tm_hour, mytm.tm_min,
+                                   mytm.tm_sec);
         m_spec.attribute("DateTime", date);
     }
 


### PR DESCRIPTION
In this PR, we convert nearly all `sprintf` uses to `format`.

It should not change any behavior or compatibility. Nonetheless, I think this is destined for master only and won't be backported, to reduce risk.

Along the way, we add format_to and format_to_n to Strutil.
