### PR TITLE
build(deps): Remove the very last references to boost

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: sonar gcc9/C++14 py39 boost1.76 exr3.1 ocio2.2
+          - desc: sonar gcc9/C++14 py39 exr3.1 ocio2.2
             nametag: static-analysis-sonar
             os: ubuntu-latest
             container: aswf/ci-osl:2023-clang15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: gcc9/C++17 py3.7 boost1.73 exr2.5 ocio2.0
+          - desc: gcc9/C++17 py3.7 exr2.5 ocio2.0
             nametag: linux-vfx2021
             runner: ubuntu-latest
             container: aswf/ci-osl:2021
@@ -57,7 +57,7 @@ jobs:
             python_ver: 3.7
             simd: "avx2,f16c"
             fmt_ver: 8.1.1
-          - desc: gcc9/C++17 py39 boost1.76 exr3.1 ocio2.1
+          - desc: gcc9/C++17 py39 exr3.1 ocio2.1
             nametag: linux-vfx2022
             runner: ubuntu-latest
             container: aswf/ci-osl:2022-clang11
@@ -79,7 +79,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 9.1.0
             pybind11_ver: v2.8.1
-          - desc: icc/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15
+          - desc: icc/C++17 py3.9 exr3.1 ocio2.1 qt5.15
             nametag: linux-vfx2022-icc
             runner: ubuntu-latest
             container: aswf/ci-osl:2022
@@ -94,7 +94,7 @@ jobs:
                             OIIO_EXTRA_CPP_ARGS="-fp-model=precise"
             # For icc, use fp-model precise to eliminate needless LSB errors
             # that make test results differ from other platforms.
-          - desc: icx/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15
+          - desc: icx/C++17 py3.9 exr3.1 ocio2.1 qt5.15
             nametag: linux-vfx2022-icx
             runner: ubuntu-latest
             container: aswf/ci-osl:2022
@@ -120,7 +120,7 @@ jobs:
                             CMAKE_BUILD_TYPE=Debug
                             CTEST_TEST_TIMEOUT=1200
                             CTEST_EXCLUSIONS="broken|png-damaged"
-          - desc: gcc11/C++17 py3.10 boost1.80 exr3.1 ocio2.2
+          - desc: gcc11/C++17 py3.10 exr3.1 ocio2.2
             nametag: linux-vfx2023
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2023-clang15
@@ -130,7 +130,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             pybind11_ver: v2.10.0
-          - desc: gcc11/C++17 py3.11 boost1.82 exr3.2 ocio2.3
+          - desc: gcc11/C++17 py3.11 exr3.2 ocio2.3
             nametag: linux-vfx2024
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2024-clang17
@@ -140,7 +140,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             pybind11_ver: v2.10.0
-          - desc: oldest/hobbled gcc9.3/C++17 py3.7 boost-1.66 exr-2.4 no-sse no-ocio
+          - desc: oldest/hobbled gcc9.3/C++17 py3.7 exr-2.4 no-sse no-ocio
             # Oldest versions of the dependencies that we can muster, and various
             # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins).
             nametag: linux-oldest
@@ -292,7 +292,7 @@ jobs:
                             USE_OPENVDB=0
                             WEBP_VERSION=v1.3.0
                             # The installed OpenVDB has a TLS conflict with Python 3.8
-          - desc: bleeding edge gcc13 C++20 py3.10 OCIO/libtiff/exr-master boost1.74 avx2
+          - desc: bleeding edge gcc13 C++20 py3.10 OCIO/libtiff/exr-master avx2
             nametag: linux-bleeding-edge
             runner: ubuntu-22.04
             cc_compiler: gcc-13

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,9 +255,9 @@ capitalize new words: `class CustomerList;` In general, local variables
 should start with lower case. Macros should be `ALL_CAPS`, if used at all.
 
 If your class is extremely similar to, or modeled after, something in the
-standard library, Boost, or something else we interoperate with, it's ok to
+standard library, or something else we interoperate with, it's ok to
 use their naming conventions. For example, very general utility classes and
