### PR TITLE
Add attribute to ignore system environment variables for plugin path

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2854,6 +2854,11 @@ OIIO_API std::string geterror(bool clear = true);
 ///    Colon-separated (or semicolon-separated) list of directories to search
 ///    for dynamically-loaded format plugins.
 ///
+/// - `int plugin_search_system_paths`
+///
+///    Search for plugins using LD_LIBRARY_PATH and DYLD_LIBRARY_PATH
+///    environment variables. Enabled by default.
+///
 /// - `int try_all_readers`
 ///
 ///    When nonzero (the default), a call to `ImageInput::create()` or

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -55,6 +55,7 @@ int limit_imagesize_MB(std::min(32 * 1024,
                                 int(Sysutil::physical_memory() >> 20)));
 ustring font_searchpath(Sysutil::getenv("OPENIMAGEIO_FONTS"));
 ustring plugin_searchpath(OIIO_DEFAULT_PLUGIN_SEARCHPATH);
+int plugin_search_system_paths(1);
 std::string format_list;         // comma-separated list of all formats
 std::string input_format_list;   // comma-separated list of readable formats
 std::string output_format_list;  // comma-separated list of writable formats
@@ -398,6 +399,10 @@ attribute(string_view name, TypeDesc type, const void* val)
         plugin_searchpath = ustring(*(const char**)val);
         return true;
     }
+    if (name == "plugin_search_system_paths" && type == TypeInt) {
+        plugin_search_system_paths = *(const int*)val;
+        return true;
+    }
     if (name == "exr_threads" && type == TypeInt) {
         oiio_exr_threads = OIIO::clamp(*(const int*)val, -1, maxthreads);
         return true;
@@ -495,6 +500,10 @@ getattribute(string_view name, TypeDesc type, void* val)
     }
     if (name == "plugin_searchpath" && type == TypeString) {
         *(ustring*)val = plugin_searchpath;
+        return true;
+    }
+    if (name == "plugin_search_system_paths" && type == TypeInt) {
+        *(int*)val = plugin_search_system_paths;
         return true;
     }
     if (name == "format_list" && type == TypeString) {

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -33,6 +33,7 @@ extern atomic_int oiio_read_chunk;
 extern atomic_int oiio_try_all_readers;
 extern ustring font_searchpath;
 extern ustring plugin_searchpath;
+extern int plugin_search_system_paths;
 extern std::string format_list;
 extern std::string input_format_list;
 extern std::string output_format_list;

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -468,13 +468,17 @@ pvt::catalog_all_plugins(std::string searchpath)
     std::call_once(builtin_flag, catalog_builtin_plugins);
 
     std::unique_lock<std::recursive_mutex> lock(imageio_mutex);
+
     append_if_env_exists(searchpath, "OIIO_LIBRARY_PATH", true);
+
+    if (pvt::plugin_search_system_paths) {
 #ifdef __APPLE__
-    append_if_env_exists(searchpath, "DYLD_LIBRARY_PATH");
+        append_if_env_exists(searchpath, "DYLD_LIBRARY_PATH");
 #endif
 #if defined(__linux__) || defined(__FreeBSD__)
-    append_if_env_exists(searchpath, "LD_LIBRARY_PATH");
+        append_if_env_exists(searchpath, "LD_LIBRARY_PATH");
 #endif
+    }
 
     size_t patlen = pattern.length();
     std::vector<std::string> dirs;


### PR DESCRIPTION
## Description

Sometimes it's useful to run an application more isolated, without picking up plugins from `LD_LIBRARY_PATH`. These may have been installed for another purpose, or be incompatible in some way.

## Tests

Not easy to test, but hopefully not needed.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
