### PR TITLE
fix: Improve IB::nsubimages and other related fixes

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -290,6 +290,9 @@ options are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:subimages``
+     - int
+     - The number of "image elements" (subimages) in the file.
 
 
 **Configuration settings for DPX output**
@@ -547,6 +550,9 @@ storage.  Currently, OpenImageIO only supports 2D FITS data (images), not 3D
    * - ``Hierarch``
      - string
      - FITS "HIERARCH" (*)
+   * - ``oiio:subimages``
+     - int
+     - The number of subimages in the file.
    * - *other*
      - 
      - all other FITS keywords will be added to the ImageSpec as arbitrary
@@ -1216,6 +1222,10 @@ Apple M4V               :file:`.m4v`
 MPEG-1/MPEG-2           :file:`.mpg`
 =====================   ====================================================
 
+The format list include may other file types as well. We rely on the
+:program:`ffmpeg` library to read these files, so the actual list of supported
+formats may vary depending on the version of :program:`ffmpeg` that was linked
+into OpenImageIO.
 
 Currently, these files may only be read. Write support may be added in a
 future release.  Also, currently, these files simply look to OIIO like
@@ -1238,10 +1248,7 @@ Some special attributes are used for movie files:
      - Nonzero value for movie files
    * - ``oiio:subimages``
      - int
-     - The number of frames in the movie, positive if it can be known
-       without reading the entire file. Zero or not present if the number
-       of frames cannot be determinend from reading from just the file
-       header.
+     - The number of frames (subimages) in the movie.
    * - ``FramesPerSecond``
      - int[2] (rational)
      - Frames per second
@@ -1377,6 +1384,9 @@ The official OpenEXR site is http://www.openexr.com/.
    * - ``captureRate``
      - int[2]
      - Frames per second capture rate (vecsemantics will be marked as RATIONAL)
+   * - ``oiio:subimages``
+     - int
+     - The number of "parts" (subimages) in the file.
    * - ``smpte:TimeCode``
      - int[2]
      - SMPTE time code (vecsemantics will be marked as TIMECODE)
@@ -1519,6 +1529,9 @@ report as tiled, using the leaf dimension size.
    * - ``oiio:subimagename``
      - string
      - unique layer name
+   * - ``oiio:subimages``
+     - int
+     - The number of "layers" (subimages) in the file.
    * - ``openvdb:indextoworld``
      - matrix of doubles
      - conversion of voxel index to world space coordinates.

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -39,7 +39,7 @@ public:
     const char* format_name(void) const override { return "dpx"; }
     int supports(string_view feature) const override
     {
-        return (feature == "ioproxy");
+        return (feature == "ioproxy" || feature == "multiimage");
     }
     bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
@@ -307,6 +307,8 @@ DPXInput::seek_subimage(int subimage, int miplevel)
     default: orientation = 0; break;
     }
     m_spec.attribute("Orientation", orientation);