-templates (the kind of thing you would normally find in std or boost) should
+templates (the kind of thing you would normally find in std) should
 be lower case with underscores separating words, as they would be if they
 were standards.
 
@@ -290,10 +290,8 @@ Namespaces: yes, use them!
 
 ### Third-party libraries
 
-Prefer C++11 `std` rather than Boost, where both can do the same task.
-Feel free to use Boost classes you already see in the code base, but don't
-use any Boost you don't see us already using, without first checking with
-the project leader.
+Prefer C++17 `std` rather than other libraries, where both can do the same
+task.
 
 Please do use Imath vector, matrix, and utility classes where applicable.
 Don't write your own vector or matrix code!

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,6 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.6)
  * libjpeg >= 8 (tested through jpeg9e), or **libjpeg-turbo >= 2.1** (tested
    through 3.0)
- * Boost >= 1.53 (recommended: at least 1.66; tested through 1.84)
  * **[fmtlib](https://github.com/fmtlib/fmt) >= 7.0** (tested through 10.1).
    If not found at build time, this will be automatically downloaded unless
    the build sets `-DBUILD_MISSING_FMT=OFF`.
@@ -180,7 +179,6 @@ Building OpenImageIO on Linux or OS X
 
 The following dependencies must be installed to build the core of
 OpenImageIO:
-* Boost
 * libjpeg
 * libtiff
 * libpng
@@ -276,15 +274,9 @@ Building on Windows
 
 You will need to have Git, CMake and Visual Studio installed.
 
-The minimal set of dependencies for OIIO is: Boost, zlib, libTIFF, OpenEXR, and libjpeg or libjpeg-turbo. If you have them built somewhere then you skip
+The minimal set of dependencies for OIIO is: zlib, libTIFF, OpenEXR, and libjpeg or libjpeg-turbo. If you have them built somewhere then you skip
 the section below, and will only have to point OIIO build process so their locations.
 
-* Boost: get the boost source archive, extract into `{BOOST_ROOT}`.
-  ```
-  cd {BOOST_ROOT}
-  bootstrap
-  b2
-  ```
 * zlib: this will build it, and then delete the non-static library, so they don't get picked up:
   ```
   cd {ZLIB_ROOT}
@@ -327,7 +319,6 @@ dependencies.
 cd {OIIO_ROOT}
 git clone https://github.com/AcademySoftwareFoundation/OpenImageIO .
 cmake -S . -B build -DVERBOSE=ON -DCMAKE_BUILD_TYPE=Release ^
-  -DBoost_USE_STATIC_LIBS=ON -DBoost_NO_WARN_NEW_VERSIONS=ON -DBoost_ROOT={BOOST_ROOT} ^
   -DZLIB_ROOT={ZLIB_ROOT}\build ^
   -DTIFF_ROOT={TIFF_ROOT}\build ^
   -DOpenEXR_ROOT={EXR_ROOT}\build\dist ^

--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,6 @@ help:
 	@echo "          LibRaw  OpenColorIO  OpenCV  OpenGL  OpenJpeg  OpenVDB"
 	@echo "          PTex  R3DSDK  TBB  TIFF  Webp"
 	@echo "  Finding and Using Dependencies:"
-	@echo "      BOOST_ROOT=path          Custom Boost installation"
 	@echo "      OPENEXR_ROOT=path        Custom OpenEXR installation"
 	@echo "      ILMBASE_ROOT=path        Custom IlmBase installation"
 	@echo "      USE_EXTERNAL_PUGIXML=1   Use the system PugiXML, not the one in OIIO"

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,7 +3,6 @@ zlib/1.2.11
 libtiff/4.0.9
 libpng/1.6.37
 openexr/2.4.0
-boost/1.70.0
 libjpeg/9c
 libjpeg-turbo/2.0.2
 giflib/5.1.4

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,8 +33,8 @@ here](https://github.com/AcademySoftwareFoundation/OpenImageIO/discussions/4151)
 See the [Dependency proposal wiki page](https://github.com/AcademySoftwareFoundation/OpenImageIO/discussions/4151)
 
 * [ ] Big required upgrades with potentially widespread impact on the code base
-  - [ ] C++17 [#4155](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4155)
-  - [ ] Python 3.7 [#4157](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4157)
+  - [x] C++17 [#4155](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4155)
+  - [x] Python 3.7 [#4157](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4157)
   - [ ] OpenEXR/Imath 3.1 [#4156](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4156)
 
 * [ ] Miscellaneous optional upgrades whose changes will be very localized
@@ -51,7 +51,7 @@ See the [Dependency proposal wiki page](https://github.com/AcademySoftwareFounda
   - [ ] pybind11 2.6 or 2.7 (from 2.4).
 
 
-- [ ] [#4156](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4156) Eliminate the last few places where we use Boost and eliminate it as a dependency.
+- [x] [#4158](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4158) Eliminate the last few places where we use Boost and eliminate it as a dependency.
 
 <br>
 

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -73,7 +73,6 @@ else
 
     time sudo apt-get -q install -y \
         git cmake ninja-build ccache g++ \
-        libboost-dev libboost-thread-dev libboost-filesystem-dev \
         libilmbase-dev libopenexr-dev \
         libtiff-dev libgif-dev libpng-dev
     if [[ "${SKIP_SYSTEM_DEPS_INSTALL}" != "1" ]] ; then

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -48,12 +48,6 @@ echo "---------------"
 # vcpkg update
 # 
 
-time vcpkg install boost-container:x64-windows
-time vcpkg install boost-filesystem:x64-windows
-time vcpkg install boost-math:x64-windows
-time vcpkg install boost-system:x64-windows
-time vcpkg install boost-thread:x64-windows
-
 #vcpkg install libdeflate:x64-windows
 #vcpkg install zlib:x64-windows
 vcpkg install tiff:x64-windows

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -26,7 +26,7 @@ echo "Before my brew installs:"
 brew list --versions
 
 # All cases except for clang-format target, we need the dependencies.
-brew install --display-times -q gcc ccache cmake ninja boost || true
+brew install --display-times -q gcc ccache cmake ninja || true
 brew link --overwrite gcc
 brew install --display-times -q python@${PYTHON_VERSION} || true
 brew unlink python@3.8 || true

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -7,7 +7,6 @@
 ###########################################################################
 
 if (NOT VERBOSE)
-    set (Boost_FIND_QUIETLY true)
     set (PkgConfig_FIND_QUIETLY true)
     set (Threads_FIND_QUIETLY true)
 endif ()
@@ -30,56 +29,6 @@ include (ExternalProject)
 option (BUILD_MISSING_DEPS "Try to download and build any missing dependencies" OFF)
 
 include (FindThreads)
-
-
-###########################################################################
-# Boost setup
-if (MSVC)
-    # Disable automatic linking using pragma comment(lib,...) of boost libraries upon including of a header
-    proj_add_compile_definitions (BOOST_ALL_NO_LIB=1)
-endif ()
-
-# If the build system hasn't been specifically told how to link Boost, link it the same way as other
-# OIIO dependencies:
-if (NOT DEFINED Boost_USE_STATIC_LIBS)
-    set (Boost_USE_STATIC_LIBS "${LINKSTATIC}")
-endif ()
-
-if (MSVC)
-    # Not linking Boost as static libraries: either an explicit setting or LINKSTATIC is FALSE:
-    if (NOT Boost_USE_STATIC_LIBS)
-        proj_add_compile_definitions (BOOST_ALL_DYN_LINK=1)
-    endif ()
-endif ()
-
-set (Boost_COMPONENTS thread)
-message (STATUS "Boost_COMPONENTS = ${Boost_COMPONENTS}")
-# The FindBoost.cmake interface is broken if it uses boost's installed
-# cmake output (e.g. boost 1.70.0, cmake <= 3.14). Specifically it fails
-# to set the expected variables printed below. So until that's fixed
-# force FindBoost.cmake to use the original brute force path.
-if (NOT DEFINED Boost_NO_BOOST_CMAKE)
-    set (Boost_NO_BOOST_CMAKE ON)
-endif ()
-
-checked_find_package (Boost REQUIRED
-                      VERSION_MIN 1.53
-                      COMPONENTS ${Boost_COMPONENTS}
-                      RECOMMEND_MIN 1.66
-                      RECOMMEND_MIN_REASON "Boost 1.66 is the oldest version our CI tests against"
-                      PRINT Boost_INCLUDE_DIRS Boost_LIBRARIES )
-
-# On Linux, Boost 1.55 and higher seems to need to link against -lrt
-if (CMAKE_SYSTEM_NAME MATCHES "Linux"
-      AND ${Boost_VERSION} VERSION_GREATER_EQUAL 105500)
-    list (APPEND Boost_LIBRARIES "rt")
-endif ()
-
-include_directories (SYSTEM "${Boost_INCLUDE_DIRS}")
-link_directories ("${Boost_LIBRARY_DIRS}")
-
-# end Boost setup
-###########################################################################
 
 
 ###########################################################################

--- a/src/doc/oiiointro.rst
+++ b/src/doc/oiiointro.rst
@@ -257,7 +257,6 @@ against dynamic libraries:
 * OpenEXR, Ilmbase, and Half © 2006, Industrial Light & Magic. http://www.openexr.com
 * zlib © 1995-2005 Jean-loup Gailly and Mark Adler. http://www.zlib.net
 * libpng © 1998-2008 Glenn Randers-Pehrson, et al. http://www.libpng.org
-* Boost © various authors. http://www.boost.org
 * GLEW © 2002-2007 Milan Ikits, et al. http://glew.sourceforge.net
 * Ptex © 2009 Disney Enterprises, Inc. http://ptex.us
 * GIFLIB © 1997 Eric S. Raymond (MIT Licensed). http://giflib.sourceforge.net/

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -89,10 +89,6 @@ function (setup_oiio_util_library targetname)
         target_compile_definitions (${targetname} PUBLIC OIIO_STATIC_DEFINE=1)
     endif ()
 
-    if (OIIO_DISABLE_BOOST_STACKTRACE)
-        target_compile_definitions (${targetname} PRIVATE OIIO_DISABLE_BOOST_STACKTRACE)
-    endif ()
-
     # Propagate C++ minimum to downstream consumers
     target_compile_features (${targetname}
                              INTERFACE cxx_std_${DOWNSTREAM_CXX_STANDARD})

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -39,15 +39,8 @@
 #    include <windows.h>
 #endif
 
-#if 0
 
-// Use boost::lockfree::queue for the task queue
-#    include <boost/lockfree/queue.hpp>
-template<typename T> using Queue = boost::lockfree::queue<T>;
-
-#else
-
-#    include <queue>
+#include <queue>
 
 OIIO_NAMESPACE_BEGIN
 namespace pvt {
@@ -91,7 +84,6 @@ private:
 }  // namespace pvt
 OIIO_NAMESPACE_END
 
-#endif
 
 
 OIIO_NAMESPACE_BEGIN

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -2392,7 +2392,7 @@ declare_imagebufalgo(py::module& m)
         .def_readonly("nfail", &ImageBufAlgo::CompareResults::nfail)
         .def_readonly("error", &ImageBufAlgo::CompareResults::error);
 
-    // Use a boost::python::scope to put this all inside "ImageBufAlgo"
+    // Put this all inside "ImageBufAlgo"
     py::class_<IBA_dummy>(m, "ImageBufAlgo")
         .def_static("zero", &IBA_zero, "dst"_a, "roi"_a = ROI::All(),
                     "nthreads"_a = 0)

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -81,8 +81,6 @@ namespace detail {
 
 namespace PyOpenImageIO {
 
-//using namespace boost::python;
-
 using namespace OIIO;
 
 // clang-format off


### PR DESCRIPTION
As Marie Kondo would say, Boost no longer sparks joy for us, so we take one last look, thank it for its many years of service to our project, and then send it on its way.

Fixes #4158
