### PR TITLE
Replace uses of boost flat_map and flat_set with robin_map and robin_set

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/container/flat_map.hpp>
+#include <tsl/robin_map.h>
 
 #include <OpenImageIO/Imath.h>
 
@@ -113,6 +113,16 @@ public:
                           b.view, b.file, b.inverse);
     }
 
+    friend bool operator==(const ColorProcCacheKey& a,
+                           const ColorProcCacheKey& b)
+    {
+        return std::tie(a.hash, a.inputColorSpace, a.outputColorSpace,
+                        a.context_key, a.context_value, a.looks, a.display,
+                        a.view, a.file, a.inverse)
+               == std::tie(b.hash, b.inputColorSpace, b.outputColorSpace,
+                           b.context_key, b.context_value, b.looks, b.display,
+                           b.view, b.file, b.inverse);
+    }
     ustring inputColorSpace;
     ustring outputColorSpace;
     ustring context_key;
@@ -126,8 +136,13 @@ public:
 };
 
 
+struct ColorProcCacheKeyHasher {
+    size_t operator()(const ColorProcCacheKey& c) const { return c.hash; }
+};
 
-typedef boost::container::flat_map<ColorProcCacheKey, ColorProcessorHandle>
+
+typedef tsl::robin_map<ColorProcCacheKey, ColorProcessorHandle,
+                       ColorProcCacheKeyHasher>
     ColorProcessorMap;
 
 

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -11,7 +11,7 @@
 #include <sstream>
 #include <vector>
 
