### PR TITLE
build!: Move OpenEXR/Imath minimum to 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: gcc9/C++17 py3.7 exr2.5 ocio2.0
+          - desc: gcc9/C++17 py3.7 exr3.1 ocio2.0
             nametag: linux-vfx2021
             runner: ubuntu-latest
             container: aswf/ci-osl:2021
             vfxyear: 2021
             cxx_std: 17
+            openexr_ver: v3.1.13
             python_ver: 3.7
             simd: "avx2,f16c"
             fmt_ver: 7.1.0
             pybind11_ver: v2.7.0
-            setenvs: export PUGIXML_VERSION=v1.9 WEBP_VERSION=v1.1.0
-          - desc: clang10/C++17 avx2 exr2.5 ocio2.0
+            setenvs: export PUGIXML_VERSION=v1.9 WEBP_VERSION=v1.1.0 USE_OPENVDB=0
+          - desc: clang10/C++14 avx2 exr3.1 ocio2.0
             nametag: linux-clang10-cpp14
             runner: ubuntu-latest
             container: aswf/ci-osl:2021-clang10
@@ -53,10 +54,12 @@ jobs:
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
+            openexr_ver: v3.1.13
             pybind11_ver: v2.6.2
             python_ver: 3.7
             simd: "avx2,f16c"
             fmt_ver: 8.1.1
+            setenvs: export USE_OPENVDB=0
           - desc: gcc9/C++17 py39 exr3.1 ocio2.1
             nametag: linux-vfx2022
             runner: ubuntu-latest
@@ -140,7 +143,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             pybind11_ver: v2.10.0
-          - desc: oldest/hobbled gcc9.3/C++17 py3.7 exr-2.4 no-sse no-ocio
+          - desc: oldest/hobbled gcc9.3/C++17 py3.7 exr-3.1 no-sse no-ocio
             # Oldest versions of the dependencies that we can muster, and various
             # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins).
             nametag: linux-oldest
@@ -149,7 +152,7 @@ jobs:
             vfxyear: 2021
             cxx_std: 17
             fmt_ver: 7.0.1
-            openexr_ver: v2.4.0
+            openexr_ver: v3.1.0
             pybind11_ver: v2.4.2
             python_ver: 3.7
             simd: 0
@@ -278,7 +281,7 @@ jobs:
             cxx_compiler: g++-12
             cxx_std: 17
             fmt_ver: 10.1.1
-            openexr_ver: v3.2.1
+            openexr_ver: v3.2.4
             pybind11_ver: v2.11.1
             python_ver: "3.10"
             simd: avx2,f16c
@@ -321,7 +324,7 @@ jobs:
             cc_compiler: clang
             cxx_std: 20
             fmt_ver: 10.1.1
-            openexr_ver: v3.1.11
+            openexr_ver: v3.1.13
             pybind11_ver: v2.9.2
             python_ver: 3.8
             simd: avx2,f16c
@@ -329,14 +332,14 @@ jobs:
                             OPENCOLORIO_VERSION=v2.1.2
                             USE_OPENVDB=0
                             # The installed OpenVDB has a TLS conflict with Python 3.8
-          - desc: debug gcc9/C++17, sse4.2, exr2.4
+          - desc: debug gcc9/C++17, sse4.2, exr3.1
             nametag: linux-gcc9-cpp17-debug
             runner: ubuntu-20.04
             cxx_compiler: g++-9
             cxx_std: 17
             python_ver: 3.8
             simd: sse4.2
-            openexr_ver: v2.4.3
+            openexr_ver: v3.1.13
             pybind11_ver: v2.6.2
             setenvs: export CMAKE_BUILD_TYPE=Debug
                             PUGIXML_VERSION=v1.9
@@ -346,7 +349,7 @@ jobs:
             runner: ubuntu-20.04
             cxx_compiler: g++-9
             cxx_std: 17
-            openexr_ver: v2.4.3
+            openexr_ver: v3.1.13
             python_ver: 3.8
             pybind11_ver: v2.6.2
             setenvs: export BUILD_SHARED_LIBS=OFF