+
+    m_spec.attribute("oiio:subimages", (int)m_dpx.header.ImageElementCount());
 
     // image linearity
     switch (m_dpx.header.Transfer(subimage)) {

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -90,6 +90,10 @@ public:
     FFmpegInput();
     ~FFmpegInput() override;
     const char* format_name(void) const override { return "FFmpeg movie"; }
+    int supports(string_view feature) const override
+    {
+        return (feature == "multiimage");
+    }
     bool valid_file(const std::string& name) const override;
     bool open(const std::string& name, ImageSpec& spec) override;
     bool close(void) override;

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -44,8 +44,9 @@ public:
     int supports(string_view feature) const override
     {
         return (feature == "arbitrary_metadata"
-                || feature == "exif"     // Because of arbitrary_metadata
-                || feature == "iptc"     // Because of arbitrary_metadata
+                || feature == "exif"  // Because of arbitrary_metadata
+                || feature == "iptc"  // Because of arbitrary_metadata
+                || feature == "multiimage"
                 || feature == "noimage"  // allow metadata only, no pixels
         );
     }

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -336,6 +336,8 @@ FitsInput::read_fits_header(void)
     m_spec.full_height = m_spec.height;
     m_spec.full_depth  = m_spec.depth;
 
+    m_spec.attribute("oiio:subimages", (int)m_subimages.size());
+
     // if (m_spec.width < 1 || m_spec.height < 1 || m_spec.depth < 1 ||
     //     m_spec.nchannels < 1) {
     //     errorf("Don't know now to read empty (0 pixel) FITS image");

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -41,7 +41,7 @@ public:
     const char* format_name(void) const override { return "gif"; }
     int supports(string_view feature) const override
     {
-        return feature == "ioproxy";
+        return (feature == "ioproxy" || feature == "multiimage");
     }
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -27,7 +27,7 @@ public:
     const char* format_name(void) const override { return "ico"; }
     int supports(string_view feature) const override
     {
-        return feature == "ioproxy";
+        return (feature == "ioproxy" || feature == "multiimage");
     }
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -890,9 +890,16 @@ public:
     /// contained only one image.
     int subimage() const;
 
-    /// Return the number of subimages in the file this ImageBuf refers to.
-    /// This will always be 1 for an ImageBuf that was not constructed as a
-    /// direct reference to a file.
+    /// Return the number of subimages in the file this ImageBuf refers to, if
+    /// it can be determined efficiently. This will always be 1 for an
+    /// ImageBuf that was not constructed as a direct reference to a file, or
+    /// for an ImageBuf that refers to a file type that is not capable of
+    /// containing multiple subimages.
+    ///
+    /// Note that a return value of 0 indicates that the number of subimages
+    /// cannot easily be known without reading the entire image file to
+    /// discover the total. To compute this yourself, you would need check
+    /// every subimage successively until you get an error.
     int nsubimages() const;
 
     /// Return the index of the miplevel with a file's subimage that the

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1003,6 +1003,11 @@ public:
     ///       Does this format reader support retrieving a reduced
     ///       resolution copy of the image via the `thumbnail()` method?
     ///
+    ///  - `"multiimage"` :
+    ///       Does this format support multiple subimages within a file?
+    ///       (Note: this doesn't necessarily mean that the particular
+    ///       file this ImageInput is reading has multiple subimages.)
+    ///
     ///  - `"noimage"` :
     ///        Does this format allow 0x0 sized images, i.e. an image file
     ///        with metadata only and no pixels?

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1057,6 +1057,9 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
         m_blackpixel.resize(
             round_to_multiple(m_xstride, OIIO_SIMD_MAX_SIZE_BYTES));
         // ^^^ NB make it big enough for SIMD
+        m_nsubimages = input->supports("multiimage")
+                           ? m_spec.get_int_attribute("oiio:subimages")
+                           : 1;
 
         // Go ahead and read any thumbnail that exists. Is that bad?
         if (m_spec["thumbnail_width"].get<int>()

--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -123,8 +123,9 @@ public:
     {
         return (feature == "arbitrary_metadata"
                 || feature == "exif"  // Because of arbitrary_metadata
+                || feature == "ioproxy"
                 || feature == "iptc"  // Because of arbitrary_metadata
-                || feature == "ioproxy");
+                || feature == "multiimage");
     }
     bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec,

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -105,8 +105,9 @@ public:
     {
         return (feature == "arbitrary_metadata"
                 || feature == "exif"  // Because of arbitrary_metadata
+                || feature == "ioproxy"
                 || feature == "iptc"  // Because of arbitrary_metadata
-                || feature == "ioproxy");
+                || feature == "multiimage");
     }
     bool valid_file(const std::string& filename) const override;
     bool open(const std::string& name, ImageSpec& newspec,

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -64,7 +64,7 @@ public:
     const char* format_name(void) const override { return "openvdb"; }
     int supports(string_view feature) const override
     {
-        return (feature == "arbitrary_metadata");
+        return (feature == "arbitrary_metadata" || feature == "multiimage");
     }
     bool valid_file(const std::string& filename) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
@@ -528,6 +528,9 @@ OpenVDBInput::open(const std::string& filename, ImageSpec& newspec)
     }
     m_name       = filename;
     m_nsubimages = (int)m_layers.size();
