### PR TITLE
build: Disable clang18 warnings about deprecated unicode conversion

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * **C++17 or higher** (also builds with C++20)
      * The default build mode is C++17. This can be controlled by via the
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=20`, etc.
- * Compilers: **gcc 9.3** - 13.1, **clang 5** - 17, MSVS 2017 - 2019 (**v19.14
+ * Compilers: **gcc 9.3** - 13.1, **clang 5** - 18, MSVS 2017 - 2019 (**v19.14
    and up**), **Intel icc 19+**, Intel OneAPI C++ compiler 2022+.
  * **CMake >= 3.15** (tested through 3.28)
  * **OpenEXR/Imath >= 3.1** (tested through 3.2

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -48,6 +48,7 @@
 #    define FMT_USE_FLOAT128 0
 #endif
 
+// Suppress certain warnings generated in the fmt headers themselves
 OIIO_PRAGMA_WARNING_PUSH
 #if OIIO_GNUC_VERSION >= 70000
 #    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -57,6 +58,9 @@ OIIO_PRAGMA_WARNING_PUSH
 #endif
 #if OIIO_INTEL_LLVM_COMPILER
 #    pragma GCC diagnostic ignored "-Wtautological-constant-compare"
+#endif
+#if OIIO_CLANG_VERSION >= 180000
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 #include <OpenImageIO/detail/fmt/format.h>

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -3,16 +3,24 @@
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 
+#include <OpenImageIO/platform.h>
+
+// Special dance to disable warnings in the included files related to
+// the deprecation of unicode conversion functions.
+OIIO_PRAGMA_WARNING_PUSH
+OIIO_CLANG_PRAGMA(clang diagnostic ignored "-Wdeprecated-declarations")
+#include <codecvt>
+#include <locale>
+OIIO_PRAGMA_WARNING_POP
+
 #include <algorithm>
 #include <cmath>
-#include <codecvt>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
 #include <limits>
-#include <locale>
 #include <mutex>
 #include <numeric>
 #include <sstream>
@@ -23,7 +31,6 @@
 #endif
 
 #include <OpenImageIO/dassert.h>
-#include <OpenImageIO/platform.h>
 #include <OpenImageIO/string_view.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/thread.h>


### PR DESCRIPTION
clang/llvm 18 (and probably other compilers soon) has made noisy warnings about the C++17-deprecated unicode conversions. Actually replacing them enirely with something else is rather hairy, we will tackle that later.

In the mean time, this patch seems to be the minimal change to disable the warnings that should be totally easy to backport.

These seem to be the only changes necessary to make a clean build with clang 18.
