### PR TITLE
Fix Analysis workflow build - add missing gcov build options

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -82,6 +82,8 @@ target_compile_definitions(OpenImageIO PRIVATE
                            ${${PROJECT_NAME}_compile_definitions})
 target_compile_options(OpenImageIO PRIVATE
                            ${${PROJECT_NAME}_compile_options})
+target_link_options(OpenImageIO PRIVATE
+                           ${${PROJECT_NAME}_link_options})
 
 # If the 'EMBEDPLUGINS' option is set, we want to compile the source for
 # all the plugins into libOpenImageIO.

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -42,6 +42,9 @@ function (setup_oiio_util_library targetname)
                                ${${PROJECT_NAME}_compile_definitions})
     target_compile_options(${targetname} PRIVATE
                                ${${PROJECT_NAME}_compile_options})
+    target_link_options(${targetname} PRIVATE
+                               ${${PROJECT_NAME}_link_options})
+
     target_include_directories (${targetname}
             PUBLIC
                 $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
## Description
The Analysis workflow seems to be failing since this [run](https://github.com/AcademySoftwareFoundation/OpenImageIO/actions/runs/8448478726)

It seems that two targets `libOpenImageIO`, `libutil` were left out during the [switch to target-based definitions] (https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4193) refactor  and have no `-ftest-coverage -fprofile-arcs` options added in the CODECOV=1 mode.

## Tests / Verification

The issue (on master) can be reproduced locally by running:
`CMAKE_GENERATOR=Ninja CMAKE_BUILD_TYPE=Debug CODECOV=1 ./src/build-scripts/ci-build.bash`

Generated build error:
```
FAILED: bin/optparser_test
: && ccache /usr/bin/c++ -g -ftest-coverage -fprofile-arcs src/libutil/CMakeFiles/optparser_test.dir/optparser_test.cpp.o -o bin/optparser_test  -Wl,-rpath,/home/kuba/PRJ/OpenImageIO/build/lib  lib/libOpenImageIO_Util_d.so.2.6.2  /usr/lib/x86_64-linux-gnu/libImath-2_5.so.25.0.6  /usr/lib/x86_64-linux-gnu/libIexMath-2_5.so.25.0.6  /usr/lib/x86_64-linux-gnu/libHalf-2_5.so.25.0.6  /usr/lib/x86_64-linux-gnu/libIex-2_5.so.25.0.6 && :
/usr/bin/ld: bin/optparser_test: hidden symbol `__gcov_init' in /usr/lib/gcc/x86_64-linux-gnu/11/libgcov.a(_gcov.o) is referenced by DSO
```

Adding the missing options resolves build errors.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
