### PR TITLE
ci: Fix broken Windows CI by building our own libtiff

### DIFF
--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -103,8 +103,8 @@ vcpkg list
 # export PNG_ROOT=$PWD/ext/dist
 
 # We're currently getting libtiff from vcpkg
-#src/build-scripts/build_libtiff.bash
-#export TIFF_ROOT=$PWD/ext/dist
+src/build-scripts/build_libtiff.bash
+export TIFF_ROOT=$PWD/ext/dist
 
 # We're currently getting jpeg from vcpkg
 # LIBJPEGTURBO_CONFIG_OPTS=-DWITH_SIMD=OFF


### PR DESCRIPTION
Windows CI was failing because it couldn't get a proper libtiff from VcPkg, which in turn is because lzma is a dependency of the libtiff build in VcPkg, and for the time being, it looks like VcPgk is failing to get lzma which is part of the big xz debacle of 2024.

So work around for now by just building our own libtiff rather than relying on VcPkg. Seems to work fine.