@@ -363,6 +366,7 @@ jobs:
             runner: ubuntu-latest
             cxx_std: 17
             extra_artifacts: "src/*.*"
+            openexr_ver: v3.1.13
             python_ver: "3.10"
             skip_tests: 1
             setenvs: export BUILDTARGET=clang-format
@@ -508,14 +512,14 @@ jobs:
             runner: windows-2019
             vsver: 2019
             generator: "Visual Studio 16 2019"
-            openexr_ver: v3.2.2
+            openexr_ver: v3.2.4
             python_ver: 3.7
             # simd: sse4.2
           - desc: windows-2022
             runner: windows-2022
             vsver: 2022
             generator: "Visual Studio 17 2022"
-            openexr_ver: v3.2.2
+            openexr_ver: v3.2.4
             python_ver: "3.9"
             # simd: sse4.2
     runs-on: ${{ matrix.runner }}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,8 +20,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * Compilers: **gcc 9.3** - 13.1, **clang 5** - 17, MSVS 2017 - 2019 (**v19.14
    and up**), **Intel icc 19+**, Intel OneAPI C++ compiler 2022+.
  * **CMake >= 3.15** (tested through 3.28)
- * **OpenEXR/Imath >= 2.4** (recommended: 3.1 or higher; tested through 3.2
-   and main) (ADVISORY: We expect that OIIO 2.6 in 2024 will require OpenEXR >= 3.1)
+ * **OpenEXR/Imath >= 3.1** (tested through 3.2
+   and main) 
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.6)
  * libjpeg >= 8 (tested through jpeg9e), or **libjpeg-turbo >= 2.1** (tested
    through 3.0)

--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,6 @@ ifneq (${OPENEXR_ROOT},)
 MY_CMAKE_FLAGS += -DOPENEXR_ROOT:STRING=${OPENEXR_ROOT}
 endif
 
-ifneq (${ILMBASE_ROOT},)
-MY_CMAKE_FLAGS += -DILMBASE_ROOT:STRING=${ILMBASE_ROOT}
-endif
-
 ifneq (${NUKE_VERSION},)
 MY_CMAKE_FLAGS += -DNUKE_VERSION:STRING=${NUKE_VERSION}
 endif
@@ -384,7 +380,6 @@ help:
 	@echo "          PTex  R3DSDK  TBB  TIFF  Webp"
 	@echo "  Finding and Using Dependencies:"
 	@echo "      OPENEXR_ROOT=path        Custom OpenEXR installation"
-	@echo "      ILMBASE_ROOT=path        Custom IlmBase installation"
 	@echo "      USE_EXTERNAL_PUGIXML=1   Use the system PugiXML, not the one in OIIO"
 	@echo "      USE_QT=0                 Skip anything that needs Qt"
 	@echo "      USE_PYTHON=0             Don't build the Python binding"

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Utility script to download and build OpenEXR & IlmBase
+# Utility script to download and build OpenEXR & Imath
 
 # Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
@@ -11,7 +11,7 @@ set -ex
 
 # Which OpenEXR to retrieve, how to build it
 OPENEXR_REPO=${OPENEXR_REPO:=https://github.com/AcademySoftwareFoundation/openexr.git}
-OPENEXR_VERSION=${OPENEXR_VERSION:=v3.1.9}
+OPENEXR_VERSION=${OPENEXR_VERSION:=v3.2.4}
 
 # Where to install the final results
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
@@ -29,7 +29,7 @@ echo "OpenEXR build dir will be: ${OPENEXR_BUILD_DIR}"
 echo "OpenEXR install dir will be: ${OPENEXR_INSTALL_DIR}"
 echo "OpenEXR Build type is ${OPENEXR_BUILD_TYPE}"
 
-# Clone OpenEXR project (including IlmBase) from GitHub and build
+# Clone OpenEXR project (including Imath) from GitHub and build
 if [[ ! -e ${OPENEXR_SOURCE_DIR} ]] ; then
     echo "git clone ${OPENEXR_REPO} ${OPENEXR_SOURCE_DIR}"
     git clone ${OPENEXR_REPO} ${OPENEXR_SOURCE_DIR}
@@ -43,10 +43,8 @@ cmake   -S . -B ${OPENEXR_BUILD_DIR} \
         -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} \
         -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
         -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-        -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
         -DOPENEXR_BUILD_UTILS=0 \
         -DBUILD_TESTING=0 \
