### PR TITLE
fix: Restore internals of strhash to compile on 32 bit architectures

### DIFF
--- a/src/include/OpenImageIO/detail/farmhash.h
+++ b/src/include/OpenImageIO/detail/farmhash.h
@@ -2097,7 +2097,7 @@ STATIC_INLINE uint64_t Hash64(const char* s, size_t len) {
 // May change from time to time, may differ on different platforms, may differ
 // depending on NDEBUG.
 STATIC_INLINE size_t Hash(const char* s, size_t len) {
-  return sizeof(size_t) == 8 ? Hash64(s, len) : Hash32(s, len);
+  return sizeof(size_t) == 8 ? size_t(Hash64(s, len)) : size_t(Hash32(s, len));
 }
 
 // Hash function for a byte array.  For convenience, a 64-bit seed is also

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -370,13 +370,13 @@ std::string OIIO_UTIL_API wordwrap (string_view src, int columns = 80,
 
 
 /// Our favorite "string" hash of a length of bytes. Currently, it is just
-/// a wrapper for an inlined, constexpr (if C++ >= 14), Cuda-safe farmhash.
+/// a wrapper for an inlined, constexpr, Cuda-safe farmhash.
 /// It returns a size_t, so will be a 64 bit hash on 64-bit platforms, but
 /// a 32 bit hash on 32-bit platforms.
 inline constexpr size_t
 strhash(size_t len, const char *s)
 {
-    return OIIO::farmhash::inlined::Hash(s, len);
+    return size_t(OIIO::farmhash::inlined::Hash64(s, len));
 }
 
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -346,13 +346,13 @@ void
 test_hash()
 {
     using namespace Strutil;
-    OIIO_CHECK_EQUAL(strhash("foo"), 6150913649986995171);
-    OIIO_CHECK_EQUAL(strhash(std::string("foo")), 6150913649986995171);
-    OIIO_CHECK_EQUAL(strhash(string_view("foo")), 6150913649986995171);
+    OIIO_CHECK_EQUAL(strhash("foo"), size_t(6150913649986995171));
+    OIIO_CHECK_EQUAL(strhash(std::string("foo")), size_t(6150913649986995171));
+    OIIO_CHECK_EQUAL(strhash(string_view("foo")), size_t(6150913649986995171));
     OIIO_CHECK_EQUAL(strhash(""), 0);  // empty string hashes to 0
     // Check longer hash and ensure that it's really constexpr
     constexpr size_t hash = Strutil::strhash("much longer string");
-    OIIO_CHECK_EQUAL(hash, 16257490369375554819ULL);
+    OIIO_CHECK_EQUAL(hash, size_t(16257490369375554819ULL));
 }
 
 


### PR DESCRIPTION
Fixes #4212
