### PR TITLE
cleanup: Remove some long-deprecated things

### DIFF
--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -328,12 +328,6 @@ public:
     /// Return a filename or other identifier for the config we're using.
     std::string configname() const;
 
-    // DEPRECATED(1.9) -- no longer necessary, because it's a shared ptr
-    OIIO_DEPRECATED("no longer necessary (1.9)")
-    static void deleteColorProcessor(const ColorProcessorHandle& /*processor*/)
-    {
-    }
-
     /// Return if OpenImageIO was built with OCIO support
     static bool supportsOpenColorIO();
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -508,18 +508,6 @@ public:
                ProgressCallback progress_callback = nullptr,
                void* progress_callback_data       = nullptr) const;
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    // DEPRECATED(1.9): old version did not have the data type
-    OIIO_DEPRECATED("use other write() that takes the dtype argument (1.9)")
-    bool write(string_view filename, string_view fileformat,
-               ProgressCallback progress_callback = nullptr,
-               void* progress_callback_data       = nullptr) const
-    {
-        return write(filename, TypeUnknown, fileformat, progress_callback,
-                     progress_callback_data);
-    }
-#endif  // DOXYGEN_SHOULD_SKIP_THIS
-
     /// Set the pixel data format that will be used for subsequent `write()`
     /// calls that do not themselves request a specific data type request.
     ///

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -199,11 +199,6 @@ namespace ImageBufAlgo {
 using KWArgs = ParamValueSpan;
 
 
-// old name (DEPRECATED 1.9)
-OIIO_DEPRECATED("use parallel_options (1.9)")
-typedef parallel_options parallel_image_options;
-
-
 /// Create an all-black `float` image of size and channels as described by
 /// the ROI.
 ImageBuf OIIO_API zero (ROI roi, int nthreads=0);
@@ -1636,16 +1631,6 @@ bool OIIO_API histogram_draw (ImageBuf &dst,
 /// to retrieve an error message.
 ImageBuf OIIO_API make_kernel (string_view name, float width, float height,
                                float depth = 1.0f, bool normalize = true);
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// DEPRECATED(1.9):
-OIIO_DEPRECATED("use version that returns ImageBuf (1.9)")
-inline bool make_kernel (ImageBuf &dst, string_view name,
-                         float width, float height, float depth = 1.0f,
-                         bool normalize = true) {
-    dst = make_kernel (name, width, height, depth, normalize);
-    return ! dst.has_error();
-}
-#endif
 
 
 /// Return the convolution of `src` and a `kernel`. If `roi` is not defined,
@@ -2461,16 +2446,6 @@ ImageBuf OIIO_API capture_image (int cameranum = 0,
                                  TypeDesc convert=TypeUnknown);
 
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// DEPRECATED(1.9):
-OIIO_DEPRECATED("use version that returns ImageBuf (1.9)")
-inline bool capture_image (ImageBuf &dst, int cameranum = 0,
-                           TypeDesc convert=TypeUnknown) {
-    dst = capture_image (cameranum, convert);
-    return !dst.has_error();
-}
-#endif  // DOXYGEN_SHOULD_SKIP_THIS
-
 
 #if defined(__OPENCV_CORE_TYPES_H__) || defined(OPENCV_CORE_TYPES_H)
 // These declarations are only visible if the OpenCV headers have already
@@ -2481,13 +2456,6 @@ inline bool capture_image (ImageBuf &dst, int cameranum = 0,
 // avoided, giving preference to from_OpenCV.
 ImageBuf OIIO_API from_IplImage (const IplImage *ipl,
                                  TypeDesc convert=TypeUnknown);
-// DEPRECATED(1.9):
-OIIO_DEPRECATED("use from_OpenCV (1.9)")
-inline bool from_IplImage (ImageBuf &dst, const IplImage *ipl,
-                           TypeDesc convert=TypeUnknown) {
-    dst = from_IplImage (ipl, convert);
-    return ! dst.has_error();
-}
 
 // DEPRECATED(2.0). The OpenCV 1.x era IplImage-based functions should be
 // avoided, giving preference to from_OpenCV.

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -90,17 +90,6 @@ parallel_image(ROI roi, std::function<void(ROI)> f)
 
 
 
-// DEPRECATED(1.8) -- eventually enable the OIIO_DEPRECATION
-template<class Func>
-OIIO_DEPRECATED("switch to new parallel_image (1.8)")
-void parallel_image(Func f, ROI roi, int nthreads = 0,
-                    SplitDir splitdir = Split_Y)
-{
-    parallel_image(roi, paropt(nthreads, paropt::SplitDir(splitdir)), f);
-}
-
-
-
 /// Common preparation for IBA functions: Given an ROI (which may or may not
 /// be the default ROI::All()), destination image (which may or may not yet
 /// be allocated), and optional input images, adjust roi if necessary and

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1565,30 +1565,6 @@ public:
     virtual bool read_native_deep_image (int subimage, int miplevel,
                                          DeepData &deepdata);
 
-#ifndef OIIO_DOXYGEN
-    // DEPRECATED(1.9), Now just used for back compatibility:
-    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
-    bool read_native_deep_scanlines (int ybegin, int yend, int z,
-                             int chbegin, int chend, DeepData &deepdata) {
-        return read_native_deep_scanlines (current_subimage(), current_miplevel(),
-                                           ybegin, yend, z,
-                                           chbegin, chend, deepdata);
-    }
-    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
-    bool read_native_deep_tiles (int xbegin, int xend, int ybegin, int yend,
-                                 int zbegin, int zend, int chbegin, int chend,
-                                 DeepData &deepdata) {
-        return read_native_deep_tiles (current_subimage(), current_miplevel(),
-                                       xbegin, xend, ybegin, yend,
-                                       zbegin, zend, chbegin, chend, deepdata);
-    }
-    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
-    bool read_native_deep_image (DeepData &deepdata) {
-        return read_native_deep_image (current_subimage(), current_miplevel(),
-                                       deepdata);
-    }
-#endif
-
     /// @}
 
     /// @{

--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -20,8 +20,6 @@
 
 OIIO_NAMESPACE_BEGIN
 
-using std::shared_ptr;  // DEPRECATED(1.8)
-
 
 
 /// A simple intrusive pointer, modeled after std::shared_ptr.

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -451,6 +451,7 @@ public:
     /// Utility: Parse a single wrap mode (e.g., "periodic") or a
     /// comma-separated wrap modes string (e.g., "black,clamp") into
     /// separate Wrap enums for s and t.
+    OIIO_DEPRECATED("TextureOptions is deprecated, use TextureOpt (1.8)")
     static void parse_wrapmodes(const char* wrapmodes,
                                 TextureOptions::Wrap& swrapcode,
                                 TextureOptions::Wrap& twrapcode)

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -276,8 +276,3 @@ private:
 
 
 OIIO_NAMESPACE_END
-
-
-// DEPRECATED(1.8): for back compatibility with old inclusion of some
-// functions that used to be here but are now in benchmark.h, include it.
-#include <OpenImageIO/benchmark.h>


### PR DESCRIPTION
This is just the first step in many for removing deprecated things along the way to a 3.0 release. I'm doing a little at a time.

I believe that here I'm only removing things that (a) have been deprecated since 2.0 or earlier, (b) most or maybe all were marked with OIIO_DEPRECATED and so should have been triggering warnings for a long time if used downstream (thus, almost certainly nobody is using it), and (c) are inline definitions, so this change should not appear to break link ABIs.
