### PR TITLE
build: need additional include

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <numeric>
 
 #include <OpenImageIO/Imath.h>
 #include <OpenImageIO/platform.h>


### PR DESCRIPTION
Apparently, the specific combination of not having OCIO available at build time, and C++17 or higher, and we were missing one header we needed in this module.
