### PR TITLE
security: change command line embedding for oiiotool & maketx output

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -365,4 +365,4 @@ inside the source code.
     images it outputs. The default if this is not set is to only write the
     name and version of the software and an indecipherable hash of the command
     line, but not the full human-readable command line. (This was added in
-    OpenImageIO 2.5.0.)
+    OpenImageIO 2.5.11.)

--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -357,3 +357,12 @@ inside the source code.
     use for its thread pool. If both are set, ``OPENIMAGEIO_THREADS`` will
     take precedence. If neither is set, the default will be 0, which means
     to use as many threads as there are physical cores on the machine.
+
+``OIIOTOOL_METADATA_HISTORY``
+
+    If set to a nonzero integer value, `oiiotool` will by default write the
+    command line into the ImageHistory and Software metadata fields of any
+    images it outputs. The default if this is not set is to only write the
+    name and version of the software and an indecipherable hash of the command
+    line, but not the full human-readable command line. (This was added in
+    OpenImageIO 2.5.0.)

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1975,10 +1975,10 @@ current top image.
 
     Prior to OpenImageIO 2.5.11, the full information was always written, but
     could be overridden with `--nosoftwareattrib`. Beginning with 2.5.11, the
-    default changed only say the software name and version (unless the
+    default changed to only write the software name and version (unless the
     `OIIOTOOL_METADATA_HISTORY` environment variable is set), and require the
-    new `--history` option to cause the command line arguments to be saved as
-    meetadata.
+    new `--history` option to cause the command line arguments to be written
+    as metadata.
 
 .. option:: --sansattrib
 

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1952,10 +1952,33 @@ current top image.
         are not set, only the first subimage will be changed, or all subimages
         if the `-a` command line flag was used.
 
-.. option:: --nosoftwareattrib
+.. option:: --history
+            --no-history
+            --nosoftwareattrib
 
-    When set, this prevents the normal adjustment of "Software" and
-    "ImageHistory" metadata to reflect what :program:`oiiotool` is doing.
+    By default, oiiotool writes "OpenImageIO <version>" and a SHA-1 hash of
+    the command line as the "Software" metadata in output images.
+    
+    The `--history` option appends the full command line arguments and appends
+    that information to the "ImageHistory" metadata as well. This behavior is
+    "opt-in" because some users may find it undesirable for metadata in the
+    image to potentially reveal any proprietary information that might have
+    been present in the command line arguments.
+    
+    If the `OIIOTOOL_METADATA_HISTORY` environment variable is set to a
+    nonzero integer value, the `--history` option will be enabled by default,
+    but can be disabled on the command line with `--no-history`.
+
+    The `--nosoftwareattrib` option prevents even the minimal default information
+    from being written, so that no information about the software is written
+    to any metadata field.
+
+    Prior to OpenImageIO 2.5.11, the full information was always written, but
+    could be overridden with `--nosoftwareattrib`. Beginning with 2.5.11, the
+    default changed only say the software name and version (unless the
+    `OIIOTOOL_METADATA_HISTORY` environment variable is set), and require the
+    new `--history` option to cause the command line arguments to be saved as
+    meetadata.
 
 .. option:: --sansattrib
 

--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -578,6 +578,11 @@ public:
     SHA1 (const void *data=NULL, size_t size=0);
     ~SHA1 ();
 
+    SHA1 (string_view str) : SHA1(str.data(), str.size()) { }
+
+    template<typename T>
+    SHA1 (span<T> v) : SHA1(v.data(), v.size()) { }
+
     /// Append more data
     void append (const void *data, size_t size);
 
@@ -587,7 +592,7 @@ public:
     }
 
     /// Append more data from a span, without thinking about sizes.
-    template<class T> void append (span<T> v) {
+    template<typename T> void append (span<T> v) {
         append (v.data(), v.size()*sizeof(T));
     }
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -126,6 +126,7 @@ public:
     bool output_dither;
     bool output_force_tiles;  // for debugging
     bool metadata_nosoftwareattrib;
+    bool metadata_history;
 
     // Options for --diff
     float diff_warnthresh;

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -49,8 +49,6 @@ Reading noattribs.jpg
 noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: A74C7DF2B01825DCB6881407AE77C11DC56AB741
     channel list: R, G, B
-    Exif:ExifVersion: "0230"
-    Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
     oiio:ColorSpace: "sRGB"
 initial keywords=
@@ -123,8 +121,6 @@ tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    Exif:ExifVersion: "0230"
-    Exif:FlashPixVersion: "0100"
     ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
     ICCProfile:cmm_type: 1094992453
     ICCProfile:color_space: "RGB"

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -49,8 +49,6 @@ Reading noattribs.jpg
 noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
     channel list: R, G, B
-    Exif:ExifVersion: "0230"
-    Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
     oiio:ColorSpace: "sRGB"
 initial keywords=
@@ -123,8 +121,6 @@ tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    Exif:ExifVersion: "0230"
-    Exif:FlashPixVersion: "0100"
     ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
     ICCProfile:cmm_type: 1094992453
     ICCProfile:color_space: "RGB"


### PR DESCRIPTION
It was pointed out that oiiotool and maketx's habit of embedding their exact command line arguments in the Software and ImageHistory metadata of output images was potentially problematic in that it might inadvertently leak important internal data (for example, file paths may reveal secret projects, etc.).

This patch changes the behavior of oiiotool and maketx as follows:

* The default behavior is now to use `"OpenImageIO <version> <hash>"` where `<hash>` is the SHA-1 hash of the command line arguments (which allows you to tell if two files use the same command line args, but doesn't let you know what they were).

* A new `--history` argument (or setting OIIOTOOL_METADATA_HISTORY env variable to a nonzero integer) instead uses the full command line arguments with no obfuscation. (This used to be the default behavior but is now deemed unsafe.) When the env variable is in effect, a `--no-history` argument explicitly disables it.

* For oiiotool, the existing `--nosoftwareattrib`, as before, causes the Software and ImageHistory metadata to not be modified at all.

Here is an example of the behavior:

```
$ oiiotool tmp.tif -o tmp.exr && iinfo -v tmp.exr
tmp.exr :  640 x  480, 3 channel, half openexr
    channel list: R, G, B
    Software: "OpenImageIO 2.6.2.0dev : B897973B86EC13E3F1858AAE5E057EFCCF99889A"
    ...

$ oiiotool --history tmp.tif -o tmp.exr && iinfo -v tmp.exr
tmp.exr :  640 x  480, 3 channel, half openexr
    channel list: R, G, B
    Software: "OpenImageIO 2.6.2.0dev : oiiotool --history tmp.tif -o tmp.exr"
    Exif:ImageHistory: "oiiotool --history tmp.tif -o tmp.exr"
    ...
```
