### PR TITLE
fix: fix crash when no default fonts are found

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -883,7 +883,7 @@ static FT_Library ft_library = NULL;
 static bool ft_broken        = false;
 
 static const char* default_font_name[] = { "DroidSans", "cour", "Courier New",
-                                           "FreeMono", nullptr };
+                                           "FreeMono" };
 
 
 


### PR DESCRIPTION
The nullptr at the end of default_font_name was left over from a time that we iterated by going through array elements until we hit the nullptr that signalled we had passed the last valid element. At some point we switched to a range-for, which iterates over every element of the array without needing an "end sentinel", and we should have eliminated the nullptr but failed to do so.

Fixes #4248
