### PR TITLE
style: Fix clang-format problem caused by 4221

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -352,7 +352,8 @@ TextureSystemImpl::init()
 
 
 
-TextureSystemImpl::~TextureSystemImpl() {
+TextureSystemImpl::~TextureSystemImpl()
+{
     printstats();
     // Erase any leftover errors from this thread
     // TODO: can we clear other threads' errors?


### PR DESCRIPTION
Oops, we let that slip by.