-        -DPYILMBASE_ENABLE=0 \
         -DOPENEXR_VIEWERS_ENABLE=0 \
         -DINSTALL_OPENEXR_EXAMPLES=0 \
         -DOPENEXR_INSTALL_EXAMPLES=0 \
@@ -61,9 +59,7 @@ popd
 
 # Set up paths. These will only affect the caller if this script is
 # run with 'source' rather than in a separate shell.
-export ILMBASE_ROOT=$OPENEXR_INSTALL_DIR
 export OPENEXR_ROOT=$OPENEXR_INSTALL_DIR
-export ILMBASE_LIBRARY_DIR=$OPENEXR_INSTALL_DIR/lib
 export OPENEXR_LIBRARY_DIR=$OPENEXR_INSTALL_DIR/lib
 export LD_LIBRARY_PATH=$OPENEXR_ROOT/lib:$LD_LIBRARY_PATH
 

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -129,7 +129,7 @@ ls -R -l "$DEP_DIR"
 
 
 # source src/build-scripts/build_openexr.bash
-# export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$ILMBASE_ROOT;$OPENEXR_ROOT"
+# export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$OPENEXR_ROOT"
 # source src/build-scripts/build_opencolorio.bash
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -42,9 +42,11 @@ checked_find_package (TIFF REQUIRED
                       RECOMMEND_MIN_REASON "to support >4GB files")
 
 # IlmBase & OpenEXR
+checked_find_package (Imath REQUIRED
+                      VERSION_MIN 3.1
+                      PRINT IMATH_INCLUDES Imath_VERSION)
 checked_find_package (OpenEXR REQUIRED
-                      VERSION_MIN 2.4
-                      RECOMMEND_MIN 3.1
+                      VERSION_MIN 3.1
                       PRINT IMATH_INCLUDES OPENEXR_INCLUDES Imath_VERSION)
 # Force Imath includes to be before everything else to ensure that we have
 # the right Imath/OpenEXR version, not some older version in the system
@@ -55,26 +57,12 @@ include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 if (MSVC AND NOT LINKSTATIC)
     proj_add_compile_definitions (OPENEXR_DLL) # Is this needed for new versions?
 endif ()
