### PR TITLE
NetPBM (PNM plugin)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -290,7 +290,7 @@ the section below, and will only have to point OIIO build process so their locat
   cd {TIFF_ROOT}
   git clone https://gitlab.com/libtiff/libtiff.git .
   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=.
-  cmake --build build --target install
+  cmake --build build --config Release --target install
   ```
 * libjpeg-turbo:
   ```
@@ -315,14 +315,18 @@ the section below, and will only have to point OIIO build process so their locat
 
 Now get the OIIO source and do one-time CMake configuration step. Replace `{*_ROOT}` below with folders where you have put the 3rd party
 dependencies.
+
+Note: For the `Imath_LIBRARY`, you might need to correct the `Imath-*.lib` file name that was built on your machine.
 ```
 cd {OIIO_ROOT}
 git clone https://github.com/AcademySoftwareFoundation/OpenImageIO .
 cmake -S . -B build -DVERBOSE=ON -DCMAKE_BUILD_TYPE=Release ^
   -DZLIB_ROOT={ZLIB_ROOT}\build ^
   -DTIFF_ROOT={TIFF_ROOT}\build ^
-  -DOpenEXR_ROOT={EXR_ROOT}\build\dist ^
-  -DImath_DIR={EXR_ROOT}\build\dist\lib\cmake\Imath ^
+  -DOpenEXR_ROOT={EXR_ROOT}\dist ^
+  -DImath_DIR={EXR_ROOT}\dist\lib\cmake\Imath ^
+  -DImath_INCLUDE_DIR={EXR_ROOT}\dist\include\Imath ^
+  -DImath_LIBRARY={EXR_ROOT}\dist\lib\Imath-3_2.lib ^
   -DJPEG_ROOT={JPEG_ROOT}\build ^
   -DUSE_PYTHON=0 -DUSE_QT=0 -DBUILD_SHARED_LIBS=0 -DLINKSTATIC=1
 ```

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1252,7 +1252,7 @@ control aspects of the writing itself:
        Default: 7. Higher numbers allow more computation at the expense of time.
        For lossless, generally it will produce smaller files.
        For lossy, higher effort should more accurately reach the target quality.
