### PR TITLE
fix(fmt.h): fix build break from recent fmt change

### DIFF
--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -23,8 +23,9 @@
 // gcc 11+ compiler bug triggered by the definition of FMT_THROW in fmt 10.1+
 // when FMT_EXCEPTIONS=0, which results in mangling SIMD math. This nugget
 // below works around the problems for hard to understand reasons.
-#if !defined(FMT_THROW) && OIIO_GNUC_VERSION >= 110000
-#    define FMT_THROW(x) OIIO_ASSERT_MSG(0, "fmt exception: %s", (x).what())
+#if !defined(FMT_THROW) && !FMT_EXCEPTIONS && OIIO_GNUC_VERSION >= 110000
+#    define FMT_THROW(x) \
+        OIIO_ASSERT_MSG(0, "fmt exception: %s", (x).what()), std::terminate()
 #endif
 
 // Use the grisu fast floating point formatting for old fmt versions


### PR DESCRIPTION
We disable fmt execptions and force it to do one of our ASSERT's instead.  But fmt in their main branch recently added `[[noreturn]]` annotations in a way that cause this to be compiler errors for our overrides.  Needed an extra std::terminate() call to guarantee the noreturn promise.
