### PR TITLE
build: Remove boost::stacktrace

### DIFF
--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -51,7 +51,6 @@ echo "---------------"
 time vcpkg install boost-container:x64-windows
 time vcpkg install boost-filesystem:x64-windows
 time vcpkg install boost-math:x64-windows
-time vcpkg install boost-stacktrace:x64-windows
 time vcpkg install boost-system:x64-windows
 time vcpkg install boost-thread:x64-windows
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -78,8 +78,6 @@ endif ()
 include_directories (SYSTEM "${Boost_INCLUDE_DIRS}")
 link_directories ("${Boost_LIBRARY_DIRS}")
 
-option (OIIO_DISABLE_BOOST_STACKTRACE "Disable use of Boost stacktrace." OFF)
-
 # end Boost setup
 ###########################################################################
 

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -110,15 +110,17 @@ OIIO_API size_t
 max_open_files();
 
 /// Return a string containing a readable stack trace from the point where
-/// it was called. Return an empty string if not supported on this platform.
+/// it was called. Return an empty string if not supported on this platform
+/// or this build of OpenImageIO.
 OIIO_API std::string
 stacktrace();
 
 /// Turn on automatic stacktrace dump to the named file if the program
 /// crashes. Return true if this is properly set up, false if it is not
-/// possible on this platform. The name may be "stdout" or "stderr" to
-/// merely print the trace to stdout or stderr, respectively. If the name
-/// is "", it will disable the auto-stacktrace printing.
+/// possible on this platform or with this build of OpenImageIO. The name may
+/// be "stdout" or "stderr" to merely print the trace to stdout or stderr,
+/// respectively. If the name is "", it will disable the auto-stacktrace
+/// printing.
 OIIO_API bool
 setup_crash_stacktrace(string_view filename);
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -61,6 +61,12 @@ function (setup_oiio_util_library targetname)
                 # ${CMAKE_DL_LIBS}
             )
 
+    if (GCC_VERSION VERSION_GREATER_EQUAL 12.0
+        AND CMAKE_CXX_STANDARD VERSION_GREATER_EQUAL 23)
+        target_link_libraries (${targetname}
+                               PRIVATE stdc++_libbacktrace)
+    endif ()
+
     if (INTERNALIZE_FMT OR OIIO_USING_FMT_LOCAL)
         add_dependencies(${targetname} fmt_internal_target)
     else ()

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -61,18 +61,14 @@
 #endif
 
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/ustring.h>
 
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 106500
-#    ifndef _GNU_SOURCE
-#        define _GNU_SOURCE
-#    endif
-#    if !defined(OIIO_DISABLE_BOOST_STACKTRACE)
-#        include <boost/stacktrace.hpp>
-#    endif
+#if __has_include(<stacktrace>) && __cpp_lib_stacktrace >= 202011L
+#    include <stacktrace>
+#    define HAVE_STACKTRACE 1
 #endif
 
 OIIO_INTEL_PRAGMA(warning disable 2196)
@@ -646,12 +642,21 @@ aligned_free(void* ptr)
 
 
 
+// Notes on stacktrace:
+//
+// To shed the boost dependency, we are disabling stacktrace for now. It's not
+// vital and probably not worth keeping boost just for that.
+//
+// C++23 has std::stacktrace, so as compilers add support for this, we will
+// phase it back in.
+
+
 std::string
 Sysutil::stacktrace()
 {
-#if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
+#ifdef HAVE_STACKTRACE
     std::stringstream out;
-    out << boost::stacktrace::stacktrace();
+    out << std::stacktrace::current();
     return out.str();
 #else
     return "";
@@ -660,8 +665,7 @@ Sysutil::stacktrace()
 
 
 
-#if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
-
+#ifdef HAVE_STACKTRACE
 static std::string stacktrace_filename;
 static std::mutex stacktrace_filename_mutex;
 
@@ -675,14 +679,12 @@ stacktrace_signal_handler(int signum)
         else if (stacktrace_filename == "stderr")
             std::cerr << Sysutil::stacktrace();
         else {
-#    if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
-            boost::stacktrace::safe_dump_to(stacktrace_filename.c_str());
-#    endif
+            Filesystem::write_text_file(stacktrace_filename,
+                                        Sysutil::stacktrace());
         }
     }
     ::raise(SIGABRT);
 }
-
 #endif
 
 
@@ -690,14 +692,15 @@ stacktrace_signal_handler(int signum)
 bool
 Sysutil::setup_crash_stacktrace(string_view filename)
 {
-#if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
+#ifdef HAVE_STACKTRACE
     std::lock_guard<std::mutex> lock(stacktrace_filename_mutex);
     stacktrace_filename = filename;
     ::signal(SIGSEGV, &stacktrace_signal_handler);
     ::signal(SIGABRT, &stacktrace_signal_handler);
     return true;
-#endif
+#else
     return false;
+#endif
 }
 
 


### PR DESCRIPTION
To shed the boost dependency, we are disabling stacktrace for now. It's not vital and probably not worth keeping boost just for that.

C++23 has std::stacktrace, so as compilers add support for this, we will phase it back in.

We can also add it back if somebody has an alternate suggestion for a 3rd party solution that is a simply drop-in replacement, portable, lightweight dependency, with compatible license. A good compromise might be this one: https://github.com/jeremy-rifkin/cpptrace But I think what I'm proposing is that we accept this PR first, get rid of boost, then we can come back to looking at cpptrace as potentially a way to restore the functionality prior to C++23.
