### PR TITLE
Don't use (DY)LD_LIBRARY_PATH as plugin search paths

### DIFF
--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -469,12 +469,6 @@ pvt::catalog_all_plugins(std::string searchpath)
 
     std::unique_lock<std::recursive_mutex> lock(imageio_mutex);
     append_if_env_exists(searchpath, "OIIO_LIBRARY_PATH", true);
-#ifdef __APPLE__
-    append_if_env_exists(searchpath, "DYLD_LIBRARY_PATH");
-#endif
-#if defined(__linux__) || defined(__FreeBSD__)
-    append_if_env_exists(searchpath, "LD_LIBRARY_PATH");
-#endif
 
     size_t patlen = pattern.length();
     std::vector<std::string> dirs;


### PR DESCRIPTION
## Description

Only use the OIIO_LIBRARY_PATH environment variable by default.

Searching through such system paths has some risk loading plugins installed for another purpose or that may be incompatible.

If the previous behavior is desired, applications can add these environment variables to the plugin search path manually.

## Tests

N/A

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
