### PR TITLE
cleanup: more old style format deprecation

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1056,15 +1056,6 @@ public:
         error(Strutil::fmt::format(fmt, args...));
     }
 
-    /// Error reporting for ImageBuf: call this with printf-like arguments
-    /// to report an error. It is not necessary to have the error message
-    /// contain a trailing newline.
-    template<typename... Args>
-    void errorf(const char* fmt, const Args&... args) const
-    {
-        error(Strutil::sprintf(fmt, args...));
-    }
-
     /// Error reporting for ImageBuf: call this with Strutil::format
     /// formatting conventions.  It is not necessary to have the error
     /// message contain a trailing newline. Beware, this is in transition,
@@ -1074,15 +1065,6 @@ public:
                                       const Args&... args) const
     {
         error(Strutil::format(fmt, args...));
-    }
-
-    // Error reporting for ImageBuf: call this with Python / {fmt} /
-    // std::format style formatting specification.
-    template<typename... Args>
-    OIIO_DEPRECATED("use `errorfmt` instead")
-    void fmterror(const char* fmt, const Args&... args) const
-    {
-        error(Strutil::fmt::format(fmt, args...));
     }
 
     /// Returns `true` if the ImageBuf has had an error and has an error

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1690,6 +1690,7 @@ public:
     /// printf-like arguments. It is not necessary to have the error message
     /// contain a trailing newline.
     template<typename... Args>
+    OIIO_FORMAT_DEPRECATED
     void errorf(const char* fmt, const Args&... args) const {
         append_error(Strutil::sprintf (fmt, args...));
     }
@@ -2485,6 +2486,7 @@ public:
     /// printf-like arguments. It is not necessary to have the error message
     /// contain a trailing newline.
     template<typename... Args>
+    OIIO_FORMAT_DEPRECATED
     void errorf(const char* fmt, const Args&... args) const {
         append_error(Strutil::sprintf (fmt, args...));
     }

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -506,7 +506,7 @@ static void
 test_uncaught_error()
 {
     ImageBuf buf;
-    buf.error("Boo!");
+    buf.errorfmt("Boo!");
     // buf exists scope and is destroyed without anybody retrieving the error.
 }
 

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -1591,7 +1591,7 @@ check_st_warp_args(ImageBuf& dst, const ImageBuf& src, const ImageBuf& stbuf,
 {
     // Validate ST buffer
     if (!stbuf.initialized()) {
-        dst.error("ImageBufAlgo::st_warp : Uninitialized ST buffer");
+        dst.errorfmt("ImageBufAlgo::st_warp : Uninitialized ST buffer");
         return false;
     }
 
@@ -1690,7 +1690,7 @@ ImageBufAlgo::st_warp(const ImageBuf& src, const ImageBuf& stbuf,
     bool ok = st_warp(result, src, stbuf, filter, chan_s, chan_t, flip_s,
                       flip_t, roi, nthreads);
     if (!ok && !result.has_error()) {
-        result.error("ImageBufAlgo::st_warp : Unknown error");
+        result.errorfmt("ImageBufAlgo::st_warp : Unknown error");
     }
     return result;
 }
@@ -1707,7 +1707,7 @@ ImageBufAlgo::st_warp(const ImageBuf& src, const ImageBuf& stbuf,
     bool ok = st_warp(result, src, stbuf, filtername, filterwidth, chan_s,
                       chan_t, flip_s, flip_t, roi, nthreads);
     if (!ok && !result.has_error()) {
-        result.error("ImageBufAlgo::st_warp : Unknown error");
+        result.errorfmt("ImageBufAlgo::st_warp : Unknown error");
     }
     return result;
 }


### PR DESCRIPTION
Remove some long-ago deprecated printf-like error functions. Mark as deprecated some other ones that we will remove when it gets closer to 3.0 release. I think these are the very last uses internally of the old style that we want to remove.

