### PR TITLE
Overload decode_wrapmode to support ustringhash

### DIFF
--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -26,6 +26,7 @@
 #define OIIO_TEXTURESYSTEM_SUPPORTS_GETATTRIBUTETYPE 1
 
 #define OIIO_TEXTURESYSTEM_SUPPORTS_STOCHASTIC 1
+#define OIIO_TEXTURESYSTEM_SUPPORTS_DECODE_BY_USTRINGHASH 1
 
 #ifndef INCLUDED_IMATHVEC_H
 // Placeholder declaration for Imath::V3f if no Imath headers have been
@@ -93,6 +94,7 @@ enum class Wrap {
 /// "default", "black", "clamp", "periodic", "mirror".
 OIIO_API Wrap decode_wrapmode (const char *name);
 OIIO_API Wrap decode_wrapmode (ustring name);
+OIIO_API Wrap decode_wrapmode (ustringhash name);
 
 /// Utility: Parse a single wrap mode (e.g., "periodic") or a
 /// comma-separated wrap modes string (e.g., "black,clamp") into
@@ -278,6 +280,10 @@ public:
     {
         return (Wrap)Tex::decode_wrapmode(name);
     }
+    static Wrap decode_wrapmode(ustringhash name)
+    {
+        return (Wrap)Tex::decode_wrapmode(name);
+    }
 
     /// Utility: Parse a single wrap mode (e.g., "periodic") or a
     /// comma-separated wrap modes string (e.g., "black,clamp") into
@@ -427,6 +433,10 @@ public:
         return (Wrap)Tex::decode_wrapmode(name);
     }
     static Wrap decode_wrapmode(ustring name)
+    {
+        return (Wrap)Tex::decode_wrapmode(name);
+    }
+    static Wrap decode_wrapmode(ustringhash name)
     {
         return (Wrap)Tex::decode_wrapmode(name);
     }

--- a/src/libtexture/texoptions.cpp
+++ b/src/libtexture/texoptions.cpp
@@ -36,6 +36,18 @@ static const ustring wrap_type_name[] = {
     ustring()
 };
 
+static const ustringhash wrap_type_hash[] = {
+    // MUST match the order of TextureOptions::Wrap
+    ustringhash("default"),
+    ustringhash("black"),
+    ustringhash("clamp"),
+    ustringhash("periodic"),
+    ustringhash("mirror"),
+    ustringhash("periodic_pow2"),
+    ustringhash("periodic_sharedborder"),
+    ustringhash()
+};
+
 }  // end anonymous namespace
 
 
@@ -139,6 +151,15 @@ Tex::decode_wrapmode(ustring name)
 {
     for (int i = 0; i < (int)Tex::Wrap::Last; ++i)
         if (name == wrap_type_name[i])
+            return (Wrap)i;
+    return Tex::Wrap::Default;
+}
+
+Tex::Wrap
+Tex::decode_wrapmode(ustringhash name)
+{
+    for (int i = 0; i < (int)Tex::Wrap::Last; ++i)
+        if (name == wrap_type_hash[i])
             return (Wrap)i;
     return Tex::Wrap::Default;
 }


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->

## Description
For OSL, we want to be able to decode a wrapmode directly from a ustringhash without having to expensively convert it to ustring.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
