### PR TITLE
bugfix: glTexImage3D

### DIFF
--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -20,7 +20,7 @@
 
 #include <vector>
 
-#include <QOpenGLFunctions>
+#include <QOpenGLExtraFunctions>
 #include <QOpenGLWidget>
 
 #include <OpenImageIO/imagebuf.h>
@@ -31,7 +31,7 @@ using namespace OIIO;
 class IvImage;
 class ImageViewer;
 
-class IvGL : public QOpenGLWidget, protected QOpenGLFunctions {
+class IvGL : public QOpenGLWidget, protected QOpenGLExtraFunctions {
     Q_OBJECT
 public:
     IvGL(QWidget* parent, ImageViewer& viewer);


### PR DESCRIPTION
## Description

[BUG] glTexImage3D not in QOpenGLFunctions but in QOpenGLExtraFunctions https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4180

## Tests

CMake and VS compiling iv without issues

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
