### PR TITLE
build: switch to target-based definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,18 +119,9 @@ message(STATUS "CMAKE_UNITY_BUILD_MODE = ${CMAKE_UNITY_BUILD_MODE}")
 message(STATUS "CMAKE_UNITY_BUILD_BATCH_SIZE = ${CMAKE_UNITY_BUILD_BATCH_SIZE}")
 
 option (OIIO_THREAD_ALLOW_DCLP "OIIO threads may use DCLP for speed" ON)
-if (NOT OIIO_THREAD_ALLOW_DCLP)
-    add_definitions ("-DOIIO_THREAD_ALLOW_DCLP=0")
-endif ()
 
 set (TEX_BATCH_SIZE "" CACHE STRING "Force TextureSystem SIMD batch size (e.g. 16)")
-if (TEX_BATCH_SIZE)
-    add_definitions ("-DOIIO_TEXTURE_SIMD_BATCH_WIDTH=${TEX_BATCH_SIZE}")
-endif ()
 option (OIIO_TEX_IMPLEMENT_VARYINGREF "Implement the deprecated batch texture functions taking VaryingRef params" ON)
-if (NOT OIIO_TEX_IMPLEMENT_VARYINGREF)
-    add_definitions (-DOIIO_TEX_NO_IMPLEMENT_VARYINGREF=1)
-endif ()
 
 # Set the default namespace
 set (${PROJ_NAME}_NAMESPACE ${PROJECT_NAME} CACHE STRING
@@ -144,10 +135,6 @@ if (${PROJ_NAME}_NAMESPACE_INCLUDE_PATCH)
 endif ()
 message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
 
-
-# Define OIIO_INTERNAL symbol only when building OIIO itself, will not be
-# defined for downstream projects using OIIO.
-add_definitions (-DOIIO_INTERNAL=1)
 
 list (APPEND CMAKE_MODULE_PATH
       "${PROJECT_SOURCE_DIR}/src/cmake/modules"
@@ -190,10 +177,25 @@ include_directories (
     "${CMAKE_BINARY_DIR}/include/OpenImageIO"
   )
 
+
+# Define OIIO_INTERNAL symbol only when building OIIO itself, will not be
+# defined for downstream projects using OIIO.
+proj_add_compile_definitions (OIIO_INTERNAL=1)
+
+if (NOT OIIO_THREAD_ALLOW_DCLP)
+    proj_add_compile_definitions (OIIO_THREAD_ALLOW_DCLP=0)
+endif ()
+if (TEX_BATCH_SIZE)
+    proj_add_compile_definitions (OIIO_TEXTURE_SIMD_BATCH_WIDTH=${TEX_BATCH_SIZE})
+endif ()
+if (NOT OIIO_TEX_IMPLEMENT_VARYINGREF)
+    proj_add_compile_definitions (OIIO_TEX_NO_IMPLEMENT_VARYINGREF=1)
+endif ()
+
+
+
 # Tell CMake to process the sub-directories
 add_subdirectory (src/libutil)
-
-
 
 # Add IO plugin directories -- if we are embedding plugins, we need to visit
 # these directories BEFORE the OpenImageIO target is established (in

--- a/src/cmake/checked_find_package.cmake
+++ b/src/cmake/checked_find_package.cmake
@@ -39,8 +39,8 @@ endfunction ()
 #     turned off explicitly from one of these sources.
 #   * Print a message if the package is enabled but not found. This is based
 #     on ${Pkgname}_FOUND or $PKGNAME_FOUND.
-#   * Optional DEFINITIONS <string>... are passed to add_definitions if the
-#     package is found.
+#   * Optional DEFINITIONS <string>... are passed to
+#     proj_add_compile_definitions if the package is found.
 #   * Optional SETVARIABLES <id>... is a list of CMake variables to set to
 #     TRUE if the package is found (they will not be set or changed if the
 #     package is not found).
@@ -151,7 +151,7 @@ macro (checked_find_package pkgname)
                 endif ()
             endforeach ()
             message (STATUS "${ColorGreen}Found ${pkgname} ${${pkgname}_VERSION} ${_config_status}${ColorReset}")
-            add_definitions (${_pkg_DEFINITIONS})
+            proj_add_compile_definitions (${_pkg_DEFINITIONS})
             foreach (_v IN LISTS _pkg_SETVARIABLES)
                 set (${_v} TRUE)
             endforeach ()

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -36,7 +36,7 @@ include (FindThreads)
 # Boost setup
 if (MSVC)
     # Disable automatic linking using pragma comment(lib,...) of boost libraries upon including of a header
-    add_definitions (-DBOOST_ALL_NO_LIB=1)
+    proj_add_compile_definitions (BOOST_ALL_NO_LIB=1)
 endif ()
 
 # If the build system hasn't been specifically told how to link Boost, link it the same way as other
@@ -48,7 +48,7 @@ endif ()
 if (MSVC)
     # Not linking Boost as static libraries: either an explicit setting or LINKSTATIC is FALSE:
     if (NOT Boost_USE_STATIC_LIBS)
-        add_definitions (-DBOOST_ALL_DYN_LINK=1)
+        proj_add_compile_definitions (BOOST_ALL_DYN_LINK=1)
     endif ()
 endif ()
 
@@ -109,7 +109,7 @@ checked_find_package (OpenEXR REQUIRED
 # install version of 2.x.
 include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 if (MSVC AND NOT LINKSTATIC)
-    add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
+    proj_add_compile_definitions (OPENEXR_DLL) # Is this needed for new versions?
 endif ()
 if (OpenEXR_VERSION VERSION_GREATER_EQUAL 3.0)
     set (OIIO_USING_IMATH 3)
@@ -191,7 +191,7 @@ if (OpenColorIO_FOUND)
     option (OIIO_DISABLE_BUILTIN_OCIO_CONFIGS
            "For deveoper debugging/testing ONLY! Disable OCIO 2.2 builtin configs." OFF)
     if (OIIO_DISABLE_BUILTIN_OCIO_CONFIGS OR "$ENV{OIIO_DISABLE_BUILTIN_OCIO_CONFIGS}")
-        add_compile_definitions(OIIO_DISABLE_BUILTIN_OCIO_CONFIGS)
+        proj_add_compile_definitions(OIIO_DISABLE_BUILTIN_OCIO_CONFIGS)
     endif ()
 else ()
     set (OpenColorIO_FOUND 0)

--- a/src/cmake/fancy_add_executable.cmake
+++ b/src/cmake/fancy_add_executable.cmake
@@ -21,15 +21,20 @@
 #                         [ SRC source1 ... ]
 #                         [ INCLUDE_DIRS include_dir1 ... ]
 #                         [ DEFINITIONS -DFOO=bar ... ])
+#                         [ COMPILE_OPTIONS -Wno-foo ... ]
 #                         [ LINK_LIBRARIES external_lib1 ... ]
+#                         [ FOLDER foldername ]
 #
 macro (fancy_add_executable)
-    cmake_parse_arguments (_target "" "NAME" "SRC;INCLUDE_DIRS;SYSTEM_INCLUDE_DIRS;LINK_LIBRARIES;DEFINITIONS" ${ARGN})
+    cmake_parse_arguments (_target "NO_INSTALL" "NAME;FOLDER" "SRC;INCLUDE_DIRS;SYSTEM_INCLUDE_DIRS;LINK_LIBRARIES;DEFINITIONS;COMPILE_OPTIONS" ${ARGN})
        # Arguments: <prefix> <options> <one_value_keywords> <multi_value_keywords> args...
     if (NOT _target_NAME)
         # If NAME is not supplied, infer target name (and therefore the
         # executable name) from the directory name.
         get_filename_component (_target_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+    endif ()
+    if (NOT _target_FOLDER)
+        set (_target_FOLDER "Tools")
     endif ()
     if (NOT _target_SRC)
         # If SRC is not supplied, assume local cpp files are its source.
@@ -44,20 +49,25 @@ macro (fancy_add_executable)
         if (_target_SYSTEM_INCLUDE_DIRS)
             target_include_directories (${_target_NAME} SYSTEM PRIVATE ${_target_SYSTEM_INCLUDE_DIRS})
         endif ()
-        if (_target_DEFINITIONS)
-            target_compile_definitions (${_target_NAME} PRIVATE ${_target_DEFINITIONS})
-        endif ()
+        target_compile_definitions (${_target_NAME} PRIVATE
+                                        ${${PROJECT_NAME}_compile_definitions}
+                                        ${_target_DEFINITIONS})
+        target_compile_options (${_target_NAME} PRIVATE
+                                    ${${PROJECT_NAME}_compile_options}
+                                    ${_target_COMPILE_OPTIONS})
+        target_link_options (${_target_NAME} PRIVATE
+                                 ${${PROJECT_NAME}_link_options})
         if (_target_LINK_LIBRARIES)
             target_link_libraries (${_target_NAME} PRIVATE ${_target_LINK_LIBRARIES})
         endif ()
-        set_target_properties (${_target_NAME} PROPERTIES FOLDER "Tools")
+        set_target_properties (${_target_NAME} PROPERTIES FOLDER ${_target_FOLDER})
         check_is_enabled (INSTALL_${_target_NAME} _target_NAME_INSTALL_enabled)
         if (CMAKE_UNITY_BUILD AND UNITY_BUILD_MODE STREQUAL GROUP)
             set_source_files_properties(${_target_SRC} PROPERTIES
                                         UNITY_GROUP ${_target_NAME})
             message (VERBOSE "Unity group ${_target_NAME} = ${_target_SRC}")
         endif ()
-        if (_target_NAME_INSTALL_enabled)
+        if (_target_NAME_INSTALL_enabled AND NOT _target_NO_INSTALL)
             install_targets (${_target_NAME})
         endif ()
     else ()

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -78,6 +78,11 @@ set (libOpenImageIO_srcs
 
 add_library (OpenImageIO ${libOpenImageIO_srcs})
 
+target_compile_definitions(OpenImageIO PRIVATE
+                           ${${PROJECT_NAME}_compile_definitions})
+target_compile_options(OpenImageIO PRIVATE
+                           ${${PROJECT_NAME}_compile_options})
+
 # If the 'EMBEDPLUGINS' option is set, we want to compile the source for
 # all the plugins into libOpenImageIO.
 if (EMBEDPLUGINS)
@@ -234,46 +239,46 @@ install_targets (OpenImageIO)
 
 if (OIIO_BUILD_TESTS AND BUILD_TESTING)
 
-    add_executable (color_test color_test.cpp)
-    target_link_libraries (color_test PRIVATE OpenImageIO)
-    set_target_properties (color_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME color_test SRC color_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_color ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/color_test)
 
-    add_executable (imagebuf_test imagebuf_test.cpp)
-    target_link_libraries (imagebuf_test PRIVATE OpenImageIO)
-    set_target_properties (imagebuf_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME imagebuf_test SRC imagebuf_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_imagebuf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagebuf_test)
 
-    add_executable (imagecache_test imagecache_test.cpp)
-    target_link_libraries (imagecache_test PRIVATE OpenImageIO)
-    set_target_properties (imagecache_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME imagecache_test SRC imagecache_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_imagecache ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagecache_test)
 
-    add_executable (imagebufalgo_test imagebufalgo_test.cpp)
-    target_link_libraries (imagebufalgo_test PRIVATE OpenImageIO ${OpenCV_LIBRARIES})
-    set_target_properties (imagebufalgo_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME imagebufalgo_test SRC imagebufalgo_test.cpp
+                          LINK_LIBRARIES OpenImageIO ${OpenCV_LIBRARIES}
+                          FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_imagebufalgo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagebufalgo_test)
 
-    add_executable (imagespec_test imagespec_test.cpp)
-    target_link_libraries (imagespec_test PRIVATE OpenImageIO)
-    set_target_properties (imagespec_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME imagespec_test SRC imagespec_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_imagespec ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagespec_test)
 
-    add_executable (imageinout_test imageinout_test.cpp)
-    target_link_libraries (imageinout_test PRIVATE OpenImageIO)
-    set_target_properties (imageinout_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME imageinout_test SRC imageinout_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_imageinout ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imageinout_test)
 
     if (NOT DEFINED ENV{OpenImageIO_CI})
-        add_executable (imagespeed_test imagespeed_test.cpp)
-        target_link_libraries (imagespeed_test PRIVATE OpenImageIO)
-        set_target_properties (imagespeed_test PROPERTIES FOLDER "Unit Tests")
+        fancy_add_executable (NAME imagespeed_test SRC imagespeed_test.cpp
+                              LINK_LIBRARIES OpenImageIO
+                              FOLDER "Unit Tests" NO_INSTALL)
         #add_test (imagespeed_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagespeed_test)
     endif ()
 
-    add_executable (compute_test compute_test.cpp)
-    target_link_libraries (compute_test PRIVATE OpenImageIO)
-    set_target_properties (compute_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME compute_test SRC compute_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_compute ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/compute_test)
 
 endif ()

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -37,6 +37,11 @@ function (setup_oiio_util_library targetname)
         set (libtype STATIC)
     endif ()
     add_library (${targetname} ${libtype} ${libOpenImageIO_Util_srcs})
+
+    target_compile_definitions(${targetname} PRIVATE
+                               ${${PROJECT_NAME}_compile_definitions})
+    target_compile_options(${targetname} PRIVATE
+                               ${${PROJECT_NAME}_compile_options})
     target_include_directories (${targetname}
             PUBLIC
                 $<INSTALL_INTERFACE:include>
@@ -62,7 +67,9 @@ function (setup_oiio_util_library targetname)
     endif ()
 
     if (WIN32)
-        add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -DNOGDI -DVC_EXTRALEAN)
+        target_compile_definitions(${targetname} PRIVATE
+                                   WIN32_LEAN_AND_MEAN NOMINMAX
+                                   NOGDI VC_EXTRALEAN)
         target_link_libraries (${targetname} PRIVATE psapi)
     endif()
 
@@ -99,7 +106,7 @@ endfunction()
 setup_oiio_util_library (OpenImageIO_Util)
 
 option (OpenImageIO_BUILD_STATIC_UTIL_LIBRARY
-        "Build additional static OpenImageIO_Util_static library" ON)
+        "Build additional static OpenImageIO_Util_static library" OFF)
 if (OpenImageIO_BUILD_STATIC_UTIL_LIBRARY)
     setup_oiio_util_library (OpenImageIO_Util_static)
 endif ()
@@ -107,109 +114,109 @@ endif ()
 
 if (OIIO_BUILD_TESTS AND BUILD_TESTING)
 
-    add_executable (argparse_test argparse_test.cpp)
-    target_link_libraries (argparse_test PRIVATE OpenImageIO_Util)
-    set_target_properties (argparse_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME argparse_test SRC argparse_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_argparse ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/argparse_test)
 
-    add_executable (atomic_test atomic_test.cpp)
-    target_link_libraries (atomic_test PRIVATE OpenImageIO_Util)
-    set_target_properties (atomic_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME atomic_test SRC atomic_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_atomic ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/atomic_test)
 
-    add_executable (span_test span_test.cpp)
-    target_link_libraries (span_test PRIVATE OpenImageIO_Util)
-    set_target_properties (span_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME span_test SRC span_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_span ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/span_test)
 
-    add_executable (spinlock_test spinlock_test.cpp)
-    target_link_libraries (spinlock_test PRIVATE OpenImageIO_Util)
-    set_target_properties (spinlock_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME spinlock_test SRC spinlock_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_spinlock ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spinlock_test)
 
-    add_executable (spin_rw_test spin_rw_test.cpp)
-    target_link_libraries (spin_rw_test PRIVATE OpenImageIO_Util)
-    set_target_properties (spin_rw_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME spin_rw_test SRC spin_rw_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_spin_rw ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spin_rw_test)
 
-    add_executable (ustring_test ustring_test.cpp)
-    target_link_libraries (ustring_test PRIVATE OpenImageIO_Util)
-    set_target_properties (ustring_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME ustring_test SRC ustring_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_ustring ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ustring_test)
 
-    add_executable (strutil_test strutil_test.cpp)
-    target_link_libraries (strutil_test PRIVATE OpenImageIO_Util)
-    set_target_properties (strutil_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME strutil_test SRC strutil_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_strutil ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/strutil_test)
 
-    add_executable (fmath_test fmath_test.cpp)
-    target_link_libraries (fmath_test PRIVATE OpenImageIO_Util
-                                              ${OPENIMAGEIO_IMATH_TARGETS})
-    set_target_properties (fmath_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME fmath_test SRC fmath_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util
+                                         ${OPENIMAGEIO_IMATH_TARGETS})
     add_test (unit_fmath ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fmath_test)
 
-    add_executable (filesystem_test filesystem_test.cpp)
-    target_link_libraries (filesystem_test PRIVATE OpenImageIO_Util)
-    set_target_properties (filesystem_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME filesystem_test SRC filesystem_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_filesystem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/filesystem_test)
 
-    add_executable (optparser_test optparser_test.cpp)
-    target_link_libraries (optparser_test PRIVATE OpenImageIO_Util)
-    set_target_properties (optparser_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME optparser_test SRC optparser_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_optparser ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/optparser_test)
 
-    add_executable (hash_test hash_test.cpp)
-    target_link_libraries (hash_test PRIVATE OpenImageIO_Util)
-    set_target_properties (hash_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME hash_test SRC hash_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_hash ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/hash_test)
 
-    add_executable (parallel_test parallel_test.cpp)
-    target_link_libraries (parallel_test PRIVATE OpenImageIO_Util)
-    set_target_properties (parallel_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME parallel_test SRC parallel_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_parallel ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/parallel_test)
 
-    add_executable (timer_test timer_test.cpp)
-    target_link_libraries (timer_test PRIVATE OpenImageIO_Util)
-    set_target_properties (timer_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME timer_test SRC timer_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_timer ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/timer_test)
 
-    add_executable (thread_test thread_test.cpp)
-    target_link_libraries (thread_test PRIVATE OpenImageIO_Util)
-    set_target_properties (thread_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME thread_test SRC thread_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_thread ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/thread_test)
 
-    add_executable (simd_test simd_test.cpp)
-    target_link_libraries (simd_test PRIVATE OpenImageIO
-                                             ${OPENIMAGEIO_IMATH_TARGETS})
-    set_target_properties (simd_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME simd_test SRC simd_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO
+                                         ${OPENIMAGEIO_IMATH_TARGETS})
     add_test (unit_simd ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/simd_test)
 
-    add_executable (filter_test filter_test.cpp)
-    target_link_libraries (filter_test PRIVATE OpenImageIO)
-    set_target_properties (filter_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME filter_test SRC filter_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO)
     add_test (unit_filter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/filter_test)
 
-    add_executable (paramlist_test paramlist_test.cpp)
-    target_link_libraries (paramlist_test PRIVATE OpenImageIO_Util
-                                                  ${OPENIMAGEIO_IMATH_TARGETS})
-    set_target_properties (paramlist_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME paramlist_test SRC paramlist_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util
+                                         ${OPENIMAGEIO_IMATH_TARGETS})
     add_test (unit_paramlist ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/paramlist_test)
 
-    add_executable (strongparam_test strongparam_test.cpp)
-    target_link_libraries (strongparam_test PRIVATE OpenImageIO_Util)
-    set_target_properties (strongparam_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME strongparam_test SRC strongparam_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util)
     add_test (unit_strongparam ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/strongparam_test)
 
-    add_executable (typedesc_test typedesc_test.cpp)
-    target_link_libraries (typedesc_test PRIVATE OpenImageIO_Util
-                           ${OPENIMAGEIO_OPENEXR_TARGETS})
-    set_target_properties (typedesc_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME typedesc_test SRC typedesc_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util
+                                         ${OPENIMAGEIO_OPENEXR_TARGETS})
     add_test (unit_typedesc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/typedesc_test)
 
-    add_executable (type_traits_test type_traits_test.cpp)
-    target_link_libraries (type_traits_test PRIVATE OpenImageIO_Util
-                           ${OPENIMAGEIO_OPENEXR_TARGETS})
-    set_target_properties (type_traits_test PROPERTIES FOLDER "Unit Tests")
+    fancy_add_executable (NAME type_traits_test SRC type_traits_test.cpp
+                          NO_INSTALL  FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_Util
+                                         ${OPENIMAGEIO_OPENEXR_TARGETS})
     add_test (unit_type_traits ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/type_traits_test)
 
 endif ()

--- a/src/nuke/txReader/CMakeLists.txt
+++ b/src/nuke/txReader/CMakeLists.txt
@@ -5,6 +5,10 @@
 
 add_library (txReader MODULE txReader.cpp)
 
+target_compile_definitions(txReader PRIVATE
+                           ${${PROJECT_NAME}_compile_definitions})
+target_compile_options(txReader PRIVATE
+                           ${${PROJECT_NAME}_compile_options})
 target_include_directories (txReader PUBLIC ${NUKE_INCLUDES})
 target_link_libraries (txReader PUBLIC ${NUKE_LIBRARIES} OpenImageIO)
 install_targets (txReader)

--- a/src/nuke/txWriter/CMakeLists.txt
+++ b/src/nuke/txWriter/CMakeLists.txt
@@ -4,6 +4,10 @@
 
 add_library (txWriter MODULE txWriter.cpp)
 
+target_compile_definitions(txWriter PRIVATE
+                           ${${PROJECT_NAME}_compile_definitions})
+target_compile_options(txWriter PRIVATE
+                           ${${PROJECT_NAME}_compile_options})
 target_include_directories (txWriter PUBLIC ${NUKE_INCLUDES})
 target_link_libraries (txWriter PUBLIC ${NUKE_LIBRARIES} OpenImageIO)
 install_targets (txWriter)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -11,6 +11,12 @@ setup_python_module (TARGET    PyOpenImageIO
                      LIBS      OpenImageIO ${OPENIMAGEIO_IMATH_TARGETS}
                      )
 
+target_compile_definitions(PyOpenImageIO PRIVATE
+                           ${${PROJECT_NAME}_compile_definitions})
+target_compile_options(PyOpenImageIO PRIVATE
+                           ${${PROJECT_NAME}_compile_options})
+
+
 # Unity builds: If in unity group mode, make the python bindings one group. If
 # in unity batch mode, use the smaller batch size because these tend to be
 # expensive files to compile.


### PR DESCRIPTION
We had lots of stray usage of add_defintions, add_compile_options,
etc.  In modern cmake, this is considered bad form, since it makes
subprojects pollute the global option lists. A better way is to add
all these to specific targets, so now that's what we do in this PR.
This should make all the definitions and options we want to set for
compilng OIIO's code not have any interference with subprojects, or
with higher-level surrounding projects.