-if (OpenEXR_VERSION VERSION_GREATER_EQUAL 3.0)
-    set (OIIO_USING_IMATH 3)
-else ()
-    set (OIIO_USING_IMATH 2)
-endif ()
+set (OIIO_USING_IMATH 3)
 set (OPENIMAGEIO_IMATH_TARGETS
-            # For OpenEXR/Imath 3.x:
             $<TARGET_NAME_IF_EXISTS:Imath::Imath>
-            $<TARGET_NAME_IF_EXISTS:Imath::Half>
-            # For OpenEXR >= 2.4/2.5 with reliable exported targets
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Imath>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Half>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex> )
+            $<TARGET_NAME_IF_EXISTS:Imath::Half> )
 set (OPENIMAGEIO_OPENEXR_TARGETS
-            # For OpenEXR/Imath 3.x:
-            $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
-            # For OpenEXR >= 2.4/2.5 with reliable exported targets
-            $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::IlmThread>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex> )
+            $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR> )
 set (OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY "PUBLIC" CACHE STRING
      "Should we expose Imath library dependency as PUBLIC or PRIVATE")
 set (OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH OFF CACHE BOOL

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -4,9 +4,6 @@
 
 # Module to find OpenEXR and Imath.
 #
-# I'm afraid this is a mess, due to needing to support a wide range of
-# OpenEXR versions.
-#
 # For OpenEXR & Imath 3.x, this will establish the following imported
 # targets:
 #
@@ -16,32 +13,18 @@
 #    OpenEXR::Iex
 #    OpenEXR::IlmThread
 #
-# For OpenEXR 2.4 & 2.5, it will establish the following imported targets:
-#
-#    IlmBase::Imath
-#    IlmBase::Half
-#    IlmBase::Iex
-#    IlmBase::IlmThread
-#    OpenEXR::IlmImf
-#
-# For all version, the following CMake variables:
+# and sets the following CMake variables:
 #
 #   OPENEXR_FOUND          true, if found
 #   OPENEXR_INCLUDES       directory where OpenEXR headers are found
 #   OPENEXR_LIBRARIES      libraries for OpenEXR + IlmBase
 #   OPENEXR_VERSION        OpenEXR version
 #   IMATH_INCLUDES         directory where Imath headers are found
-#   ILMBASE_INCLUDES       directory where IlmBase headers are found
-#   ILMBASE_LIBRARIES      libraries just IlmBase
 #
 #
 
-# First, try to fine just the right config files
+# First, try to find just the right config files
 find_package(Imath CONFIG)
-if (NOT TARGET Imath::Imath)
-    # Couldn't find Imath::Imath, maybe it's older and has IlmBase?
-    find_package(IlmBase CONFIG)
-endif ()
 find_package(OpenEXR CONFIG)
 
 if (TARGET OpenEXR::OpenEXR AND TARGET Imath::Imath)
@@ -54,59 +37,18 @@ if (TARGET OpenEXR::OpenEXR AND TARGET Imath::Imath)
     # Mimic old style variables
     set (OPENEXR_VERSION ${OpenEXR_VERSION})
     get_target_property(IMATH_INCLUDES Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(ILMBASE_INCLUDES Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(ILMBASE_IMATH_LIBRARY Imath::Imath INTERFACE_LINK_LIBRARIES)
     get_target_property(IMATH_LIBRARY Imath::Imath INTERFACE_LINK_LIBRARIES)
     get_target_property(OPENEXR_IEX_LIBRARY OpenEXR::Iex INTERFACE_LINK_LIBRARIES)
     get_target_property(OPENEXR_ILMTHREAD_LIBRARY OpenEXR::IlmThread INTERFACE_LINK_LIBRARIES)
-    set (ILMBASE_LIBRARIES ${ILMBASE_IMATH_LIBRARY})
-    set (ILMBASE_FOUND true)
-
     get_target_property(OPENEXR_INCLUDES OpenEXR::OpenEXR INTERFACE_INCLUDE_DIRECTORIES)
     get_target_property(OPENEXR_ILMIMF_LIBRARY OpenEXR::OpenEXR INTERFACE_LINK_LIBRARIES)
-    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY} ${ILMBASE_LIBRARIES})
+    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY})
     set (OPENEXR_FOUND true)
 
     # Link with pthreads if required
