### PR TITLE
Jpegxl

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1195,6 +1195,94 @@ the `set_ioproxy()` methods.
 
 |
 
+.. _sec-bundledplugins-jpegxl:
+
+JPEG XL
+===============================================
+
+JPEG XL is a new image format that is designed to be a successor to JPEG
+and to provide better compression and quality. JPEG XL files use the file
+extension :file:`.jxl`. The official JPEG XL format specification and other
+helpful info may be found at: https://jpeg.org/jpegxl/
+
+**Configuration settings for JPEG XL input**
+
+When opening a JPEG XL ImageInput with a *configuration* (see
+Section :ref:`sec-input with-config`), the following special configuration
+attributes are supported:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Input Configuration Attribute
+     - Type
+     - Meaning
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.
+       
+**Configuration settings for JPEG XL output**
+
+When opening a JPEG XL ImageOutput, the following special metadata tokens
+control aspects of the writing itself:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Output Configuration Attribute
+	 - Type
+	 - JPEG XL header data or explanation
+   * - ``oiio:dither``
+     - int
+     - If nonzero and outputting UINT8 values in the file from a source of
+       higher bit depth, will add a small amount of random dither to combat
+       the appearance of banding.
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by writing to a memory buffer.
+   * - ``oiio:UnassociatedAlpha``
+     - int
+     - If nonzero, indicates that the data being passed is already in
+       unassociated form (non-premultiplied colors) and should stay that way
+       for output rather than being assumed to be associated and get automatic
+       un-association to store in the file.
+   * - ``compression``
+	 - string
+	 - If supplied, must be ``"jpegxl"``, but may optionally have a quality
+	   value appended, like ``"jpegxl:90"``. Quality can be 0-100, with 100
+	   meaning lossless.
+   * - ``jpegxl:distance``
+	 - float
+     - Target visual distance in JND units, lower = higher quality.
+       0.0 = mathematically lossless. 1.0 = visually lossless.
+       Recommended range: 0.5 .. 3.0. Allowed range: 0.0 ... 25.0. 
+       Mutually exclusive with ``*compression jpegxl:*```.
+   * - ``jpegxl:effort``
+     - int
+	 - Encoder effort setting. Range: 1 .. 10.
+       Default: 7. Higher numbers allow more computation at the expense of time.
+       For lossless, generally it will produce smaller files.
+       For lossy, higher effort should more accurately reach the target quality.
+   * - ``jpegxl:speed``
+     - int
+     - Sets the encoding speed tier for the provided options. Minimum is 0
+       (slowest to encode, best quality/density), and maximum is 4 (fastest to
+       encode, at the cost of some quality/density). Default is 0.
+       (Note: in libjxl it named JXL_ENC_FRAME_SETTING_DECODING_SPEED. But it
+       is about encoding speed and compression quality, not decoding speed.)
+   * - ``jpegxl:photon_noise_iso``
+     - float
+     - (ISO_FILM_SPEED) Adds noise to the image emulating photographic film or
+       sensor noise. Higher number = grainier image, e.g. 100 gives a low
+       amount of noise, 3200 gives a lot of noise. Default is 0.
+       Encoded as metadata in the image.
+
+|
+
 .. _sec-bundledplugins-ffmpeg:
 
 Movie formats (using ffmpeg)

--- a/src/jpegxl.imageio/jxlinput.cpp
+++ b/src/jpegxl.imageio/jxlinput.cpp
@@ -57,8 +57,7 @@ private:
     JxlResizableParallelRunnerPtr m_runner;
     std::unique_ptr<ImageSpec> m_config;  // Saved copy of configuration spec
     std::vector<uint8_t> m_icc_profile;
-    std::vector<float> m_pixels;
-    // std::vector<uint8_t> m_pixels;
+    uint8_t* m_buffer;
 
     void init()
     {
@@ -66,6 +65,7 @@ private:
         m_config.reset();
         m_decoder = nullptr;
         m_runner  = nullptr;
+        m_buffer  = nullptr;
     }
 
     void close_file() { init(); }
@@ -218,9 +218,9 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
     }
 
     JxlBasicInfo info;
-    // JxlPixelFormat format = { channels, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0 };
-    JxlPixelFormat format = { m_channels, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN,
-                              0 };
+    JxlPixelFormat format;
+    JxlDataType jxl_data_type;
+    TypeDesc m_data_type;
 
     for (;;) {
         JxlDecoderStatus status = JxlDecoderProcessInput(m_decoder.get());
@@ -239,11 +239,34 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
         } else if (status == JXL_DEC_BASIC_INFO) {
             DBG std::cout << "JXL_DEC_BASIC_INFO\n";
 
+            // Get the basic information about the image
             if (JXL_DEC_SUCCESS
                 != JxlDecoderGetBasicInfo(m_decoder.get(), &info)) {
                 errorfmt("JxlDecoderGetBasicInfo failed\n");
                 return false;
             }
+
+            // Need to check how we can support bfloat16 if jpegxl supports it
+            bool is_float = info.exponent_bits_per_sample > 0;
+
+            switch (info.bits_per_sample) {
+            case 8:
+                jxl_data_type = JXL_TYPE_UINT8;
+                m_data_type   = TypeDesc::UINT8;
+                break;
+            case 16:
+                jxl_data_type = is_float ? JXL_TYPE_FLOAT16 : JXL_TYPE_UINT16;
+                m_data_type   = is_float ? TypeDesc::HALF : TypeDesc::UINT16;
+                break;
+            case 32:
+                jxl_data_type = JXL_TYPE_FLOAT;
+                m_data_type   = TypeDesc::FLOAT;
+                break;
+            default: errorfmt("Unsupported bits per sample\n"); return false;
+            }
+
+            format = { m_channels, jxl_data_type, JXL_NATIVE_ENDIAN, 0 };
+
             format.num_channels = info.num_color_channels
                                   + info.num_extra_channels;
             m_channels = info.num_color_channels + info.num_extra_channels;
@@ -284,19 +307,19 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
                 return false;
             }
             if (buffer_size
-                != info.xsize * info.ysize * m_channels * sizeof(float)) {
+                != info.xsize * info.ysize * m_channels * info.bits_per_sample
+                       / 8) {
                 errorfmt("Invalid out buffer size {} {}\n", buffer_size,
-                         info.xsize * info.ysize * m_channels * sizeof(float));
+                         info.xsize * info.ysize * m_channels
+                             * info.bits_per_sample / 8);
                 return false;
             }
-            m_pixels.resize(info.xsize * info.ysize * m_channels);
-            void* pixels_buffer       = (void*)m_pixels.data();
-            size_t pixels_buffer_size = m_pixels.size() * sizeof(float);
-            // size_t pixels_buffer_size = m_pixels.size() * sizeof(uint8_t);
+
+            m_buffer = new uint8_t[buffer_size];
+
             if (JXL_DEC_SUCCESS
                 != JxlDecoderSetImageOutBuffer(m_decoder.get(), &format,
-                                               pixels_buffer,
-                                               pixels_buffer_size)) {
+                                               m_buffer, buffer_size)) {
                 errorfmt("JxlDecoderSetImageOutBuffer failed\n");
                 return false;
             }
@@ -321,8 +344,8 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
         }
     }
 
-    m_spec = ImageSpec(info.xsize, info.ysize, m_channels, TypeDesc::FLOAT);
-    // TypeDesc::UINT8);
+    m_spec = ImageSpec(info.xsize, info.ysize, m_channels, m_data_type);
+
     newspec = m_spec;
     return true;
 }
@@ -334,7 +357,7 @@ JxlInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     DBG std::cout << "JxlInput::read_native_scanline(, , " << y << ")\n";
-    size_t scanline_size = m_spec.width * m_channels * sizeof(float);
+    size_t scanline_size = m_spec.width * m_channels * m_spec.channel_bytes();
     // size_t scanline_size = m_spec.width * m_channels * sizeof(uint8_t);
 
     lock_guard lock(*this);
@@ -343,8 +366,7 @@ JxlInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (y < 0 || y >= m_spec.height)  // out of range scanline
         return false;
 
-    memcpy(data, (void*)((uint8_t*)(m_pixels.data()) + y * scanline_size),
-           scanline_size);
+    memcpy(data, (void*)(m_buffer + y * scanline_size), scanline_size);
 
     return true;
 }
@@ -359,6 +381,12 @@ JxlInput::close()
     if (ioproxy_opened()) {
         close_file();
     }
+
+    if (m_buffer) {
+        delete[] m_buffer;
+        m_buffer = nullptr;
+    }
+
     init();  // Reset to initial state
     return true;
 }

--- a/src/jpegxl.imageio/jxlinput.cpp
+++ b/src/jpegxl.imageio/jxlinput.cpp
@@ -382,11 +382,7 @@ JxlInput::close()
         close_file();
     }
 
-    if (m_buffer) {
-        m_buffer.reset();
-        m_buffer = nullptr;
-    }
-
+    m_buffer.reset();
     init();  // Reset to initial state
     return true;
 }

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -17,7 +17,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-#define DBG if (0)
+#define DBG if (1)
 
 class JxlOutput final : public ImageOutput {
 public:
@@ -40,6 +40,10 @@ public:
     bool write_tile(int x, int y, int z, TypeDesc format, const void* data,
                     stride_t xstride, stride_t ystride,
                     stride_t zstride) override;
+    bool write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                     int zend, TypeDesc format, const void* data,
+                     stride_t xstride, stride_t ystride,
+                     stride_t zstride) override;
     bool close() override;
 
 private:
@@ -49,11 +53,11 @@ private:
     JxlBasicInfo m_basic_info;
     JxlEncoderFrameSettings* m_frame_settings;
     JxlPixelFormat m_pixel_format;
-
+    
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
     std::vector<unsigned char> m_tilebuffer;
-    std::vector<float> m_pixels;
+    std::vector<unsigned char> m_scanbuffer; // hack
 
     void init(void)
     {
@@ -62,7 +66,7 @@ private:
         m_runner  = nullptr;
     }
 
-    bool save_image();
+    bool save_image(const void* data);
 };
 
 
@@ -105,7 +109,13 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
         return false;
     }
 
-    m_spec.set_format(TypeFloat);
+    switch (m_spec.format.basetype) {
+    case TypeDesc::UINT8:
+    case TypeDesc::UINT16:
+    case TypeDesc::HALF:
+    case TypeDesc::FLOAT: m_spec.set_format(m_spec.format); break;
+    default: errorfmt("Unsupported data type {}", m_spec.format); return false;
+    }
 
     m_dither = (m_spec.format == TypeDesc::UINT8)
                    ? m_spec.get_int_attribute("oiio:dither", 0)
@@ -144,11 +154,28 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
 
     DBG std::cout << "m_spec " << m_spec.width << "×" << m_spec.height << "×"
                   << m_spec.nchannels << "\n";
-    m_basic_info.xsize           = m_spec.width;
-    m_basic_info.ysize           = m_spec.height;
-    m_basic_info.bits_per_sample = 32;
-    // m_basic_info.exponent_bits_per_sample = 0;
-    m_basic_info.exponent_bits_per_sample = 8;
+    m_basic_info.xsize = m_spec.width;
+    m_basic_info.ysize = m_spec.height;
+
+    switch (m_spec.format.basetype) {
+    case TypeDesc::UINT8:
+        m_basic_info.bits_per_sample          = 8;
+        m_basic_info.exponent_bits_per_sample = 0;
+        break;
+    case TypeDesc::UINT16:
+        m_basic_info.bits_per_sample          = 16;
+        m_basic_info.exponent_bits_per_sample = 0;
+        break;
+    case TypeDesc::HALF:
+        m_basic_info.bits_per_sample          = 16;
+        m_basic_info.exponent_bits_per_sample = 5;
+        break;
+    case TypeDesc::FLOAT:
+        m_basic_info.bits_per_sample          = 32;
+        m_basic_info.exponent_bits_per_sample = 8;
+        break;
+    default: errorfmt("Unsupported data type {}", m_spec.format); return false;
+    }
 
     if (m_spec.nchannels >= 4) {
         m_basic_info.num_color_channels = 3;
@@ -165,23 +192,71 @@ JxlOutput::open(const std::string& name, const ImageSpec& newspec,
 
     m_frame_settings = JxlEncoderFrameSettingsCreate(m_encoder.get(), nullptr);
 
-    // const float quality = 100.0;
-    const int effort = 7;
-    const int tier   = 0;
-    // Lossless only makes sense for integer modes
-    if (m_basic_info.exponent_bits_per_sample == 0) {
-        // Must preserve original profile for lossless mode
-        m_basic_info.uses_original_profile = JXL_TRUE;
-        JxlEncoderSetFrameDistance(m_frame_settings, 0.0);
-        JxlEncoderSetFrameLossless(m_frame_settings, JXL_TRUE);
+    // JpegXL Compression Settings
+    
+    bool lossless = true;
+     
+    // Distance Mutually exclusive with quality
+    if (m_spec.find_attribute("jpegxl:distance")) {
+        const float distance = 
+            m_spec.get_float_attribute("jpegxl:distance", 0.0f);
+
+        m_basic_info.uses_original_profile = distance == 0.0f ? JXL_TRUE
+                                                              : JXL_FALSE;
+        JxlEncoderSetFrameDistance(m_frame_settings, distance);
+        JxlEncoderSetFrameLossless(m_frame_settings,
+                                   distance == 0.0f ? JXL_TRUE : JXL_FALSE);
+
+        lossless = distance == 0.0f;
+
+        DBG std::cout << "Compression distance set to " << distance << "\n";
+
+    } else {
+        auto compqual = m_spec.decode_compression_metadata("jpegxl", 100);
+        if (Strutil::iequals(compqual.first, "jpegxl")) {
+            if (compqual.second == 100) {
+                m_basic_info.uses_original_profile = JXL_TRUE;
+                JxlEncoderSetFrameDistance(m_frame_settings, 0.0);
+                JxlEncoderSetFrameLossless(m_frame_settings, JXL_TRUE);
+
+                lossless = true;
+            } else {
+                m_basic_info.uses_original_profile = JXL_FALSE;
+                JxlEncoderSetFrameDistance(
+                    m_frame_settings,
+                    1.0f / static_cast<float>(compqual.second));
+                JxlEncoderSetFrameLossless(m_frame_settings, JXL_FALSE);
+            }
+        } else {  // default to lossless
+            m_basic_info.uses_original_profile = JXL_TRUE;
+            JxlEncoderSetFrameDistance(m_frame_settings, 0.0);
+            JxlEncoderSetFrameLossless(m_frame_settings, JXL_TRUE);
+
+            lossless = true;
+        }
+
+        DBG std::cout << "compression set to " << compqual.second << "\n";
     }
 
+    const int effort = m_spec.get_int_attribute("jpegxl:effort", 7);
+    const int tier   = m_spec.get_int_attribute("jpegxl:tier", 0);
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_EFFORT, effort);
 
     JxlEncoderFrameSettingsSetOption(m_frame_settings,
                                      JXL_ENC_FRAME_SETTING_DECODING_SPEED,
                                      tier);
+
+    // Preprocessing (maybe not works yet)
+    if (m_spec.find_attribute("jpegxl:photon_noise_iso") && !lossless) {
+        JxlEncoderFrameSettingsSetOption(
+            m_frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE,
+            m_spec.get_float_attribute("jpegxl:photon_noise_iso", 0.0f));
+
+        DBG std::cout << "Photon noise set to "
+					  << m_spec.get_float_attribute(
+                          "jpegxl:photon_noise_iso", 0.0f) << "\n";
+    }
 
     // Codestream level should be chosen automatically given the settings
     JxlEncoderSetBasicInfo(m_encoder.get(), &m_basic_info);
@@ -248,10 +323,11 @@ JxlOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
     DBG std::cout << "data = " << data << " nvals = " << nvals << "\n";
 
-    std::vector<float>::iterator m_it
-        = m_pixels.begin() + m_spec.width * ybegin * m_spec.nchannels;
+    // add data to m_scanbuffer
+    m_scanbuffer.insert(m_scanbuffer.end(), (unsigned char*)data,
+        				(unsigned char*)data + nvals * m_spec.format.size());
 
-    m_pixels.insert(m_it, (float*)data, (float*)data + nvals);
+    //save_image(data);
 
     return true;
 }
@@ -272,27 +348,61 @@ JxlOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
 
 
 bool
-JxlOutput::save_image()
+JxlOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                       int zend, TypeDesc format, const void* data,
+                       stride_t xstride, stride_t ystride, stride_t zstride)
+{
+    // placeholder
+
+    return true;
+};
+
+
+
+bool
+JxlOutput::save_image(const void* data)
 {
     JxlEncoderStatus status;
     JxlEncoderError error;
     std::vector<uint8_t> compressed;
     bool ok = true;
 
+    JxlDataType jxl_type = JXL_TYPE_FLOAT;
+    size_t jxl_bytes = 1;
+
     DBG std::cout << "JxlOutput::save_image()\n";
 
+    switch (m_spec.format.basetype) {
+        case TypeDesc::UINT8:
+			jxl_type = JXL_TYPE_UINT8;
+            jxl_bytes = 1;
+			break;
+        case TypeDesc::UINT16:
+            jxl_type = JXL_TYPE_UINT16;
+            jxl_bytes = 2;
+            break;
+        case TypeDesc::HALF:
+            jxl_type = JXL_TYPE_FLOAT16;
+            jxl_bytes = 2;
+			break;
+        case TypeDesc::FLOAT:
+			jxl_type = JXL_TYPE_FLOAT;
+            jxl_bytes = 4;
+			break;
+		default:
+			errorfmt("Unsupported data type {}", m_spec.format);
+			return false;
+    }
+
     m_pixel_format = { m_basic_info.num_color_channels
-                           + m_basic_info.num_extra_channels,
-                       JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0 };
+                       + m_basic_info.num_extra_channels,
+                       jxl_type, JXL_NATIVE_ENDIAN, 0 };
 
     const size_t pixels_size = m_basic_info.xsize * m_basic_info.ysize
                                * (m_basic_info.num_color_channels
-                                  + m_basic_info.num_extra_channels);
+                               + m_basic_info.num_extra_channels);
 
-    m_pixels.resize(pixels_size);
-
-    const void* data = m_pixels.data();
-    size_t size      = m_pixels.size() * sizeof(float);
+    size_t size = pixels_size * jxl_bytes;
 
     DBG std::cout << "data = " << data << " size = " << size << "\n";
 
@@ -365,7 +475,8 @@ JxlOutput::close()
         std::vector<unsigned char>().swap(m_tilebuffer);
     }
 
-    save_image();
+    //save_image();
+    save_image(m_scanbuffer.data());
 
     init();
     return ok;

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -138,7 +138,7 @@ if int(os.getenv('TESTSUITE_CLEANUP_ON_SUCCESS', '0')) :
 
 image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla",
                      ".dpx", ".iff", ".psd", ".bmp", ".fits", ".ico",
-                     ".jp2", ".sgi", ".tga", ".TGA", ".zfile" ]
+                     ".jp2", ".jxl", ".sgi", ".tga", ".TGA", ".zfile" ]
 
 # print ("srcdir = " + srcdir)
 # print ("tmpdir = " + tmpdir)


### PR DESCRIPTION
## Description
JpegXL Output plugin
• support for uint8/uint16/half/float
• compression settings
  jpegxl:distance
  compression jpegxl:##
  jpegxl:effort
  jpegxl:photon_noise_iso

JpegXL Input plugin
• support for uint8/uint16/half/float

**Encode:**
```
oiiotools -v ^
-i DISP_16bit.tif -o DISP_16bit_tif.jxl ^
-i  DISP_8bit.tif -o DISP_8bit_tif.jxl ^
-i DISP_float.exr -o DISP_float_exr.jxl ^
-i DISP_half.exr -o DISP_half_exr.jxl
```

jxlinfo.exe -v output
```
JPEG XL image, 1440x1440, (possibly) lossless, 16-bit RGB
JPEG XL image, 1440x1440, (possibly) lossless, 8-bit RGB
JPEG XL image, 1440x1440, (possibly) lossless, 32-bit float (8 exponent bits) RGB
JPEG XL image, 1440x1440, (possibly) lossless, 16-bit float (5 exponent bits) RGB
```

**Decode**
```
oiiotool.exe -v ^
-i w:\DISP_16bit_tif.jxl -o w:\DISP_16bit_tif_jxl.tif ^
-i w:\DISP_8bit_tif.jxl -o w:\DISP_8bit_tif_jxl.tif ^
-i w:\DISP_float_exr.jxl -o w:\DISP_float_exr_jxl.exr ^
-i w:\DISP_half_exr.jxl -o w:\DISP_half_exr_jxl.exr
```

iinfo.exe output
```
DISP_16bit_tif_jxl.tif : 1440 x 1440, 3 channel, uint16 tiff
DISP_8bit_tif_jxl.tif : 1440 x 1440, 3 channel, uint8 tiff
DISP_float_exr_jxl.exr : 1440 x 1440, 3 channel, float openexr
DISP_half_exr_jxl.exr : 1440 x 1440, 3 channel, half openexr
```

TODO:
- [ ] EXIF and metadata
- [ ] Color spaces support
- [x] Encoding settings
- [ ] Decoding settings

## OIIO Tests
not yet


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
