### PR TITLE
refactor: Make span default ctr and assignment be `= default`

### DIFF
--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -113,7 +113,7 @@ public:
     /// Construct from a fixed-length C array.  Template magic automatically
     /// finds the length from the declared type of the array.
     template<size_t N>
-    constexpr span (T (&data)[N]) : m_data(data), m_size(N) { }
+    constexpr span (T (&data)[N]) noexcept : m_data(data), m_size(N) { }
 
     /// Construct from std::vector<T>.
     template<class Allocator>
@@ -125,21 +125,21 @@ public:
     /// `const std::vector<T>` into a `span<const T>` (the span isn't const,
     /// but the data it points to will be).
     template<class Allocator>
-    span (const std::vector<value_type, Allocator> &v)
+    span (const std::vector<value_type, Allocator> &v) noexcept
         : m_data(v.data()), m_size(v.size()) { }
 
     /// Construct from mutable element std::array
     template <size_t N>
-    constexpr span (std::array<value_type, N> &arr)
+    constexpr span (std::array<value_type, N> &arr) noexcept
         : m_data(arr.data()), m_size(N) {}
 
     /// Construct from read-only element std::array
     template <size_t N>
-    constexpr span (const std::array<value_type, N>& arr)
+    constexpr span (const std::array<value_type, N>& arr) noexcept
         : m_data(arr.data()), m_size(N) {}
 
     /// Construct a span from an initializer_list.
-    constexpr span (std::initializer_list<T> il)
+    constexpr span (std::initializer_list<T> il) noexcept
         : span (il.begin(), il.size()) { }
 
     /// Assignment copies the pointer and length, not the data.

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -89,8 +89,8 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     static constexpr size_type extent = Extent;
 
-    /// Default constructor -- the span points to nothing.
-    constexpr span () noexcept { }
+    /// Default constructor -- the span will be `{nullptr,0}`.
+    constexpr span () noexcept = default;
 
     /// Copy constructor (copies the span pointer and length, NOT the data).
     template<class U, oiio_span_size_type N>
@@ -143,11 +143,7 @@ public:
         : span (il.begin(), il.size()) { }
 
     /// Assignment copies the pointer and length, not the data.
-    span& operator= (const span &copy) {
-        m_data = copy.data();
-        m_size = copy.size();
-        return *this;
-    }
+    constexpr span& operator= (const span &copy) = default;
 
     /// Subview containing the first Count elements of the span.
     template<size_type Count>


### PR DESCRIPTION
Minor simplification.