-    find_package (Threads)
-    if (CMAKE_USE_PTHREADS_INIT)
-        list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-    endif ()
-
-elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND
-        (OPENEXR_VERSION VERSION_GREATER_EQUAL 2.4 OR OpenEXR_VERSION VERSION_GREATER_EQUAL 2.4))
-    # OpenEXR 2.4 or 2.5 with exported config
-    set (FOUND_OPENEXR_WITH_CONFIG 1)
-    if (NOT OpenEXR_FIND_QUIETLY)
-        message (STATUS "Found CONFIG for OpenEXR 2 (OpenEXR_VERSION=${OpenEXR_VERSION})")
-    endif ()
-
-    # Mimic old style variables
-    get_target_property(ILMBASE_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(ILMBASE_Imath_LIBRARY IlmBase::Imath INTERFACE_LINK_LIBRARIES)
-    get_target_property(ILMBASE_IMATH_LIBRARY IlmBase::Imath INTERFACE_LINK_LIBRARIES)
-    get_target_property(ILMBASE_HALF_LIBRARY IlmBase::Half INTERFACE_LINK_LIBRARIES)
-    get_target_property(OPENEXR_IEX_LIBRARY IlmBase::Iex INTERFACE_LINK_LIBRARIES)
-    get_target_property(OPENEXR_ILMTHREAD_LIBRARY IlmBase::IlmThread INTERFACE_LINK_LIBRARIES)
-    set (ILMBASE_LIBRARIES ${ILMBASE_IMATH_LIBRARY} ${ILMBASE_HALF_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY})
-    set (ILMBASE_FOUND true)
-
-    get_target_property(OPENEXR_INCLUDES OpenEXR::IlmImfConfig INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(OPENEXR_ILMIMF_LIBRARY OpenEXR::IlmImf INTERFACE_LINK_LIBRARIES)
-    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${ILMBASE_LIBRARIES})
-    set (OPENEXR_FOUND true)
-
-    # Link with pthreads if required
-    find_package (Threads)
-    if (CMAKE_USE_PTHREADS_INIT)
-        list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-    endif ()
-
-    # Correct for how old OpenEXR config exports set the directory one
-    # level lower than we prefer it.
-    string(REGEX REPLACE "include/OpenEXR$" "include" ILMBASE_INCLUDES "${ILMBASE_INCLUDES}")
-    string(REGEX REPLACE "include/OpenEXR$" "include" IMATH_INCLUDES "${IMATH_INCLUDES}")
-    string(REGEX REPLACE "include/OpenEXR$" "include" OPENEXR_INCLUDES "${OPENEXR_INCLUDES}")
+    # find_package (Threads)
+    # if (CMAKE_USE_PTHREADS_INIT)
+    #     list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    # endif ()
 
 endif ()

--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -13,20 +13,11 @@
 #ifndef OIIO_IMATH_H_INCLUDED
 #define OIIO_IMATH_H_INCLUDED 1
 
-// Determine which Imath we're dealing with and include the appropriate
-// headers.
-
 #define OIIO_USING_IMATH @OIIO_USING_IMATH@
 
-#if OIIO_USING_IMATH >= 3
-#   include <Imath/ImathColor.h>
-#   include <Imath/ImathMatrix.h>
-#   include <Imath/ImathVec.h>
-#else
-#   include <OpenEXR/ImathColor.h>
-#   include <OpenEXR/ImathMatrix.h>
-#   include <OpenEXR/ImathVec.h>
-#endif
+#include <Imath/ImathColor.h>
+#include <Imath/ImathMatrix.h>
+#include <Imath/ImathVec.h>
 
 
 /// Custom fmtlib formatters for Imath types.
@@ -38,10 +29,8 @@ template<> struct formatter<Imath::V3f>
     : OIIO::pvt::array_formatter<Imath::V3f, float, 3> {};
 template<> struct formatter<Imath::V4f>
     : OIIO::pvt::array_formatter<Imath::V4f, float, 4> {};
-#if OIIO_USING_IMATH >= 3
 template<> struct formatter<Imath::M22f>
     : OIIO::pvt::array_formatter<Imath::M22f, float, 4> {};
-#endif
 template<> struct formatter<Imath::M33f>
     : OIIO::pvt::array_formatter<Imath::M33f, float, 9> {};
 template<> struct formatter<Imath::M44f>

--- a/src/include/OpenImageIO/half.h.in
+++ b/src/include/OpenImageIO/half.h.in
@@ -5,16 +5,7 @@
 
 #pragma once
 
-// Determine which Imath we're dealing with and include the appropriate path
-// to half.h.
-
-#if defined(__has_include) && __has_include(<Imath/half.h>)
-#    include <Imath/half.h>
-#elif @OIIO_USING_IMATH@ >= 3
-#    include <Imath/half.h>
-#else
-#    include <OpenEXR/half.h>
-#endif
+#include <Imath/half.h>
 
 
 #if defined(FMT_VERSION) && !defined(OIIO_HALF_FORMATTER)

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -19,11 +19,7 @@
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/thread.h>
 
-#if OIIO_USING_IMATH >= 3
-#    include <Imath/ImathBox.h>
-#else
-#    include <OpenEXR/ImathBox.h>
-#endif
+#include <Imath/ImathBox.h>
 
 OIIO_NAMESPACE_BEGIN
 

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -8,11 +8,8 @@
 
 #include <OpenImageIO/Imath.h>
 
-#if OIIO_USING_IMATH >= 3
-#    include <Imath/ImathBox.h>
-#else
-#    include <OpenEXR/ImathBox.h>
-#endif
+#include <Imath/ImathBox.h>
+
 #include <OpenEXR/ImfKeyCode.h>
 #include <OpenEXR/ImfTimeCode.h>
 

--- a/src/oiiotool/CMakeLists.txt
+++ b/src/oiiotool/CMakeLists.txt
@@ -8,5 +8,4 @@ fancy_add_executable (SYSTEM_INCLUDE_DIRS
                         OpenImageIO
                         $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
                         $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
-                        ${OPENEXR_LIBRARIES}
                      )

--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -18,20 +18,11 @@
 #include <OpenEXR/ImfIO.h>
 #include <OpenEXR/ImfRgbaFile.h>
 
-#ifdef OPENEXR_VERSION_MAJOR
-#    define OPENEXR_CODED_VERSION                                    \
-        (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100 \
-         + OPENEXR_VERSION_PATCH)
-#else
-#    define OPENEXR_CODED_VERSION 20000
-#endif
+#define OPENEXR_CODED_VERSION                                    \
+    (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100 \
+     + OPENEXR_VERSION_PATCH)
 
-#if OPENEXR_CODED_VERSION >= 20400 \
-    || __has_include(<OpenEXR/ImfFloatVectorAttribute.h>)
-#    define OPENEXR_HAS_FLOATVECTOR 1
-#else
-#    define OPENEXR_HAS_FLOATVECTOR 0
-#endif
+#define OPENEXR_HAS_FLOATVECTOR 1
 
 #define ENABLE_READ_DEBUG_PRINTS 0
 
@@ -91,21 +82,12 @@ public:
             throw Iex::IoExc("Unexpected end of file.");
         return n;
     }
