### PR TITLE
fix(build): libOpenImageIO_Util does need DL libs, we removed it incorrectly

### DIFF
--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -59,7 +59,7 @@ function (setup_oiio_util_library targetname)
                 ${OPENIMAGEIO_IMATH_TARGETS}
             PRIVATE
                 $<TARGET_NAME_IF_EXISTS:TBB::tbb>
-                # ${CMAKE_DL_LIBS}
+                ${CMAKE_DL_LIBS}
             )
 
     if (GCC_VERSION VERSION_GREATER_EQUAL 12.0


### PR DESCRIPTION
Was broken by #4193 