### PR TITLE
build: FindOpenColorIO failed to properly set OpenColorIO_VERSION

### DIFF
--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -91,6 +91,7 @@ find_package_handle_standard_args (OpenColorIO
     )
 
 if (OpenColorIO_FOUND)
+    set (OpenColorIO_VERSION ${OPENCOLORIO_VERSION})
     set (OPENCOLORIO_INCLUDES ${OPENCOLORIO_INCLUDE_DIR})
     set (OPENCOLORIO_LIBRARIES ${OPENCOLORIO_LIBRARY})
     set (OPENCOLORIO_DEFINITIONS "")


### PR DESCRIPTION
... in the OCIO 1.x case where we relied on our own Find module rather than an exported cmake config from OCIO itself. This is desired for uniformity of naming with the exported configs of the later versions.