-#if OIIO_USING_IMATH >= 3
     uint64_t tellg() override { return m_io->tell(); }
     void seekg(uint64_t pos) override
     {
         if (!m_io->seek(pos))
             throw Iex::IoExc("File input failed.");
     }
-#else
-    Imath::Int64 tellg() override { return m_io->tell(); }
-    void seekg(Imath::Int64 pos) override
-    {
-        if (!m_io->seek(pos))
-            throw Iex::IoExc("File input failed.");
-    }
-#endif
     void clear() override {}
 
 private:

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -87,21 +87,12 @@ public:
         if (m_io->write(c, n) != size_t(n))
             throw Iex::IoExc("File output failed.");
     }
-#if OIIO_USING_IMATH >= 3
     uint64_t tellp() override { return m_io->tell(); }
     void seekp(uint64_t pos) override
     {
         if (!m_io->seek(pos))
             throw Iex::IoExc("File output failed.");
     }
-#else
-    Imath::Int64 tellp() override { return m_io->tell(); }
-    void seekp(Imath::Int64 pos) override
-    {
-        if (!m_io->seek(pos))
-            throw Iex::IoExc("File output failed.");
-    }
-#endif
 
 private:
     Filesystem::IOProxy* m_io = nullptr;


### PR DESCRIPTION
These are build-breaking changes that impose a new minimum OpenEXR/Imath version supported of 3.1 or higher.

Needless to say, this will not be backported to any release branches, which guarantee that they will never raise the minimum supported versions of any dependencies. This is just for future OIIO. There is already a "developer preview" branch dev-2.6.1 marking the last spot in master in which the old dependencies are supported.

Fixes #4156 

