### PR TITLE
build: have checked_find_package accept CONFIG, fix DCMTK

### DIFF
--- a/src/cmake/checked_find_package.cmake
+++ b/src/cmake/checked_find_package.cmake
@@ -64,6 +64,8 @@ endfunction ()
 #     version, accepting but warning if it is below this number (even
 #     if above the true minimum version accepted). The warning message
 #     can give an optional explanation, passed as RECOMMEND_MIN_REASON.
+#   * Optional CONFIG, if supplied, only accepts the package from an
+#     exported config and never uses a FindPackage.cmake module.
 #   * Optional PREFER_CONFIG, if supplied, tries to use an exported config
 #     file from the package before using a FindPackage.cmake module.
 #   * Optional DEBUG turns on extra debugging information related to how
@@ -78,7 +80,7 @@ endfunction ()
 macro (checked_find_package pkgname)
     cmake_parse_arguments(_pkg   # prefix
         # noValueKeywords:
-        "REQUIRED;PREFER_CONFIG;DEBUG;NO_RECORD_NOTFOUND"
+        "REQUIRED;CONFIG;PREFER_CONFIG;DEBUG;NO_RECORD_NOTFOUND"
         # singleValueKeywords:
         "ENABLE;ISDEPOF;VERSION_MIN;VERSION_MAX;RECOMMEND_MIN;RECOMMEND_MIN_REASON"
         # multiValueKeywords:
@@ -122,13 +124,13 @@ macro (checked_find_package pkgname)
     if (_enable OR _pkg_REQUIRED)
         if (${pkgname}_FOUND OR ${pkgname_upper}_FOUND)
             # was already found
-        elseif (_pkg_PREFER_CONFIG OR ALWAYS_PREFER_CONFIG)
+        elseif (_pkg_CONFIG OR _pkg_PREFER_CONFIG OR ALWAYS_PREFER_CONFIG)
             find_package (${pkgname} CONFIG ${_pkg_UNPARSED_ARGUMENTS})
             if (${pkgname}_FOUND OR ${pkgname_upper}_FOUND)
                 set (_config_status "from CONFIG")
             endif ()
         endif ()
-        if (NOT (${pkgname}_FOUND OR ${pkgname_upper}_FOUND))
+        if (NOT (${pkgname}_FOUND OR ${pkgname_upper}_FOUND) AND NOT _pkg_CONFIG)
             find_package (${pkgname} ${_pkg_UNPARSED_ARGUMENTS})
         endif()
         if ((${pkgname}_FOUND OR ${pkgname_upper}_FOUND)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -207,8 +207,7 @@ checked_find_package (TBB 2017
                       PREFER_CONFIG)
 
 # DCMTK is used to read DICOM images
-checked_find_package (DCMTK VERSION_MIN 3.6.1
-                      PREFER_CONFIG)
+checked_find_package (DCMTK CONFIG VERSION_MIN 3.6.1)
 
 checked_find_package (FFmpeg VERSION_MIN 3.0)
 checked_find_package (GIF


### PR DESCRIPTION
Add another optional flag to our checked_find_package cmake function -- CONFIG means only accept a config for the package, never use a FindBlah.cmake module.

(Reminder: this is in contrast to the existing PREFER_CONFIG option, which tries a config first, then if that fails, will try the module, and also different from the default if neither is used, which is to prefer the module over the exported config.)

And rig our search for DCMTK to use the new CONFIG option. There is a FindDCMTK.cmake modules that comes with cmake, and for at least some versions of cmake, it seems subtly broken in such a way that actually wrecks our finding of other packages properly.