+
+    for (auto& lr : m_layers)
+        lr.spec.attribute("oiio:subimages", m_nsubimages);
 
     bool ok = seek_subimage(0, 0);
     newspec = ImageInput::spec();

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -103,7 +103,8 @@ public:
     bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     int supports(string_view feature) const override
     {
-        return (feature == "exif" || feature == "iptc" || feature == "ioproxy");
+        return (feature == "exif" || feature == "iptc" || feature == "ioproxy"
+                || feature == "multiimage");
         // N.B. No support for arbitrary metadata.
     }
     bool open(const std::string& name, ImageSpec& newspec) override;

--- a/testsuite/dpx/ref/out.txt
+++ b/testsuite/dpx/ref/out.txt
@@ -36,6 +36,7 @@ Reading ../oiio-images/dpx_nuke_10bits_rgb.dpx
     dpx:XScannedSize: 0
     dpx:YScannedSize: 0
     oiio:BitsPerSample: 10
+    oiio:subimages: 1
     smpte:TimeCode: 00:00:00:00
 Comparing "../oiio-images/dpx_nuke_10bits_rgb.dpx" and "dpx_nuke_10bits_rgb.dpx"
 PASS
@@ -77,6 +78,7 @@ Reading ../oiio-images/dpx_nuke_16bits_rgba.dpx
     dpx:XScannedSize: 0
     dpx:YScannedSize: 0
     oiio:BitsPerSample: 10
+    oiio:subimages: 1
     smpte:TimeCode: 00:00:00:00
 Comparing "../oiio-images/dpx_nuke_16bits_rgba.dpx" and "dpx_nuke_16bits_rgba.dpx"
 PASS
@@ -100,6 +102,7 @@ stereo.dpx           :   80 x   60, 3 channel, uint10 dpx
     dpx:Transfer: "Undefined"
     dpx:Version: "V2.0"
     oiio:BitsPerSample: 10
+    oiio:subimages: 2
     Stats Min: 0 0 0 (of 1023)
     Stats Max: 1023 1023 1023 (of 1023)
     Stats Avg: 18.64 18.64 18.64 (of 1023)
@@ -124,6 +127,7 @@ stereo.dpx           :   80 x   60, 3 channel, uint10 dpx
     dpx:Transfer: "Undefined"
     dpx:Version: "V2.0"
     oiio:BitsPerSample: 10
+    oiio:subimages: 2
     Stats Min: 0 0 0 (of 1023)
     Stats Max: 1023 1023 1023 (of 1023)
     Stats Avg: 24.44 24.44 24.44 (of 1023)
@@ -151,5 +155,6 @@ grey.dpx             :  512 x  512, 1 channel, uint10 dpx
     dpx:Transfer: "Undefined"
     dpx:Version: "V2.0"
     oiio:BitsPerSample: 10
+    oiio:subimages: 1
 Comparing "grey.dpx" and "ref/grey.tif"
 PASS

--- a/testsuite/fits/ref/out.txt
+++ b/testsuite/fits/ref/out.txt
@@ -17,6 +17,7 @@ Simple 8-bit ramp pattern for testing of FITS readers"
     Extend: "T"
     Object: "Ramp 8-bit"
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/pg93/tst0001.fits" and "tst0001.fits"
 PASS
 Reading ../fits-images/pg93/tst0003.fits
@@ -40,6 +41,7 @@ Simple 32-bit ramp pattern for testing of FITS readers"
     Extend: "T"
     Object: "Ramp 32-bit"
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/pg93/tst0003.fits" and "tst0003.fits"
 PASS
 Reading ../fits-images/pg93/tst0005.fits
@@ -59,6 +61,7 @@ Simple 32-bit FP sine wave pattern for testing of FITS readers"
     Extend: "T"
     Object: "Wave 32-bit FP"
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/pg93/tst0005.fits" and "tst0005.fits"
 PASS
 Reading ../fits-images/pg93/tst0006.fits
@@ -78,6 +81,7 @@ Simple 64-bit FP sine wave pattern for testing of FITS readers"
     Extend: "T"
     Object: "Wave 64-bit fp"
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/pg93/tst0006.fits" and "tst0006.fits"
 PASS
 Reading ../fits-images/pg93/tst0007.fits
@@ -134,6 +138,7 @@ So best of luck with the decoding"
     DateTime: "1992:08:20 00:00:00"
     Object: "IEEE 32-bit test"
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/pg93/tst0007.fits" and "tst0007.fits"
 PASS
 Reading ../fits-images/pg93/tst0008.fits