-   * - ``jpegxl:tier``
+   * - ``jpegxl:speed``
    	 - int
      - Sets the decoding speed tier for the provided options. Minimum is 0
        (slowest to decode, best quality/density), and maximum is 4 (fastest to

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1197,20 +1197,40 @@ the `set_ioproxy()` methods.
 
 .. _sec-bundledplugins-jpegxl:
 
-JPEG-XL
+JPEG XL
 ===============================================
 
-JPEG-XL is a new image format that is designed to be a successor to JPEG
-and to provide better compression and quality. JPEG-XL files use the file
-extension :file:`.jxl`. The official JPEG-XL format specification and other
+JPEG XL is a new image format that is designed to be a successor to JPEG
+and to provide better compression and quality. JPEG XL files use the file
+extension :file:`.jxl`. The official JPEG XL format specification and other
 helpful info may be found at: https://jpeg.org/jpegxl/
 
-**Configuration settings for JPEG-XL input**
+**Configuration settings for JPEG XL input**
 
+When opening a JPEG XL ImageInput with a *configuration* (see
+Section :ref:`sec-input with-config`), the following special configuration
+attributes are supported:
 
-**Configuration settings for JPEG-XL output**
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
 
-When opening a JPEG-XL ImageOutput, the following special metadata tokens
+   * - Input Configuration Attribute
+     - Type
+     - Meaning
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.
+   * - ``jpegxl:speed``
+   	 - int
+     - Sets the decoding speed tier for the provided options. Minimum is 0
+       (slowest to decode, best quality/density), and maximum is 4 (fastest to
+       decode, at the cost of some quality/density). Default is 0.
+       
+**Configuration settings for JPEG XL output**
+
+When opening a JPEG XL ImageOutput, the following special metadata tokens
 control aspects of the writing itself:
 
 .. list-table::
@@ -1219,7 +1239,7 @@ control aspects of the writing itself:
 
    * - Output Configuration Attribute
 	 - Type
-	 - JPEG-XL header data or explanation
+	 - JPEG XL header data or explanation
    * - ``oiio:dither``
      - int
      - If nonzero and outputting UINT8 values in the file from a source of
@@ -1252,11 +1272,6 @@ control aspects of the writing itself:
        Default: 7. Higher numbers allow more computation at the expense of time.
        For lossless, generally it will produce smaller files.
        For lossy, higher effort should more accurately reach the target quality.
-   * - ``jpegxl:speed``
-   	 - int
-     - Sets the decoding speed tier for the provided options. Minimum is 0
-       (slowest to decode, best quality/density), and maximum is 4 (fastest to
-       decode, at the cost of some quality/density). Default is 0.
    * - ``jpegxl:photon_noise_iso``
      - float
      - ISO_FILM_SPEED. Adds noise to the image emulating photographic film or

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1197,40 +1197,20 @@ the `set_ioproxy()` methods.
 
 .. _sec-bundledplugins-jpegxl:
 
-JPEG XL
+JPEG-XL
 ===============================================
 
-JPEG XL is a new image format that is designed to be a successor to JPEG
-and to provide better compression and quality. JPEG XL files use the file
-extension :file:`.jxl`. The official JPEG XL format specification and other
+JPEG-XL is a new image format that is designed to be a successor to JPEG
+and to provide better compression and quality. JPEG-XL files use the file
+extension :file:`.jxl`. The official JPEG-XL format specification and other
 helpful info may be found at: https://jpeg.org/jpegxl/
 
-**Configuration settings for JPEG XL input**
+**Configuration settings for JPEG-XL input**
 
-When opening a JPEG XL ImageInput with a *configuration* (see
-Section :ref:`sec-input with-config`), the following special configuration
-attributes are supported:
 
-.. list-table::
-   :widths: 30 10 65
-   :header-rows: 1
+**Configuration settings for JPEG-XL output**
 
-   * - Input Configuration Attribute
-     - Type
-     - Meaning
-   * - ``oiio:ioproxy``
-     - ptr
-     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
-       example by reading from memory rather than the file system.
-   * - ``jpegxl:speed``
-   	 - int
-     - Sets the decoding speed tier for the provided options. Minimum is 0
-       (slowest to decode, best quality/density), and maximum is 4 (fastest to
-       decode, at the cost of some quality/density). Default is 0.
-       
-**Configuration settings for JPEG XL output**
-
-When opening a JPEG XL ImageOutput, the following special metadata tokens
+When opening a JPEG-XL ImageOutput, the following special metadata tokens
 control aspects of the writing itself:
 
 .. list-table::
@@ -1239,7 +1219,7 @@ control aspects of the writing itself:
 
    * - Output Configuration Attribute
 	 - Type
-	 - JPEG XL header data or explanation
+	 - JPEG-XL header data or explanation
    * - ``oiio:dither``
      - int
      - If nonzero and outputting UINT8 values in the file from a source of
@@ -1272,6 +1252,11 @@ control aspects of the writing itself:
        Default: 7. Higher numbers allow more computation at the expense of time.
        For lossless, generally it will produce smaller files.
        For lossy, higher effort should more accurately reach the target quality.
+   * - ``jpegxl:tier``
+   	 - int
+     - Sets the decoding speed tier for the provided options. Minimum is 0
+       (slowest to decode, best quality/density), and maximum is 4 (fastest to
+       decode, at the cost of some quality/density). Default is 0.
    * - ``jpegxl:photon_noise_iso``
      - float
      - ISO_FILM_SPEED. Adds noise to the image emulating photographic film or

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1797,12 +1797,6 @@ no multi-image, no MIPmapping.
      - int
      - The true bits per sample of the file (1 for true PBM files, even
        though OIIO will report the ``format`` as UINT8).
-   * - ``pnm:binary``
-     - int
-     - nonzero if the file itself used the PNM binary format, 0 if it used
-       ASCII.  The PNM writer honors this attribute in the ImageSpec to
-       determine whether to write an ASCII or binary file.
-       Float PFM files are always written in binary format.
 
 **Configuration settings for PNM input**
 
@@ -1821,6 +1815,13 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``pnm:bigendian``
+     - int
+     - If nonzero, the PNM file is big-endian (the default is little-endian).  
+   * - ``pnm:pfmflip``
+      - int
+      - If nonzero, the PFM (float) file is flipped upside-down (the default
+      is flipped).
 
 **Configuration settings for PNM output**
 
@@ -1843,6 +1844,19 @@ control aspects of the writing itself:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by writing to a memory buffer.
+   * - ``pnm:bigendian``
+     - int
+     - If nonzero, the PNM file is big-endian (the default is little-endian).
+   * - ``pnm:binary``
+     - int
+     - nonzero if the file itself used the PNM binary format, 0 if it used
+       ASCII.  The PNM writer honors this attribute in the ImageSpec to
+       determine whether to write an ASCII or binary file.
+       Float PFM files are always written in binary format.
+   * - ``pnm:pfmflip``
+      - int
+      - If nonzero, the PFM (float) file is flipped upside-down (the default
+      is flipped).
 
 **Custom I/O Overrides**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1195,6 +1195,77 @@ the `set_ioproxy()` methods.
 
 |
 
+.. _sec-bundledplugins-jpegxl:
+
+JPEG-XL
+===============================================
+
+JPEG-XL is a new image format that is designed to be a successor to JPEG
+and to provide better compression and quality. JPEG-XL files use the file
+extension :file:`.jxl`. The official JPEG-XL format specification and other
+helpful info may be found at: https://jpeg.org/jpegxl/
+
+**Configuration settings for JPEG-XL input**
+
+
+**Configuration settings for JPEG-XL output**
+
+When opening a JPEG-XL ImageOutput, the following special metadata tokens
+control aspects of the writing itself:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Output Configuration Attribute
+	 - Type
+	 - JPEG-XL header data or explanation
+   * - ``oiio:dither``
+     - int
+     - If nonzero and outputting UINT8 values in the file from a source of
+       higher bit depth, will add a small amount of random dither to combat
+       the appearance of banding.
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by writing to a memory buffer.
+   * - ``oiio:UnassociatedAlpha``
+     - int
+     - If nonzero, indicates that the data being passed is already in
+       unassociated form (non-premultiplied colors) and should stay that way
+       for output rather than being assumed to be associated and get automatic
+       un-association to store in the file.
+   * - ``compression``
+	 - string
+	 - If supplied, must be ``"jpegxl"``, but may optionally have a quality
+	   value appended, like ``"jpegxl:90"``. Quality can be 0-100, with 100
+	   meaning lossless.
+   * - ``jpegxl:distance``
+	 - float
+     - Target visual distance in JND units, lower = higher quality.
+       0.0 = mathematically lossless. 1.0 = visually lossless.
+       Recommended range: 0.5 .. 3.0. Allowed range: 0.0 ... 25.0. 
+       Mutually exclusive with ``*compression jpegxl:*```.
+   * - ``jpegxl:effort``
+     - int
+	 - Encoder effort setting. Range: 1 .. 10.
+       Default: 7. Higher numbers allow more computation at the expense of time.
+       For lossless, generally it will produce smaller files.
+       For lossy, higher effort should more accurately reach the target quality.
+   * - ``jpegxl:tier``
+   	 - int
+     - Sets the decoding speed tier for the provided options. Minimum is 0
+       (slowest to decode, best quality/density), and maximum is 4 (fastest to
+       decode, at the cost of some quality/density). Default is 0.
+   * - ``jpegxl:photon_noise_iso``
+     - float
+     - ISO_FILM_SPEED. Adds noise to the image emulating photographic film or
+       sensor noise. Higher number = grainier image, e.g. 100 gives a low
+       amount of noise, 3200 gives a lot of noise. Default is 0.
+       Encoded as metadata in the image.
+
+|
+
 .. _sec-bundledplugins-ffmpeg:
 
 Movie formats (using ffmpeg)

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1222,11 +1222,6 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
-   * - ``jpegxl:speed``
-   	 - int
-     - Sets the decoding speed tier for the provided options. Minimum is 0
-       (slowest to decode, best quality/density), and maximum is 4 (fastest to
-       decode, at the cost of some quality/density). Default is 0.
        
 **Configuration settings for JPEG XL output**
 
@@ -1272,9 +1267,16 @@ control aspects of the writing itself:
        Default: 7. Higher numbers allow more computation at the expense of time.
        For lossless, generally it will produce smaller files.
        For lossy, higher effort should more accurately reach the target quality.
+   * - ``jpegxl:speed``
+     - int
+     - Sets the encoding speed tier for the provided options. Minimum is 0
+       (slowest to encode, best quality/density), and maximum is 4 (fastest to
+       encode, at the cost of some quality/density). Default is 0.
+       (Note: in libjxl it named JXL_ENC_FRAME_SETTING_DECODING_SPEED. But it
+       is about encoding speed and compression quality, not decoding speed.)
    * - ``jpegxl:photon_noise_iso``
      - float
-     - ISO_FILM_SPEED. Adds noise to the image emulating photographic film or
+     - (ISO_FILM_SPEED) Adds noise to the image emulating photographic film or
        sensor noise. Higher number = grainier image, e.g. 100 gives a low
        amount of noise, 3200 gives a lot of noise. Default is 0.
        Encoded as metadata in the image.

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1766,22 +1766,23 @@ and :ref:`sec-imageinput-ioproxy`) as well as the `set_ioproxy()` methods.
 PNM / Netpbm
 ===============================================
 
-The Netpbm project, a.k.a. PNM (portable "any" map) defines PBM, PGM,
-and PPM (portable bitmap, portable graymap, portable pixmap) files.
+The Netpbm project, a.k.a. PNM (portable "any" map) defines PBM, PGM, PPM
+and later added PFM (portable float map) as a set of simple image formats
+(portable bitmap, portable graymap, portable pixmap) files.
 Without loss of generality, we will refer to these all collectively as
-"PNM."  These files have extensions :file:`.pbm`, :file:`.pgm`, and
-:file:`.ppm` and customarily correspond to bi-level bitmaps, 1-channel
-grayscale, and 3-channel RGB files, respectively, or :file:`.pnm` for
-those who reject the nonsense about naming the files depending on the
+"PNM."  These files have extensions :file:`.pbm`, :file:`.pgm`,
+:file:`.ppm`, :file:`.pfm` and customarily correspond to bi-level bitmaps,
+1-channel grayscale, and 3-channel RGB files, respectively, or :file:`.pnm`
+for those who reject the nonsense about naming the files depending on the
 number of channels and bitdepth.
 
-PNM files are not much good for anything, but because of their
-historical significance and extreme simplicity (that causes many
-"amateur" programs to write images in these formats), OpenImageIO
-supports them.  PNM files do not support floating point images, anything
-other than 1 or 3 channels, no tiles, no multi-image, no MIPmapping.
-It's not a smart choice unless you are sending your images back to the
-1980's via a time machine.
+PNM files widely used in the Unix world as simple ASCII or binary image 
+files that are easy to read and write. They are not compressed, and are
+not particularly efficient for large images. They are not widely used in
+the professional graphics world, but because of their historical
+significance and extreme simplicity, OpenImageIO supports them.
+PNM files do not support anything other than 1 or 3 channels, no tiles,
+no multi-image, no MIPmapping.
 
 **Attributes**
 
@@ -1801,6 +1802,7 @@ It's not a smart choice unless you are sending your images back to the
      - nonzero if the file itself used the PNM binary format, 0 if it used
        ASCII.  The PNM writer honors this attribute in the ImageSpec to
        determine whether to write an ASCII or binary file.
+       Float PFM files are always written in binary format.
 
 **Configuration settings for PNM input**
 

--- a/src/jpegxl.imageio/jxlinput.cpp
+++ b/src/jpegxl.imageio/jxlinput.cpp
@@ -58,8 +58,6 @@ private:
     std::unique_ptr<ImageSpec> m_config;  // Saved copy of configuration spec
     std::vector<uint8_t> m_icc_profile;
     uint8_t* m_buffer;
-    //std::vector<float> m_pixels;
-    // std::vector<uint8_t> m_pixels;
 
     void init()
     {
@@ -222,7 +220,6 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
     JxlPixelFormat format;
     JxlDataType jxl_data_type;
     TypeDesc m_data_type;
-    // JxlPixelFormat format = { channels, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0 };
 
     for (;;) {
         JxlDecoderStatus status = JxlDecoderProcessInput(m_decoder.get());
@@ -317,12 +314,6 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
                 return false;
             }
 
-            //m_pixels.resize(info.xsize * info.ysize * m_channels);
-            //void* pixels_buffer       = (void*)m_pixels.data();
-            //size_t pixels_buffer_size = m_pixels.size() * info.bits_per_sample
-            //                          / 8;
-            // size_t pixels_buffer_size = m_pixels.size() * sizeof(uint8_t);
-            // allocate buffer
             m_buffer = new uint8_t[buffer_size];
 
             if (JXL_DEC_SUCCESS
@@ -353,7 +344,7 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
     }
 
     m_spec = ImageSpec(info.xsize, info.ysize, m_channels, m_data_type);
-    // TypeDesc::UINT8);
+
     newspec = m_spec;
     return true;
 }
@@ -374,10 +365,7 @@ JxlInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (y < 0 || y >= m_spec.height)  // out of range scanline
         return false;
 
-    //memcpy(data, (void*)((uint8_t*)(m_pixels.data()) + y * scanline_size),
-    //       scanline_size);
-    memcpy(data, (void*)(m_buffer + y * scanline_size),
-        		   scanline_size);
+    memcpy(data, (void*)(m_buffer + y * scanline_size), scanline_size);
 
     return true;
 }

--- a/src/jpegxl.imageio/jxlinput.cpp
+++ b/src/jpegxl.imageio/jxlinput.cpp
@@ -57,7 +57,8 @@ private:
     JxlResizableParallelRunnerPtr m_runner;
     std::unique_ptr<ImageSpec> m_config;  // Saved copy of configuration spec
     std::vector<uint8_t> m_icc_profile;
-    std::vector<float> m_pixels;
+    uint8_t* m_buffer;
+    //std::vector<float> m_pixels;
     // std::vector<uint8_t> m_pixels;
 
     void init()
@@ -218,9 +219,10 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
     }
 
     JxlBasicInfo info;
+    JxlPixelFormat format;
+    JxlDataType jxl_data_type;
+    TypeDesc m_data_type;
     // JxlPixelFormat format = { channels, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0 };
-    JxlPixelFormat format = { m_channels, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN,
-                              0 };
 
     for (;;) {
         JxlDecoderStatus status = JxlDecoderProcessInput(m_decoder.get());
@@ -239,11 +241,34 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
         } else if (status == JXL_DEC_BASIC_INFO) {
             DBG std::cout << "JXL_DEC_BASIC_INFO\n";
 
+            // Get the basic information about the image
             if (JXL_DEC_SUCCESS
                 != JxlDecoderGetBasicInfo(m_decoder.get(), &info)) {
                 errorfmt("JxlDecoderGetBasicInfo failed\n");
                 return false;
             }
+
+            // Need to check how we can support bfloat16 if jpegxl supports it
+            bool is_float = info.exponent_bits_per_sample > 0;
+
+            switch (info.bits_per_sample) {
+            case 8:
+                jxl_data_type = JXL_TYPE_UINT8;
+                m_data_type   = TypeDesc::UINT8;
+                break;
+            case 16:
+                jxl_data_type = is_float ? JXL_TYPE_FLOAT16 : JXL_TYPE_UINT16;
+                m_data_type   = is_float ? TypeDesc::HALF : TypeDesc::UINT16;
+                break;
+            case 32:
+                jxl_data_type = JXL_TYPE_FLOAT;
+                m_data_type   = TypeDesc::FLOAT;
+                break;
+            default: errorfmt("Unsupported bits per sample\n"); return false;
+            }
+
+            format = { m_channels, jxl_data_type, JXL_NATIVE_ENDIAN, 0 };
+
             format.num_channels = info.num_color_channels
                                   + info.num_extra_channels;
             m_channels = info.num_color_channels + info.num_extra_channels;
@@ -284,19 +309,25 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
                 return false;
             }
             if (buffer_size
-                != info.xsize * info.ysize * m_channels * sizeof(float)) {
+                != info.xsize * info.ysize * m_channels * info.bits_per_sample
+                       / 8) {
                 errorfmt("Invalid out buffer size {} {}\n", buffer_size,
-                         info.xsize * info.ysize * m_channels * sizeof(float));
+                         info.xsize * info.ysize * m_channels
+                             * info.bits_per_sample / 8);
                 return false;
             }
-            m_pixels.resize(info.xsize * info.ysize * m_channels);
-            void* pixels_buffer       = (void*)m_pixels.data();
-            size_t pixels_buffer_size = m_pixels.size() * sizeof(float);
+
+            //m_pixels.resize(info.xsize * info.ysize * m_channels);
+            //void* pixels_buffer       = (void*)m_pixels.data();
+            //size_t pixels_buffer_size = m_pixels.size() * info.bits_per_sample
+            //                          / 8;
             // size_t pixels_buffer_size = m_pixels.size() * sizeof(uint8_t);
+            // allocate buffer
+            m_buffer = new uint8_t[buffer_size];
+
             if (JXL_DEC_SUCCESS
                 != JxlDecoderSetImageOutBuffer(m_decoder.get(), &format,
-                                               pixels_buffer,
-                                               pixels_buffer_size)) {
+                                               m_buffer, buffer_size)) {
                 errorfmt("JxlDecoderSetImageOutBuffer failed\n");
                 return false;
             }
@@ -321,7 +352,7 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
         }
     }
 
-    m_spec = ImageSpec(info.xsize, info.ysize, m_channels, TypeDesc::FLOAT);
+    m_spec = ImageSpec(info.xsize, info.ysize, m_channels, m_data_type);
     // TypeDesc::UINT8);
     newspec = m_spec;
     return true;
@@ -334,7 +365,7 @@ JxlInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     DBG std::cout << "JxlInput::read_native_scanline(, , " << y << ")\n";
-    size_t scanline_size = m_spec.width * m_channels * sizeof(float);
+    size_t scanline_size = m_spec.width * m_channels * m_spec.channel_bytes();
     // size_t scanline_size = m_spec.width * m_channels * sizeof(uint8_t);
 
     lock_guard lock(*this);
@@ -343,8 +374,10 @@ JxlInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (y < 0 || y >= m_spec.height)  // out of range scanline
         return false;
 
-    memcpy(data, (void*)((uint8_t*)(m_pixels.data()) + y * scanline_size),
-           scanline_size);
+    //memcpy(data, (void*)((uint8_t*)(m_pixels.data()) + y * scanline_size),
+    //       scanline_size);
+    memcpy(data, (void*)(m_buffer + y * scanline_size),
+        		   scanline_size);
 
     return true;
 }

--- a/src/jpegxl.imageio/jxlinput.cpp
+++ b/src/jpegxl.imageio/jxlinput.cpp
@@ -65,6 +65,7 @@ private:
         m_config.reset();
         m_decoder = nullptr;
         m_runner  = nullptr;
+        m_buffer  = nullptr;
     }
 
     void close_file() { init(); }
@@ -380,6 +381,12 @@ JxlInput::close()
     if (ioproxy_opened()) {
         close_file();
     }
+
+    if (m_buffer) {
+        delete[] m_buffer;
+        m_buffer = nullptr;
+    }
+
     init();  // Reset to initial state
     return true;
 }

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -239,7 +239,7 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     }
 
     const int effort = m_spec.get_int_attribute("jpegxl:effort", 7);
-    const int speed   = m_spec.get_int_attribute("jpegxl:speed", 0);
+    const int speed  = m_spec.get_int_attribute("jpegxl:speed", 0);
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_EFFORT, effort);
 
@@ -254,8 +254,9 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
             m_spec.get_float_attribute("jpegxl:photon_noise_iso", 0.0f));
 
         DBG std::cout << "Photon noise set to "
-					  << m_spec.get_float_attribute(
-                          "jpegxl:photon_noise_iso", 0.0f) << "\n";
+                      << m_spec.get_float_attribute("jpegxl:photon_noise_iso",
+                                                    0.0f)
+                      << "\n";
     }
 
     // Codestream level should be chosen automatically given the settings

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -111,9 +111,11 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
 
     switch (m_spec.format.basetype) {
     case TypeDesc::UINT8:
-    case TypeDesc::UINT16:
+    case TypeDesc::UINT16: m_spec.set_format(m_spec.format); break;
+    case TypeDesc::UINT32: m_spec.set_format(TypeDesc::UINT16); break;
     case TypeDesc::HALF:
     case TypeDesc::FLOAT: m_spec.set_format(m_spec.format); break;
+    case TypeDesc::DOUBLE: m_spec.set_format(TypeDesc::FLOAT); break;
     default: errorfmt("Unsupported data type {}", m_spec.format); return false;
     }
 
@@ -163,6 +165,7 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
         m_basic_info.exponent_bits_per_sample = 0;
         break;
     case TypeDesc::UINT16:
+    case TypeDesc::UINT32:
         m_basic_info.bits_per_sample          = 16;
         m_basic_info.exponent_bits_per_sample = 0;
         break;
@@ -171,6 +174,7 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
         m_basic_info.exponent_bits_per_sample = 5;
         break;
     case TypeDesc::FLOAT:
+    case TypeDesc::DOUBLE:
         m_basic_info.bits_per_sample          = 32;
         m_basic_info.exponent_bits_per_sample = 8;
         break;
@@ -380,6 +384,7 @@ JxlOutput::save_image(const void* data)
         jxl_bytes = 1;
         break;
     case TypeDesc::UINT16:
+    case TypeDesc::UINT32:
         jxl_type  = JXL_TYPE_UINT16;
         jxl_bytes = 2;
         break;
@@ -388,6 +393,7 @@ JxlOutput::save_image(const void* data)
         jxl_bytes = 2;
         break;
     case TypeDesc::FLOAT:
+    case TypeDesc::DOUBLE:
         jxl_type  = JXL_TYPE_FLOAT;
         jxl_bytes = 4;
         break;

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -263,7 +263,7 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     JxlEncoderSetBasicInfo(m_encoder.get(), &m_basic_info);
 
     if (m_basic_info.num_extra_channels > 0) {
-        for (int i = 0; i < m_basic_info.num_extra_channels; i++) {
+        for (uint32_t i = 0; i < m_basic_info.num_extra_channels; i++) {
             JxlExtraChannelType type = JXL_CHANNEL_ALPHA;
             JxlExtraChannelInfo extra_channel_info;
 
@@ -351,9 +351,12 @@ JxlOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
                        int zend, TypeDesc format, const void* data,
                        stride_t xstride, stride_t ystride, stride_t zstride)
 {
-    // placeholder
+    DBG std::cout << "JxlOutput::write_tiles()\n";
 
-    return true;
+    // Call the parent class default implementation of write_tiles, which 
+    // will loop over the tiles and write each one individually.
+    return ImageOutput::write_tiles(xbegin, xend, ybegin, yend, zbegin, zend,
+                                    format, data, xstride, ystride, zstride);
 };
 
 

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -353,7 +353,7 @@ JxlOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
 {
     DBG std::cout << "JxlOutput::write_tiles()\n";
 
-    // Call the parent class default implementation of write_tiles, which 
+    // Call the parent class default implementation of write_tiles, which
     // will loop over the tiles and write each one individually.
     return ImageOutput::write_tiles(xbegin, xend, ybegin, yend, zbegin, zend,
                                     format, data, xstride, ystride, zstride);

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -17,7 +17,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-#define DBG if (1)
+#define DBG if (0)
 
 class JxlOutput final : public ImageOutput {
 public:

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -17,7 +17,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-#define DBG if (0)
+#define DBG if (1)
 
 class JxlOutput final : public ImageOutput {
 public:
@@ -40,6 +40,10 @@ public:
     bool write_tile(int x, int y, int z, TypeDesc format, const void* data,
                     stride_t xstride, stride_t ystride,
                     stride_t zstride) override;
+    bool write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                     int zend, TypeDesc format, const void* data,
+                     stride_t xstride, stride_t ystride,
+                     stride_t zstride) override;
     bool close() override;
 
 private:
@@ -49,11 +53,11 @@ private:
     JxlBasicInfo m_basic_info;
     JxlEncoderFrameSettings* m_frame_settings;
     JxlPixelFormat m_pixel_format;
-
+    
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
     std::vector<unsigned char> m_tilebuffer;
-    std::vector<float> m_pixels;
+    std::vector<unsigned char> m_scanbuffer; // hack
 
     void init(void)
     {
@@ -62,7 +66,7 @@ private:
         m_runner  = nullptr;
     }
 
-    bool save_image();
+    bool save_image(const void* data);
 };
 
 
@@ -105,7 +109,13 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
         return false;
     }
 
-    m_spec.set_format(TypeFloat);
+    switch (m_spec.format.basetype) {
+    case TypeDesc::UINT8:
+    case TypeDesc::UINT16:
+    case TypeDesc::HALF:
+    case TypeDesc::FLOAT: m_spec.set_format(m_spec.format); break;
+    default: errorfmt("Unsupported data type {}", m_spec.format); return false;
+    }
 
     m_dither = (m_spec.format == TypeDesc::UINT8)
                    ? m_spec.get_int_attribute("oiio:dither", 0)
@@ -144,11 +154,28 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
 
     DBG std::cout << "m_spec " << m_spec.width << "×" << m_spec.height << "×"
                   << m_spec.nchannels << "\n";
-    m_basic_info.xsize           = m_spec.width;
-    m_basic_info.ysize           = m_spec.height;
-    m_basic_info.bits_per_sample = 32;
-    // m_basic_info.exponent_bits_per_sample = 0;
-    m_basic_info.exponent_bits_per_sample = 8;
+    m_basic_info.xsize = m_spec.width;
+    m_basic_info.ysize = m_spec.height;
+
+    switch (m_spec.format.basetype) {
+    case TypeDesc::UINT8:
+        m_basic_info.bits_per_sample          = 8;
+        m_basic_info.exponent_bits_per_sample = 0;
+        break;
+    case TypeDesc::UINT16:
+        m_basic_info.bits_per_sample          = 16;
+        m_basic_info.exponent_bits_per_sample = 0;
+        break;
+    case TypeDesc::HALF:
+        m_basic_info.bits_per_sample          = 16;
+        m_basic_info.exponent_bits_per_sample = 5;
+        break;
+    case TypeDesc::FLOAT:
+        m_basic_info.bits_per_sample          = 32;
+        m_basic_info.exponent_bits_per_sample = 8;
+        break;
+    default: errorfmt("Unsupported data type {}", m_spec.format); return false;
+    }
 
     if (m_spec.nchannels >= 4) {
         m_basic_info.num_color_channels = 3;
@@ -165,23 +192,71 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
 
     m_frame_settings = JxlEncoderFrameSettingsCreate(m_encoder.get(), nullptr);
 
-    // const float quality = 100.0;
-    const int effort = 7;
-    const int tier   = 0;
-    // Lossless only makes sense for integer modes
-    if (m_basic_info.exponent_bits_per_sample == 0) {
-        // Must preserve original profile for lossless mode
-        m_basic_info.uses_original_profile = JXL_TRUE;
-        JxlEncoderSetFrameDistance(m_frame_settings, 0.0);
-        JxlEncoderSetFrameLossless(m_frame_settings, JXL_TRUE);
+    // JpegXL Compression Settings
+    
+    bool lossless = true;
+     
+    // Distance Mutually exclusive with quality
+    if (m_spec.find_attribute("jpegxl:distance")) {
+        const float distance = 
+            m_spec.get_float_attribute("jpegxl:distance", 0.0f);
+
+        m_basic_info.uses_original_profile = distance == 0.0f ? JXL_TRUE
+                                                              : JXL_FALSE;
+        JxlEncoderSetFrameDistance(m_frame_settings, distance);
+        JxlEncoderSetFrameLossless(m_frame_settings,
+                                   distance == 0.0f ? JXL_TRUE : JXL_FALSE);
+
+        lossless = distance == 0.0f;
+
+        DBG std::cout << "Compression distance set to " << distance << "\n";
+
+    } else {
+        auto compqual = m_spec.decode_compression_metadata("jpegxl", 100);
+        if (Strutil::iequals(compqual.first, "jpegxl")) {
+            if (compqual.second == 100) {
+                m_basic_info.uses_original_profile = JXL_TRUE;
+                JxlEncoderSetFrameDistance(m_frame_settings, 0.0);
+                JxlEncoderSetFrameLossless(m_frame_settings, JXL_TRUE);
+
+                lossless = true;
+            } else {
+                m_basic_info.uses_original_profile = JXL_FALSE;
+                JxlEncoderSetFrameDistance(
+                    m_frame_settings,
+                    1.0f / static_cast<float>(compqual.second));
+                JxlEncoderSetFrameLossless(m_frame_settings, JXL_FALSE);
+            }
+        } else {  // default to lossless
+            m_basic_info.uses_original_profile = JXL_TRUE;
+            JxlEncoderSetFrameDistance(m_frame_settings, 0.0);
+            JxlEncoderSetFrameLossless(m_frame_settings, JXL_TRUE);
+
+            lossless = true;
+        }
+
+        DBG std::cout << "compression set to " << compqual.second << "\n";
     }
 
+    const int effort = m_spec.get_int_attribute("jpegxl:effort", 7);
+    const int tier   = m_spec.get_int_attribute("jpegxl:tier", 0);
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_EFFORT, effort);
 
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_DECODING_SPEED,
                                      tier);
+
+    // Preprocessing (maybe not works yet)
+    if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
+        JxlEncoderFrameSettingsSetOption(
+            m_frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE,
+            m_spec.get_float_attribute("jpegxl:photon_noise_iso", 0.0f));
+
+        DBG std::cout << "Photon noise set to "
+					  << m_spec.get_float_attribute(
+                          "jpegxl:photon_noise_iso", 0.0f) << "\n";
+    }
 
     // Codestream level should be chosen automatically given the settings
     JxlEncoderSetBasicInfo(m_encoder.get(), &m_basic_info);
@@ -248,10 +323,11 @@ JxlOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
     DBG std::cout << "data = " << data << " nvals = " << nvals << "\n";
 
-    std::vector<float>::iterator m_it
-        = m_pixels.begin() + m_spec.width * ybegin * m_spec.nchannels;
+    // add data to m_scanbuffer
+    m_scanbuffer.insert(m_scanbuffer.end(), (unsigned char*)data,
+        				(unsigned char*)data + nvals * m_spec.format.size());
 
-    m_pixels.insert(m_it, (float*)data, (float*)data + nvals);
+    //save_image(data);
 
     return true;
 }
@@ -272,27 +348,61 @@ JxlOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
 
 
 bool
-JxlOutput::save_image()
+JxlOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                       int zend, TypeDesc format, const void* data,
+                       stride_t xstride, stride_t ystride, stride_t zstride)
+{
+    // placeholder
+
+    return true;
+};
+
+
+
+bool
+JxlOutput::save_image(const void* data)
 {
     JxlEncoderStatus status;
     JxlEncoderError error;
     std::vector<uint8_t> compressed;
     bool ok = true;
 
+    JxlDataType jxl_type = JXL_TYPE_FLOAT;
+    size_t jxl_bytes = 1;
+
     DBG std::cout << "JxlOutput::save_image()\n";
 
+    switch (m_spec.format.basetype) {
+        case TypeDesc::UINT8:
+			jxl_type = JXL_TYPE_UINT8;
+            jxl_bytes = 1;
+			break;
+        case TypeDesc::UINT16:
+            jxl_type = JXL_TYPE_UINT16;
+            jxl_bytes = 2;
+            break;
+        case TypeDesc::HALF:
+            jxl_type = JXL_TYPE_FLOAT16;
+            jxl_bytes = 2;
+			break;
+        case TypeDesc::FLOAT:
+			jxl_type = JXL_TYPE_FLOAT;
+            jxl_bytes = 4;
+			break;
+		default:
+			errorfmt("Unsupported data type {}", m_spec.format);
+			return false;
+    }
+
     m_pixel_format = { m_basic_info.num_color_channels
-                           + m_basic_info.num_extra_channels,
-                       JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
+                       + m_basic_info.num_extra_channels,
+                       jxl_type, JXL_NATIVE_ENDIAN, 0 };
 
     const size_t pixels_size = m_basic_info.xsize * m_basic_info.ysize
                                * (m_basic_info.num_color_channels
-                                  + m_basic_info.num_extra_channels);
+                               + m_basic_info.num_extra_channels);
 
-    m_pixels.resize(pixels_size);
-
-    const void* data = m_pixels.data();
-    size_t size      = m_pixels.size() * sizeof(float);
+    size_t size = pixels_size * jxl_bytes;
 
     DBG std::cout << "data = " << data << " size = " << size << "\n";
 
@@ -365,7 +475,8 @@ JxlOutput::close()
         std::vector<unsigned char>().swap(m_tilebuffer);
     }
 
-    save_image();
+    //save_image();
+    save_image(m_scanbuffer.data());
 
     init();
     return ok;

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -279,7 +279,7 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
 
     // Preprocessing (maybe not works yet)
     if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
-        JxlEncoderFrameSettingsSetOption(
+        JxlEncoderFrameSettingsSetFloatOption(
             m_frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE,
             m_spec.get_float_attribute("jpegxl:photon_noise_iso", 0.0f));
 

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -53,11 +53,11 @@ private:
     JxlBasicInfo m_basic_info;
     JxlEncoderFrameSettings* m_frame_settings;
     JxlPixelFormat m_pixel_format;
-    
+
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
     std::vector<unsigned char> m_tilebuffer;
-    std::vector<unsigned char> m_scanbuffer; // hack
+    std::vector<unsigned char> m_scanbuffer;  // hack
 
     void init(void)
     {
@@ -193,13 +193,13 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     m_frame_settings = JxlEncoderFrameSettingsCreate(m_encoder.get(), nullptr);
 
     // JpegXL Compression Settings
-    
+
     bool lossless = true;
-     
+
     // Distance Mutually exclusive with quality
     if (m_spec.find_attribute("jpegxl:distance")) {
-        const float distance = 
-            m_spec.get_float_attribute("jpegxl:distance", 0.0f);
+        const float distance = m_spec.get_float_attribute("jpegxl:distance",
+                                                          0.0f);
 
         m_basic_info.uses_original_profile = distance == 0.0f ? JXL_TRUE
                                                               : JXL_FALSE;
@@ -239,13 +239,13 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     }
 
     const int effort = m_spec.get_int_attribute("jpegxl:effort", 7);
-    const int tier   = m_spec.get_int_attribute("jpegxl:tier", 0);
+    const int speed   = m_spec.get_int_attribute("jpegxl:speed", 0);
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_EFFORT, effort);
 
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_DECODING_SPEED,
-                                     tier);
+                                     speed);
 
     // Preprocessing (maybe not works yet)
     if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
@@ -325,9 +325,7 @@ JxlOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
     // add data to m_scanbuffer
     m_scanbuffer.insert(m_scanbuffer.end(), (unsigned char*)data,
-        				(unsigned char*)data + nvals * m_spec.format.size());
-
-    //save_image(data);
+                        (unsigned char*)data + nvals * m_spec.format.size());
 
     return true;
 }
@@ -368,39 +366,37 @@ JxlOutput::save_image(const void* data)
     bool ok = true;
 
     JxlDataType jxl_type = JXL_TYPE_FLOAT;
-    size_t jxl_bytes = 1;
+    size_t jxl_bytes     = 1;
 
     DBG std::cout << "JxlOutput::save_image()\n";
 
     switch (m_spec.format.basetype) {
-        case TypeDesc::UINT8:
-			jxl_type = JXL_TYPE_UINT8;
-            jxl_bytes = 1;
-			break;
-        case TypeDesc::UINT16:
-            jxl_type = JXL_TYPE_UINT16;
-            jxl_bytes = 2;
-            break;
-        case TypeDesc::HALF:
-            jxl_type = JXL_TYPE_FLOAT16;
-            jxl_bytes = 2;
-			break;
-        case TypeDesc::FLOAT:
-			jxl_type = JXL_TYPE_FLOAT;
-            jxl_bytes = 4;
-			break;
-		default:
-			errorfmt("Unsupported data type {}", m_spec.format);
-			return false;
+    case TypeDesc::UINT8:
+        jxl_type  = JXL_TYPE_UINT8;
+        jxl_bytes = 1;
+        break;
+    case TypeDesc::UINT16:
+        jxl_type  = JXL_TYPE_UINT16;
+        jxl_bytes = 2;
+        break;
+    case TypeDesc::HALF:
+        jxl_type  = JXL_TYPE_FLOAT16;
+        jxl_bytes = 2;
+        break;
+    case TypeDesc::FLOAT:
+        jxl_type  = JXL_TYPE_FLOAT;
+        jxl_bytes = 4;
+        break;
+    default: errorfmt("Unsupported data type {}", m_spec.format); return false;
     }
 
     m_pixel_format = { m_basic_info.num_color_channels
-                       + m_basic_info.num_extra_channels,
+                           + m_basic_info.num_extra_channels,
                        jxl_type, JXL_NATIVE_ENDIAN, 0 };
 
     const size_t pixels_size = m_basic_info.xsize * m_basic_info.ysize
                                * (m_basic_info.num_color_channels
-                               + m_basic_info.num_extra_channels);
+                                  + m_basic_info.num_extra_channels);
 
     size_t size = pixels_size * jxl_bytes;
 

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -53,15 +53,11 @@ private:
     JxlBasicInfo m_basic_info;
     JxlEncoderFrameSettings* m_frame_settings;
     JxlPixelFormat m_pixel_format;
-    
+
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
     std::vector<unsigned char> m_tilebuffer;
-<<<<<<< HEAD
     std::vector<unsigned char> m_scanbuffer;  // hack
-=======
-    std::vector<unsigned char> m_scanbuffer; // hack
->>>>>>> 3ab245d07 (JpegXL output plugin)
 
     void init(void)
     {
@@ -197,7 +193,6 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     m_frame_settings = JxlEncoderFrameSettingsCreate(m_encoder.get(), nullptr);
 
     // JpegXL Compression Settings
-<<<<<<< HEAD
 
     bool lossless = true;
 
@@ -205,15 +200,6 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     if (m_spec.find_attribute("jpegxl:distance")) {
         const float distance = m_spec.get_float_attribute("jpegxl:distance",
                                                           0.0f);
-=======
-    
-    bool lossless = true;
-     
-    // Distance Mutually exclusive with quality
-    if (m_spec.find_attribute("jpegxl:distance")) {
-        const float distance = 
-            m_spec.get_float_attribute("jpegxl:distance", 0.0f);
->>>>>>> 3ab245d07 (JpegXL output plugin)
 
         m_basic_info.uses_original_profile = distance == 0.0f ? JXL_TRUE
                                                               : JXL_FALSE;
@@ -253,29 +239,13 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     }
 
     const int effort = m_spec.get_int_attribute("jpegxl:effort", 7);
-<<<<<<< HEAD
-    const int speed  = m_spec.get_int_attribute("jpegxl:speed", 0);
-=======
-    const int tier   = m_spec.get_int_attribute("jpegxl:tier", 0);
->>>>>>> 3ab245d07 (JpegXL output plugin)
+    const int speed   = m_spec.get_int_attribute("jpegxl:speed", 0);
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_EFFORT, effort);
 
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_DECODING_SPEED,
                                      speed);
-
-    // Preprocessing (maybe not works yet)
-    if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
-        JxlEncoderFrameSettingsSetFloatOption(
-            m_frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE,
-            m_spec.get_float_attribute("jpegxl:photon_noise_iso", 0.0f));
-
-        DBG std::cout << "Photon noise set to "
-                      << m_spec.get_float_attribute("jpegxl:photon_noise_iso",
-                                                    0.0f)
-                      << "\n";
-    }
 
     // Preprocessing (maybe not works yet)
     if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
@@ -355,13 +325,7 @@ JxlOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
     // add data to m_scanbuffer
     m_scanbuffer.insert(m_scanbuffer.end(), (unsigned char*)data,
-<<<<<<< HEAD
                         (unsigned char*)data + nvals * m_spec.format.size());
-=======
-        				(unsigned char*)data + nvals * m_spec.format.size());
-
-    //save_image(data);
->>>>>>> 3ab245d07 (JpegXL output plugin)
 
     return true;
 }
@@ -402,16 +366,11 @@ JxlOutput::save_image(const void* data)
     bool ok = true;
 
     JxlDataType jxl_type = JXL_TYPE_FLOAT;
-<<<<<<< HEAD
     size_t jxl_bytes     = 1;
-=======
-    size_t jxl_bytes = 1;
->>>>>>> 3ab245d07 (JpegXL output plugin)
 
     DBG std::cout << "JxlOutput::save_image()\n";
 
     switch (m_spec.format.basetype) {
-<<<<<<< HEAD
     case TypeDesc::UINT8:
         jxl_type  = JXL_TYPE_UINT8;
         jxl_bytes = 1;
@@ -433,36 +392,11 @@ JxlOutput::save_image(const void* data)
 
     m_pixel_format = { m_basic_info.num_color_channels
                            + m_basic_info.num_extra_channels,
-=======
-        case TypeDesc::UINT8:
-			jxl_type = JXL_TYPE_UINT8;
-            jxl_bytes = 1;
-			break;
-        case TypeDesc::UINT16:
-            jxl_type = JXL_TYPE_UINT16;
-            jxl_bytes = 2;
-            break;
-        case TypeDesc::HALF:
-            jxl_type = JXL_TYPE_FLOAT16;
-            jxl_bytes = 2;
-			break;
-        case TypeDesc::FLOAT:
-			jxl_type = JXL_TYPE_FLOAT;
-            jxl_bytes = 4;
-			break;
-		default:
-			errorfmt("Unsupported data type {}", m_spec.format);
-			return false;
-    }
-
-    m_pixel_format = { m_basic_info.num_color_channels
-                       + m_basic_info.num_extra_channels,
->>>>>>> 3ab245d07 (JpegXL output plugin)
                        jxl_type, JXL_NATIVE_ENDIAN, 0 };
 
     const size_t pixels_size = m_basic_info.xsize * m_basic_info.ysize
                                * (m_basic_info.num_color_channels
-                               + m_basic_info.num_extra_channels);
+                                  + m_basic_info.num_extra_channels);
 
     size_t size = pixels_size * jxl_bytes;
 

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -17,7 +17,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-#define DBG if (0)
+#define DBG if (1)
 
 class JxlOutput final : public ImageOutput {
 public:
@@ -53,11 +53,15 @@ private:
     JxlBasicInfo m_basic_info;
     JxlEncoderFrameSettings* m_frame_settings;
     JxlPixelFormat m_pixel_format;
-
+    
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
     std::vector<unsigned char> m_tilebuffer;
+<<<<<<< HEAD
     std::vector<unsigned char> m_scanbuffer;  // hack
+=======
+    std::vector<unsigned char> m_scanbuffer; // hack
+>>>>>>> 3ab245d07 (JpegXL output plugin)
 
     void init(void)
     {
@@ -193,6 +197,7 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     m_frame_settings = JxlEncoderFrameSettingsCreate(m_encoder.get(), nullptr);
 
     // JpegXL Compression Settings
+<<<<<<< HEAD
 
     bool lossless = true;
 
@@ -200,6 +205,15 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     if (m_spec.find_attribute("jpegxl:distance")) {
         const float distance = m_spec.get_float_attribute("jpegxl:distance",
                                                           0.0f);
+=======
+    
+    bool lossless = true;
+     
+    // Distance Mutually exclusive with quality
+    if (m_spec.find_attribute("jpegxl:distance")) {
+        const float distance = 
+            m_spec.get_float_attribute("jpegxl:distance", 0.0f);
+>>>>>>> 3ab245d07 (JpegXL output plugin)
 
         m_basic_info.uses_original_profile = distance == 0.0f ? JXL_TRUE
                                                               : JXL_FALSE;
@@ -239,7 +253,11 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
     }
 
     const int effort = m_spec.get_int_attribute("jpegxl:effort", 7);
+<<<<<<< HEAD
     const int speed  = m_spec.get_int_attribute("jpegxl:speed", 0);
+=======
+    const int tier   = m_spec.get_int_attribute("jpegxl:tier", 0);
+>>>>>>> 3ab245d07 (JpegXL output plugin)
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_EFFORT, effort);
 
@@ -257,6 +275,17 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
                       << m_spec.get_float_attribute("jpegxl:photon_noise_iso",
                                                     0.0f)
                       << "\n";
+    }
+
+    // Preprocessing (maybe not works yet)
+    if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
+        JxlEncoderFrameSettingsSetOption(
+            m_frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE,
+            m_spec.get_float_attribute("jpegxl:photon_noise_iso", 0.0f));
+
+        DBG std::cout << "Photon noise set to "
+					  << m_spec.get_float_attribute(
+                          "jpegxl:photon_noise_iso", 0.0f) << "\n";
     }
 
     // Codestream level should be chosen automatically given the settings
@@ -326,7 +355,13 @@ JxlOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
     // add data to m_scanbuffer
     m_scanbuffer.insert(m_scanbuffer.end(), (unsigned char*)data,
+<<<<<<< HEAD
                         (unsigned char*)data + nvals * m_spec.format.size());
+=======
+        				(unsigned char*)data + nvals * m_spec.format.size());
+
+    //save_image(data);
+>>>>>>> 3ab245d07 (JpegXL output plugin)
 
     return true;
 }
@@ -367,11 +402,16 @@ JxlOutput::save_image(const void* data)
     bool ok = true;
 
     JxlDataType jxl_type = JXL_TYPE_FLOAT;
+<<<<<<< HEAD
     size_t jxl_bytes     = 1;
+=======
+    size_t jxl_bytes = 1;
+>>>>>>> 3ab245d07 (JpegXL output plugin)
 
     DBG std::cout << "JxlOutput::save_image()\n";
 
     switch (m_spec.format.basetype) {
+<<<<<<< HEAD
     case TypeDesc::UINT8:
         jxl_type  = JXL_TYPE_UINT8;
         jxl_bytes = 1;
@@ -393,11 +433,36 @@ JxlOutput::save_image(const void* data)
 
     m_pixel_format = { m_basic_info.num_color_channels
                            + m_basic_info.num_extra_channels,
+=======
+        case TypeDesc::UINT8:
+			jxl_type = JXL_TYPE_UINT8;
+            jxl_bytes = 1;
+			break;
+        case TypeDesc::UINT16:
+            jxl_type = JXL_TYPE_UINT16;
+            jxl_bytes = 2;
+            break;
+        case TypeDesc::HALF:
+            jxl_type = JXL_TYPE_FLOAT16;
+            jxl_bytes = 2;
+			break;
+        case TypeDesc::FLOAT:
+			jxl_type = JXL_TYPE_FLOAT;
+            jxl_bytes = 4;
+			break;
+		default:
+			errorfmt("Unsupported data type {}", m_spec.format);
+			return false;
+    }
+
+    m_pixel_format = { m_basic_info.num_color_channels
+                       + m_basic_info.num_extra_channels,
+>>>>>>> 3ab245d07 (JpegXL output plugin)
                        jxl_type, JXL_NATIVE_ENDIAN, 0 };
 
     const size_t pixels_size = m_basic_info.xsize * m_basic_info.ysize
                                * (m_basic_info.num_color_channels
-                                  + m_basic_info.num_extra_channels);
+                               + m_basic_info.num_extra_channels);
 
     size_t size = pixels_size * jxl_bytes;
 

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -249,7 +249,7 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
 
     // Preprocessing (maybe not works yet)
     if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
-        JxlEncoderFrameSettingsSetOption(
+        JxlEncoderFrameSettingsSetFloatOption(
             m_frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE,
             m_spec.get_float_attribute("jpegxl:photon_noise_iso", 0.0f));
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -59,7 +59,7 @@ function (setup_oiio_util_library targetname)
                 ${OPENIMAGEIO_IMATH_TARGETS}
             PRIVATE
                 $<TARGET_NAME_IF_EXISTS:TBB::tbb>
-                # ${CMAKE_DL_LIBS}
+                ${CMAKE_DL_LIBS}
             )
 
     if (GCC_VERSION VERSION_GREATER_EQUAL 12.0

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -204,9 +204,8 @@ PNMInput::read_file_scanline(void* data, int y)
     // If y is farther ahead, skip scanlines to get to it
     for (; good && m_y_next <= y; ++m_y_next) {
         // PFM files are bottom-to-top, so we need to seek to the right spot
-        int flp = m_spec.get_int_attribute("pnm:pfmflip", 0);
-        if (flp == 1) {
-            if (m_pnm_type == PF || m_pnm_type == Pf) {
+        if (m_pnm_type == PF || m_pnm_type == Pf) {
+            if (m_spec.get_int_attribute("pnm:pfmflip", 1) == 1) {
                 int file_scanline = m_spec.height - 1 - (y - m_spec.y);
                 auto offset       = file_scanline * m_spec.scanline_bytes();
                 m_remaining       = m_after_header.substr(offset);

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
-#include <cstdio>
 #include <string>
 
 #include <OpenImageIO/filesystem.h>
@@ -13,7 +13,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-#define DBG if (1)
+#define DBG if (0)
 
 //
 // Documentation on the PNM formats can be found at:
@@ -203,9 +203,8 @@ PNMInput::read_file_scanline(void* data, int y)
     bool good    = true;
     // If y is farther ahead, skip scanlines to get to it
     for (; good && m_y_next <= y; ++m_y_next) {
-
         // PFM files are bottom-to-top, so we need to seek to the right spot
-        int flp = m_spec.get_int_attribute("pnm:pfmflip", 1);
+        int flp = m_spec.get_int_attribute("pnm:pfmflip", 0);
         if (flp == 1) {
             if (m_pnm_type == PF || m_pnm_type == Pf) {
                 int file_scanline = m_spec.height - 1 - (y - m_spec.y);

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -191,6 +191,7 @@ unpack_floats(const unsigned char* read, float* write, imagesize_t numsamples,
 bool
 PNMInput::read_file_scanline(void* data, int y)
 {
+    DBG std::cerr << "PNMInput::read_file_scanline(" << y << ")\n";
     if (y < m_y_next) {
         // If being asked to backtrack to an earlier scanline, reset all the
         // way to the beginning, right after the header.
@@ -319,6 +320,7 @@ PNMInput::read_file_header()
         int bps = int(ceilf(logf(m_max_val + 1) / logf(2)));
         if (bps < 8)
             m_spec.attribute("oiio:BitsPerSample", bps);
+        m_spec.attribute("pnm:pfmflip", 0);
     } else {
         //Read scaling factor
         if (!nextVal(m_scaling_factor))
@@ -333,6 +335,7 @@ PNMInput::read_file_header()
         m_spec = ImageSpec(width, height, m_pnm_type == PF ? 3 : 1,
                            TypeDesc::FLOAT);
         m_spec.attribute("pnm:bigendian", m_scaling_factor < 0 ? 0 : 1);
+        m_spec.attribute("pnm:binary", 1);
     }
     m_spec.attribute("oiio:ColorSpace", "Rec709");
     return true;

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
-#include <fstream>
 #include <cstdio>
+#include <fstream>
 
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>
@@ -245,7 +245,7 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
     
     if (m_pnm_type != 1 && m_pnm_type != 4) {  // only non-monochrome
         if (m_pfn_type == "")
-			ok &= iowritefmt("{}\n", m_max_val);
+            ok &= iowritefmt("{}\n", m_max_val);
         else
             ok &= iowritefmt("{}\n", "-1.0000");
     }

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -340,7 +340,8 @@ PNMOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 {
     DBG std::cerr << "PNMOutput::write_scanlines()\n";
 
-    if (m_spec.get_int_attribute("pnm:pfmflip", 1) == 1) {
+    if (m_spec.get_int_attribute("pnm:pfmflip", 1) == 1
+        && format == TypeDesc::FLOAT) {
         DBG std::cerr << "Flipping PFM vertically\n";
 
         // Default implementation: write each scanline individually

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -247,7 +247,7 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
         if (m_pfn_type == "")
 			ok &= iowritefmt("{}\n", m_max_val);
         else
-            ok &= iowritefmt("{}\n", "-1.0");
+            ok &= iowritefmt("{}\n", "-1.0000");
     }
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -159,7 +159,7 @@ PNMOutput::write_float(const float* data, const stride_t stride)
         for (int c = 0; c < nc; c++) {
             float val = data[pixel + c];
             if (big)
-                swap_endian(&val, 4);
+                swap_endian(&val, 1);
             if (!iowrite(&val, sizeof(val)))
                 return false;
         }

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -242,7 +242,7 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
     }
 
     ok &= iowritefmt("{} {}\n", m_spec.width, m_spec.height);
-    
+
 
     if (m_pnm_type != 1 && m_pnm_type != 4) {  // only non-monochrome
         if (m_pfn_type == "")

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -243,6 +243,7 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
 
     ok &= iowritefmt("{} {}\n", m_spec.width, m_spec.height);
     
+
     if (m_pnm_type != 1 && m_pnm_type != 4) {  // only non-monochrome
         if (m_pfn_type == "")
             ok &= iowritefmt("{}\n", m_max_val);

--- a/testsuite/pnm/ref/out.txt
+++ b/testsuite/pnm/ref/out.txt
@@ -5,6 +5,7 @@ src/bw-ascii.pbm     :   16 x   16, 1 channel, uint1 pnm
     oiio:BitsPerSample: 1
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/bw-ascii.pbm" and "bw-ascii.pbm"
 PASS
 Reading src/bw-binary.pbm
@@ -14,6 +15,7 @@ src/bw-binary.pbm    :   32 x   32, 1 channel, uint1 pnm
     oiio:BitsPerSample: 1
     oiio:ColorSpace: "Rec709"
     pnm:binary: 1
+    pnm:pfmflip: 1
 Comparing "src/bw-binary.pbm" and "bw-binary.pbm"
 PASS
 Reading src/grey-ascii.pgm
@@ -22,6 +24,7 @@ src/grey-ascii.pgm   :   16 x   16, 1 channel, uint8 pnm
     channel list: Y
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/grey-ascii.pgm" and "grey-ascii.pgm"
 PASS
 Reading src/grey-binary.pgm
@@ -30,6 +33,7 @@ src/grey-binary.pgm  :   32 x   32, 1 channel, uint8 pnm
     channel list: Y
     oiio:ColorSpace: "Rec709"
     pnm:binary: 1
+    pnm:pfmflip: 1
 Comparing "src/grey-binary.pgm" and "grey-binary.pgm"
 PASS
 Reading src/rgb-ascii.ppm
@@ -38,6 +42,7 @@ src/rgb-ascii.ppm    :   16 x   16, 3 channel, uint8 pnm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/rgb-ascii.ppm" and "rgb-ascii.ppm"
 PASS
 Reading src/rgb-binary.ppm
@@ -46,6 +51,7 @@ src/rgb-binary.ppm   :   32 x   32, 3 channel, uint8 pnm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/rgb-binary.ppm" and "rgb-binary.ppm"
 PASS
 Reading ../oiio-images/pnm/test-1.pfm
@@ -54,15 +60,18 @@ Reading ../oiio-images/pnm/test-1.pfm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-2.pfm
 ../oiio-images/pnm/test-2.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 312B084985EF1B9C20D35A9D7A5DC8E8EAEB25A0
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-3.pfm
 ../oiio-images/pnm/test-3.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 613A9639725F51ADC8B6F8F5A38DB5EFF0B3A628
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 1
+    pnm:pfmflip: 1

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -138,7 +138,7 @@ if int(os.getenv('TESTSUITE_CLEANUP_ON_SUCCESS', '0')) :
 
 image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla",
                      ".dpx", ".iff", ".psd", ".bmp", ".fits", ".ico",
-                     ".jp2", ".sgi", ".tga", ".TGA", ".zfile" ]
+                     ".jp2", ".jxl", ".sgi", ".tga", ".TGA", ".zfile" ]
 
 # print ("srcdir = " + srcdir)
 # print ("tmpdir = " + tmpdir)


### PR DESCRIPTION
## Description

Proper support for NetPBM 8/16/32 float files for import and export

## Tests

tests updated


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