-#include <boost/container/flat_map.hpp>
+#include <tsl/robin_map.h>
 
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
@@ -27,8 +27,8 @@ using namespace pvt;
 
 class TagMap::Impl {
 public:
-    typedef boost::container::flat_map<int, const TagInfo*> tagmap_t;
-    typedef boost::container::flat_map<std::string, const TagInfo*> namemap_t;
+    typedef tsl::robin_map<int, const TagInfo*> tagmap_t;
+    typedef tsl::robin_map<std::string, const TagInfo*> namemap_t;
     // Name map is lower case so it's effectively case-insensitive
 
     Impl(string_view mapname, cspan<TagInfo> tag_table)
@@ -568,11 +568,11 @@ enum GPSTag {
 
 static const TagInfo gps_tag_table[] = {
     // clang-format off
-    { GPSTAG_VERSIONID,		"GPS:VersionID",	TIFF_BYTE, 4, version4uint8_handler }, 
+    { GPSTAG_VERSIONID,		"GPS:VersionID",	TIFF_BYTE, 4, version4uint8_handler },
     { GPSTAG_LATITUDEREF,	"GPS:LatitudeRef",	TIFF_ASCII, 2 },
     { GPSTAG_LATITUDE,		"GPS:Latitude",		TIFF_RATIONAL, 3 },
     { GPSTAG_LONGITUDEREF,	"GPS:LongitudeRef",	TIFF_ASCII, 2 },
-    { GPSTAG_LONGITUDE,		"GPS:Longitude",	TIFF_RATIONAL, 3 }, 
+    { GPSTAG_LONGITUDE,		"GPS:Longitude",	TIFF_RATIONAL, 3 },
     { GPSTAG_ALTITUDEREF,	"GPS:AltitudeRef",	TIFF_BYTE, 1 },
     { GPSTAG_ALTITUDE,		"GPS:Altitude",		TIFF_RATIONAL, 1 },
     { GPSTAG_TIMESTAMP,		"GPS:TimeStamp",	TIFF_RATIONAL, 3 },
@@ -590,7 +590,7 @@ static const TagInfo gps_tag_table[] = {
     { GPSTAG_DESTLATITUDEREF,	"GPS:DestLatitudeRef",	TIFF_ASCII, 2 },
     { GPSTAG_DESTLATITUDE,	"GPS:DestLatitude",	TIFF_RATIONAL, 3 },
     { GPSTAG_DESTLONGITUDEREF,	"GPS:DestLongitudeRef",	TIFF_ASCII, 2 },
-    { GPSTAG_DESTLONGITUDE,	"GPS:DestLongitude",	TIFF_RATIONAL, 3 }, 
+    { GPSTAG_DESTLONGITUDE,	"GPS:DestLongitude",	TIFF_RATIONAL, 3 },
     { GPSTAG_DESTBEARINGREF,	"GPS:DestBearingRef",	TIFF_ASCII, 2 },
     { GPSTAG_DESTBEARING,	"GPS:DestBearing",	TIFF_RATIONAL, 1 },
     { GPSTAG_DESTDISTANCEREF,	"GPS:DestDistanceRef",	TIFF_ASCII, 2 },
@@ -756,7 +756,7 @@ add_exif_item_to_spec(ImageSpec& spec, const char* name,
 #if 0
     if (dirp->tdir_type == TIFF_UNDEFINED || dirp->tdir_type == TIFF_BYTE) {
         // Add it as bytes
-        const void *addr = dirp->tdir_count <= 4 ? (const void *) &dirp->tdir_offset 
+        const void *addr = dirp->tdir_count <= 4 ? (const void *) &dirp->tdir_offset
                                                  : (const void *) &buf[dirp->tdir_offset];
         spec.attribute (name, TypeDesc(TypeDesc::UINT8, dirp->tdir_count), addr);
     }

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include <boost/container/flat_map.hpp>
+#include <tsl/robin_map.h>
 
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
@@ -222,7 +222,7 @@ static XMPtag xmptag[] = {
 
 
 class XMPtagMap {
-    typedef boost::container::flat_map<std::string, const XMPtag*> tagmap_t;
+    typedef tsl::robin_map<std::string, const XMPtag*> tagmap_t;
     // Key is lower case so it's effectively case-insensitive
 public:
     XMPtagMap(const XMPtag* tag_table)

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -12,7 +12,6 @@
 
 #include <tsl/robin_map.h>
 
-#include <boost/container/flat_map.hpp>
 #include <boost/thread/tss.hpp>
 
 #include <OpenImageIO/Imath.h>

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -45,6 +45,8 @@ function (setup_oiio_util_library targetname)
     target_include_directories (${targetname}
             PUBLIC
                 $<INSTALL_INTERFACE:include>
+            PRIVATE
+                ${ROBINMAP_INCLUDES}
             )
     target_link_libraries (${targetname}
             PUBLIC

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -33,7 +33,7 @@
 #    include <tbb/task_arena.h>
 #endif
 
-#include <boost/container/flat_map.hpp>
+#include <tsl/robin_map.h>
 
 #ifdef _WIN32
 #    include <windows.h>
@@ -360,7 +360,7 @@ private:
     int m_size { 0 };           // Number of threads in the queue
     std::mutex mutex;
     std::condition_variable cv;
-    mutable boost::container::flat_map<std::thread::id, int> m_worker_threadids;
+    mutable tsl::robin_map<std::thread::id, int> m_worker_threadids;
     mutable spin_mutex m_worker_threadids_mutex;
 };
 

--- a/src/oiiotool/CMakeLists.txt
+++ b/src/oiiotool/CMakeLists.txt
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
-fancy_add_executable (LINK_LIBRARIES
+fancy_add_executable (SYSTEM_INCLUDE_DIRS
+                        ${ROBINMAP_INCLUDES}
+                      LINK_LIBRARIES
                         OpenImageIO
                         $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
                         $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <stack>
 
-#include <boost/container/flat_set.hpp>
+#include <tsl/robin_set.h>
 
 #include <OpenImageIO/half.h>
 
@@ -1099,7 +1099,7 @@ protected:
     std::vector<ImageBuf*> m_img;
     std::vector<string_view> m_args;
     ParamValueList m_options;
-    typedef boost::container::flat_set<int> FastIntSet;
+    typedef tsl::robin_set<int> FastIntSet;
     FastIntSet subimage_includes;  // Subimages to operate on (empty == all)
     FastIntSet subimage_excludes;  // Subimages to skip for the op
     setup_func_t m_setup_func;


### PR DESCRIPTION
## Description

A tiny bit more progress towards #4158.

None of the code was actually dependent on the fact that these containers are sorted by key. Switching to the robin containers instead removes one less use of boost in the project.

## Tests

It passes the tests that I can run locally -- will be looking at the actual CI results to confirm everything passes, since I can't get all tests to pass locally (even without this change).

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