@@ -189,6 +194,7 @@ So best of luck with the decoding"
     DateTime: "1992:08:20 00:00:00"
     Object: "IEEE 64-bit test"
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/pg93/tst0008.fits" and "tst0008.fits"
 PASS
 Reading ../fits-images/pg93/tst0013.fits
@@ -246,6 +252,7 @@ ESO DET NCORRS = 'Double '"
     Time-sid: 36564
     Tm-end: 70121
     Tm-start: 69932
+    oiio:subimages: 1
 Comparing "../fits-images/pg93/tst0013.fits" and "tst0013.fits"
 PASS
 Reading ../fits-images/ftt4b/file001.fits
@@ -256,6 +263,7 @@ Reading ../fits-images/ftt4b/file001.fits
     Extend: "T"
     Object: "SNG - CAT."
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/ftt4b/file001.fits" and "file001.fits"
 PASS
 Reading ../fits-images/ftt4b/file002.fits
@@ -266,6 +274,7 @@ Reading ../fits-images/ftt4b/file002.fits
     Extend: "T"
     Object: "PGSNC - SN.CAT."
     Origin: "ESO"
+    oiio:subimages: 1
 Comparing "../fits-images/ftt4b/file002.fits" and "file002.fits"
 PASS
 Reading ../fits-images/ftt4b/file003.fits
@@ -479,6 +488,7 @@ AIPS   CLEAN NITER= 12000 PRODUCT=1"
     Observer: "LISZ"
     Obsra: 252.167
     Origin: "AIPSNRAO node CVAX       15JUL84"
+    oiio:subimages: 1
 Comparing "../fits-images/ftt4b/file003.fits" and "file003.fits"
 PASS
 Reading ../fits-images/ftt4b/file009.fits
@@ -561,6 +571,7 @@ VLACV ANT   N=22 X=  1021.275 Y= -2683.726 Z= -1494.627 ST='CW6'"
     Pzero4: 0
     Pzero5: 0
     Telescop: "VLA"
+    oiio:subimages: 1
 Comparing "../fits-images/ftt4b/file009.fits" and "file009.fits"
 PASS
 Reading ../fits-images/ftt4b/file012.fits
@@ -698,5 +709,6 @@ AIPS   CLEAN NITER= 12000 PRODUCT=1"
     Observer: "LAIN"
     Origin: "AIPS"
     Tables: 1
+    oiio:subimages: 1
 Comparing "../fits-images/ftt4b/file012.fits" and "file012.fits"
 PASS


### PR DESCRIPTION
Background: Some formats that support multi-image files know as soon as they are opened and read the header what the total subimage count is.  Others (I'm looking at you, TIFF) can't know without reading each subimage in succession until you hit the end of the file. Format readers who can easily figure it out open first opening are supposed to set attribute "oiio:subimages" to the number of subimages, or 0 / unset if it can't be cheaply or immediately determined.

ImageBuf has a `nsubimages()` method that you'd think would give you the right count, and it did when all IBs were read through the ImageCache (which fully inventories the subimages of any file it reads). But when OIIO 2.5 changed IB behavior to only be backed by IC when explicitly requested, we effectively lost this functionality most of the time, and instead returned 0 ("don't know yet"). This was confusing. And also silly, because it reported 0 even for files whose formats don't permit multiple images (so you know the count is 1).

This patch does the following:

* Changes the behavior and documentation of `ImageBuf::nsubimages()` to the following return values:
  - 1, for formats that are always a single subimage. (Or for ImageBufs that are not direct reads of a file.) 
  - n>=1 for files that permit multiple subimages and the count is known. 
  - 0 for files that permit multiple subimages, but the count is not known because it's one of the formats where it can't easily be determined upon opening the file.
* Add a new ImageInput::supports("multiimage") that says if the input file format permits multiple images, and ensure that it returns true for all formats where this is the case.
* Ensure that formats permitting multiimage and can easily know the count up front set the "oiio:subimages" attribute (not all did).
* Document in the built-in format section of the docs the formats that are expected to set this attribute.

Fixes #4225
