### PR TITLE
pnm-plugin

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1732,8 +1732,7 @@ attributes are supported:
      - If nonzero, the PNM file is big-endian (the default is little-endian).  
    * - ``pnm:pfmflip``
       - int
-      - If nonzero, the PFM (float) file is flipped upside-down (the default
-      is flipped).
+      - If this configuration hint is present and is zero, the automatic vertical flipping of PFM image will be disabled (i.e., scanline 0 will really be the first one stored in the file). If nonzero (the default), float PFM files will store scanline 0 as the last scanline in the file (i.e. the visual "top" of the image).
 
 **Configuration settings for PNM output**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1766,8 +1766,7 @@ control aspects of the writing itself:
        Float PFM files are always written in binary format.
    * - ``pnm:pfmflip``
       - int
-      - If nonzero, the PFM (float) file is flipped upside-down (the default
-      is flipped).
+      - If this configuration hint is present and is zero, for PFM files, scanline 0 will really be stored first in the file, thus disabling the usual automatically flipping that accounts for PFM files conventionally being stored in bottom-to-top order. If nonzero (the default), float PFM files will store scanline 0 as the last scanline in the file (i.e. the visual "top" of the image).
 
 **Custom I/O Overrides**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1688,7 +1688,7 @@ Without loss of generality, we will refer to these all collectively as
 for those who reject the nonsense about naming the files depending on the
 number of channels and bitdepth.
 
-PNM files widely used in the Unix world as simple ASCII or binary image 
+PNM files are widely used in the Unix world as simple ASCII or binary image 
 files that are easy to read and write. They are not compressed, and are
 not particularly efficient for large images. They are not widely used in
 the professional graphics world, but because of their historical

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1712,6 +1712,11 @@ Both the reader and writer accept configuration hints "pnm:pfmflip" (default: 1)
      - int
      - The true bits per sample of the file (1 for true PBM files, even
        though OIIO will report the ``format`` as UINT8).
+   * - ``pnm:binary``
+     - int
+     - nonzero if the file itself used the PNM binary format, 0 if it used
+       ASCII.  The PNM writer honors this attribute in the ImageSpec to
+       determine whether to write an ASCII or binary file.
 
 **Configuration settings for PNM input**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1696,6 +1696,9 @@ significance and extreme simplicity, OpenImageIO supports them.
 PNM files do not support anything other than 1 or 3 channels, no tiles,
 no multi-image, no MIPmapping.
 
+The pbm, pgm, and ppm varieties are stored with scanlines ordered in the file as top-to-bottom (the same as the usual OIIO convention), but the float-based pfm files are conventionally ordered in the file as bottom-to-top. Therefore, by default, reading and writing of the pfm variety will automatically flip the image so that an application calling the OpenImageIO API can, as usual, assume that scanline 0 is the visual "top" (even though it is actually the last scanline stored in the file).
+
+Both the reader and writer accept configuration hints "pnm:pfmflip" (default: 1), which if set to 0 will disable this flipping and ensure that scanline 0 is written as the first in the file (therefore representing what PFM assumes is the visual "bottom" of the image). This hint only affects PFM files and has no effect on the pbm, pgm, or ppm varieties.
 **Attributes**
 
 .. list-table::

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1696,9 +1696,21 @@ significance and extreme simplicity, OpenImageIO supports them.
 PNM files do not support anything other than 1 or 3 channels, no tiles,
 no multi-image, no MIPmapping.
 
-The pbm, pgm, and ppm varieties are stored with scanlines ordered in the file as top-to-bottom (the same as the usual OIIO convention), but the float-based pfm files are conventionally ordered in the file as bottom-to-top. Therefore, by default, reading and writing of the pfm variety will automatically flip the image so that an application calling the OpenImageIO API can, as usual, assume that scanline 0 is the visual "top" (even though it is actually the last scanline stored in the file).
+The pbm, pgm, and ppm varieties are stored with scanlines ordered in the
+file as top-to-bottom (the same as the usual OIIO convention), but the
+float-based pfm files are conventionally ordered in the file as
+bottom-to-top. Therefore, by default, reading and writing of the pfm
+variety will automatically flip the image so that an application calling
+the OpenImageIO API can, as usual, assume that scanline 0 is the visual
+"top" (even though it is actually the last scanline stored in the file).
 
-Both the reader and writer accept configuration hints "pnm:pfmflip" (default: 1), which if set to 0 will disable this flipping and ensure that scanline 0 is written as the first in the file (therefore representing what PFM assumes is the visual "bottom" of the image). This hint only affects PFM files and has no effect on the pbm, pgm, or ppm varieties.
+Both the reader and writer accept configuration hints "pnm:pfmflip"
+(default: 1), which if set to 0 will disable this flipping and ensure
+that scanline 0 is written as the first in the file (therefore
+representing what PFM assumes is the visual "bottom" of the image).
+This hint only affects PFM files and has no effect on the pbm, pgm,
+or ppm varieties.
+
 **Attributes**
 
 .. list-table::
@@ -1740,7 +1752,11 @@ attributes are supported:
      - If nonzero, the PNM file is big-endian (the default is little-endian).  
    * - ``pnm:pfmflip``
       - int
-      - If this configuration hint is present and is zero, the automatic vertical flipping of PFM image will be disabled (i.e., scanline 0 will really be the first one stored in the file). If nonzero (the default), float PFM files will store scanline 0 as the last scanline in the file (i.e. the visual "top" of the image).
+      - If this configuration hint is present and is zero, the automatic
+      vertical flipping of PFM image will be disabled (i.e., scanline 0 will
+      really be the first one stored in the file). If nonzero (the default),
+      float PFM files will store scanline 0 as the last scanline in the file
+      (i.e. the visual "top" of the image).
 
 **Configuration settings for PNM output**
 
@@ -1774,7 +1790,12 @@ control aspects of the writing itself:
        Float PFM files are always written in binary format.
    * - ``pnm:pfmflip``
       - int
-      - If this configuration hint is present and is zero, for PFM files, scanline 0 will really be stored first in the file, thus disabling the usual automatically flipping that accounts for PFM files conventionally being stored in bottom-to-top order. If nonzero (the default), float PFM files will store scanline 0 as the last scanline in the file (i.e. the visual "top" of the image).
+      - If this configuration hint is present and is zero, for PFM files,
+      scanline 0 will really be stored first in the file, thus disabling the
+      usual automatically flipping that accounts for PFM files conventionally
+      being stored in bottom-to-top order. If nonzero (the default), float
+      PFM files will store scanline 0 as the last scanline in the file (i.e.
+      the visual "top" of the image).
 
 **Custom I/O Overrides**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1678,22 +1678,23 @@ and :ref:`sec-imageinput-ioproxy`) as well as the `set_ioproxy()` methods.
 PNM / Netpbm
 ===============================================
 
-The Netpbm project, a.k.a. PNM (portable "any" map) defines PBM, PGM,
-and PPM (portable bitmap, portable graymap, portable pixmap) files.
+The Netpbm project, a.k.a. PNM (portable "any" map) defines PBM, PGM, PPM
+and later added PFM (portable float map) as a set of simple image formats
+(portable bitmap, portable graymap, portable pixmap) files.
 Without loss of generality, we will refer to these all collectively as
-"PNM."  These files have extensions :file:`.pbm`, :file:`.pgm`, and
-:file:`.ppm` and customarily correspond to bi-level bitmaps, 1-channel
-grayscale, and 3-channel RGB files, respectively, or :file:`.pnm` for
-those who reject the nonsense about naming the files depending on the
+"PNM."  These files have extensions :file:`.pbm`, :file:`.pgm`,
+:file:`.ppm`, :file:`.pfm` and customarily correspond to bi-level bitmaps,
+1-channel grayscale, and 3-channel RGB files, respectively, or :file:`.pnm`
+for those who reject the nonsense about naming the files depending on the
 number of channels and bitdepth.
 
-PNM files are not much good for anything, but because of their
-historical significance and extreme simplicity (that causes many
-"amateur" programs to write images in these formats), OpenImageIO
-supports them.  PNM files do not support floating point images, anything
-other than 1 or 3 channels, no tiles, no multi-image, no MIPmapping.
-It's not a smart choice unless you are sending your images back to the
-1980's via a time machine.
+PNM files widely used in the Unix world as simple ASCII or binary image 
+files that are easy to read and write. They are not compressed, and are
+not particularly efficient for large images. They are not widely used in
+the professional graphics world, but because of their historical
+significance and extreme simplicity, OpenImageIO supports them.
+PNM files do not support anything other than 1 or 3 channels, no tiles,
+no multi-image, no MIPmapping.
 
 **Attributes**
 
@@ -1708,11 +1709,6 @@ It's not a smart choice unless you are sending your images back to the
      - int
      - The true bits per sample of the file (1 for true PBM files, even
        though OIIO will report the ``format`` as UINT8).
-   * - ``pnm:binary``
-     - int
-     - nonzero if the file itself used the PNM binary format, 0 if it used
-       ASCII.  The PNM writer honors this attribute in the ImageSpec to
-       determine whether to write an ASCII or binary file.
 
 **Configuration settings for PNM input**
 
@@ -1731,6 +1727,13 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``pnm:bigendian``
+     - int
+     - If nonzero, the PNM file is big-endian (the default is little-endian).  
+   * - ``pnm:pfmflip``
+      - int
+      - If nonzero, the PFM (float) file is flipped upside-down (the default
+      is flipped).
 
 **Configuration settings for PNM output**
 
@@ -1753,6 +1756,19 @@ control aspects of the writing itself:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by writing to a memory buffer.
+   * - ``pnm:bigendian``
+     - int
+     - If nonzero, the PNM file is big-endian (the default is little-endian).
+   * - ``pnm:binary``
+     - int
+     - nonzero if the file itself used the PNM binary format, 0 if it used
+       ASCII.  The PNM writer honors this attribute in the ImageSpec to
+       determine whether to write an ASCII or binary file.
+       Float PFM files are always written in binary format.
+   * - ``pnm:pfmflip``
+      - int
+      - If nonzero, the PFM (float) file is flipped upside-down (the default
+      is flipped).
 
 **Custom I/O Overrides**
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <string>
@@ -11,6 +12,8 @@
 #include <OpenImageIO/imageio.h>
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
+
+#define DBG if (0)
 
 //
 // Documentation on the PNM formats can be found at:
@@ -188,6 +191,7 @@ unpack_floats(const unsigned char* read, float* write, imagesize_t numsamples,
 bool
 PNMInput::read_file_scanline(void* data, int y)
 {
+    DBG std::cerr << "PNMInput::read_file_scanline(" << y << ")\n";
     if (y < m_y_next) {
         // If being asked to backtrack to an earlier scanline, reset all the
         // way to the beginning, right after the header.
@@ -202,9 +206,11 @@ PNMInput::read_file_scanline(void* data, int y)
     for (; good && m_y_next <= y; ++m_y_next) {
         // PFM files are bottom-to-top, so we need to seek to the right spot
         if (m_pnm_type == PF || m_pnm_type == Pf) {
-            int file_scanline = m_spec.height - 1 - (y - m_spec.y);
-            auto offset       = file_scanline * m_spec.scanline_bytes();
-            m_remaining       = m_after_header.substr(offset);
+            if (m_spec.get_int_attribute("pnm:pfmflip", 1) == 1) {
+                int file_scanline = m_spec.height - 1 - (y - m_spec.y);
+                auto offset       = file_scanline * m_spec.scanline_bytes();
+                m_remaining       = m_after_header.substr(offset);
+            }
         }
 
         if ((m_pnm_type >= P4 && m_pnm_type <= P6) || m_pnm_type == PF
@@ -219,6 +225,7 @@ PNMInput::read_file_scanline(void* data, int y)
             if (size_t(numbytes) > m_remaining.size())
                 return false;
             buf.assign(m_remaining.begin(), m_remaining.begin() + numbytes);
+
             m_remaining.remove_prefix(numbytes);
         }
 
@@ -313,6 +320,7 @@ PNMInput::read_file_header()
         int bps = int(ceilf(logf(m_max_val + 1) / logf(2)));
         if (bps < 8)
             m_spec.attribute("oiio:BitsPerSample", bps);
+        m_spec.attribute("pnm:pfmflip", 0);
     } else {
         //Read scaling factor
         if (!nextVal(m_scaling_factor))
@@ -327,6 +335,7 @@ PNMInput::read_file_header()
         m_spec = ImageSpec(width, height, m_pnm_type == PF ? 3 : 1,
                            TypeDesc::FLOAT);
         m_spec.attribute("pnm:bigendian", m_scaling_factor < 0 ? 0 : 1);
+        m_spec.attribute("pnm:binary", 1);
     }
     m_spec.attribute("oiio:ColorSpace", "Rec709");
     return true;
@@ -339,7 +348,13 @@ PNMInput::open(const std::string& name, ImageSpec& newspec,
                const ImageSpec& config)
 {
     ioproxy_retrieve_from_config(config);
-    return open(name, newspec);
+    if (!open(name, newspec)) {
+        errorfmt("Could parse spec for file \"%s\"", name);
+        return false;
+    }
+
+    m_spec["pnm:pfmflip"] = config.get_int_attribute("pnm:pfmflip", 1);
+    return true;
 }
 
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -349,7 +349,7 @@ PNMInput::open(const std::string& name, ImageSpec& newspec,
 {
     ioproxy_retrieve_from_config(config);
     if (!open(name, newspec)) {
-        errorfmt("Could parse spec for file \"%s\"", name);
+        errorfmt("Could not parse spec for file \"%s\"", name);
         return false;
     }
 

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+#include <cstdio>
 #include <fstream>
 
 #include <OpenImageIO/filesystem.h>
@@ -9,6 +10,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
+#define DBG if (0)
 
 class PNMOutput final : public ImageOutput {
 public:
@@ -24,13 +26,19 @@ public:
     bool close() override;
     bool write_scanline(int y, int z, TypeDesc format, const void* data,
                         stride_t xstride) override;
+    bool write_scanlines(int ybegin, int yend, int z, TypeDesc format,
+                         const void* data, stride_t xstride = AutoStride,
+                         stride_t ystride = AutoStride) override;
     bool write_tile(int x, int y, int z, TypeDesc format, const void* data,
                     stride_t xstride, stride_t ystride,
                     stride_t zstride) override;
 
 private:
     std::string m_filename;  // Stash the filename
-    unsigned int m_max_val, m_pnm_type;
+    unsigned int m_max_val;
+    unsigned int m_pnm_type;
+    std::string m_pfn_type;
+
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
     std::vector<unsigned char> m_tilebuffer;
@@ -39,6 +47,7 @@ private:
 
     bool write_ascii_binary(const unsigned char* data, const stride_t stride);
     bool write_raw_binary(const unsigned char* data, const stride_t stride);
+    bool write_float(const void* data, TypeDesc format, const stride_t stride);
 
     template<class T>
     bool write_ascii(const T* data, const stride_t stride,
@@ -58,8 +67,8 @@ pnm_output_imageio_create()
     return new PNMOutput;
 }
 
-OIIO_EXPORT const char* pnm_output_extensions[] = { "ppm", "pgm", "pbm", "pnm",
-                                                    nullptr };
+OIIO_EXPORT const char* pnm_output_extensions[] = { "ppm", "pgm", "pbm",
+                                                    "pnm", "pfm", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 
@@ -95,12 +104,19 @@ bool
 PNMOutput::write_ascii(const T* data, const stride_t stride,
                        unsigned int max_val)
 {
-    int nc = m_spec.nchannels;
+    DBG std::cerr << "PNMOutput::write_ascii()\n";
+    int nc   = m_spec.nchannels;
+    bool big = m_spec.get_int_attribute("pnm:bigendian", 0) == 1;
+    DBG std::cerr << "bigendian: " << big << "\n";
+    stride_t m_stride = stride / sizeof(T);
+
     for (int x = 0; x < m_spec.width; x++) {
-        unsigned int pixel = x * stride;
+        unsigned int pixel = x * m_stride;
         for (int c = 0; c < nc; c++) {
             unsigned int val = data[pixel + c];
             val              = val * max_val / std::numeric_limits<T>::max();
+            if (big)
+                swap_endian(&val, 1);
             if (!iowritefmt("{}\n", val))
                 return false;
         }
@@ -114,17 +130,22 @@ template<class T>
 bool
 PNMOutput::write_raw(const T* data, const stride_t stride, unsigned int max_val)
 {
-    int nc = m_spec.nchannels;
+    //DBG std::cerr << "PNMOutput::write_raw()\n";
+    int nc            = m_spec.nchannels;
+    bool big          = m_spec.get_int_attribute("pnm:bigendian", 0) == 1;
+    stride_t m_stride = stride / sizeof(T);
+
     for (int x = 0; x < m_spec.width; x++) {
-        unsigned int pixel = x * stride;
+        unsigned int pixel = x * m_stride;
         for (int c = 0; c < nc; c++) {
             unsigned int val = data[pixel + c];
             val              = val * max_val / std::numeric_limits<T>::max();
             if (sizeof(T) == 2) {
                 // Writing a 16bit ppm file
-                // I'll adopt the practice of Netpbm and write the MSB first
-                uint8_t byte[2] = { static_cast<uint8_t>(val >> 8),
-                                    static_cast<uint8_t>(val & 0xff) };
+                uint8_t byte[2] = { big ? static_cast<uint8_t>(val & 0xff)
+                                        : static_cast<uint8_t>(val >> 8),
+                                    big ? static_cast<uint8_t>(val >> 8)
+                                        : static_cast<uint8_t>(val & 0xff) };
                 if (!iowrite(&byte, 2))
                     return false;
             } else {
@@ -141,6 +162,62 @@ PNMOutput::write_raw(const T* data, const stride_t stride, unsigned int max_val)
 
 
 bool
+PNMOutput::write_float(const void* data, TypeDesc format, const stride_t stride)
+{
+    int nc   = m_spec.nchannels;
+    bool big = m_spec.get_int_attribute("pnm:bigendian", 0) == 1;
+    stride_t m_stride;
+
+    switch (format.basetype) {
+    case TypeDesc::HALF:
+        m_stride = stride / sizeof(half);
+        for (int x = 0; x < m_spec.width; x++) {
+            unsigned int pixel = x * m_stride;
+            for (int c = 0; c < nc; c++) {
+                half* d   = (half*)data;
+                float val = static_cast<float>(d[pixel + c]);
+                if (big)
+                    swap_endian(&val, 1);
+                if (!iowrite(&val, sizeof(val)))
+                    return false;
+            }
+        }
+        break;
+    case TypeDesc::FLOAT:
+        m_stride = stride / sizeof(float);
+        for (int x = 0; x < m_spec.width; x++) {
+            unsigned int pixel = x * m_stride;
+            for (int c = 0; c < nc; c++) {
+                float* d  = (float*)data;
+                float val = d[pixel + c];
+                if (big)
+                    swap_endian(&val, 1);
+                if (!iowrite(&val, sizeof(val)))
+                    return false;
+            }
+        }
+        break;
+    case TypeDesc::DOUBLE:
+        m_stride = stride / sizeof(double);
+        for (int x = 0; x < m_spec.width; x++) {
+            unsigned int pixel = x * m_stride;
+            for (int c = 0; c < nc; c++) {
+                double* d = (double*)data;
+                float val = static_cast<float>(d[pixel + c]);
+                if (big)
+                    swap_endian(&val, 1);
+                if (!iowrite(&val, sizeof(val)))
+                    return false;
+            }
+        }
+        break;
+    }
+    return true;
+}
+
+
+
+bool
 PNMOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
@@ -148,33 +225,90 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
                     uint64_t(OpenChecks::Disallow2Channel)))
         return false;
 
-    m_spec.set_format(TypeDesc::UINT8);  // Force 8 bit output
-    int bits_per_sample = m_spec.get_int_attribute("oiio:BitsPerSample", 8);
-    m_dither            = (m_spec.format == TypeDesc::UINT8)
-                              ? m_spec.get_int_attribute("oiio:dither", 0)
-                              : 0;
+    DBG std::cerr << "Bit depth: " << m_spec.format << "\n";
 
-    if (bits_per_sample == 1)
-        m_pnm_type = 4;
-    else if (m_spec.nchannels == 1)
-        m_pnm_type = 5;
-    else
-        m_pnm_type = 6;
-    if (!m_spec.get_int_attribute("pnm:binary", 1))
-        m_pnm_type -= 3;
+    m_pnm_type = 0;
+    m_pfn_type = "";
+
+    int bits_per_sample = 0;
+    if (m_spec.find_attribute("oiio:BitsPerSample")) {
+        bits_per_sample = m_spec.get_int_attribute("oiio:BitsPerSample", 8);
+    }
+
+    bool p_binary = m_spec.get_int_attribute("pnm:binary", 1);
+    DBG std::cerr << "p_binary: " << p_binary << "\n";
+
+    if (bits_per_sample == 1) {
+        // black and white
+        m_pnm_type = p_binary ? 4 : 1;
+    } else if (bits_per_sample == 8 || bits_per_sample == 16) {
+        // 8 or 16 bit
+        m_pnm_type = (m_spec.nchannels == 1) ? (p_binary ? 5 : 2)
+                                             : (p_binary ? 6 : 3);
+    } else if (bits_per_sample == 32) {
+        // 32 bit float
+        m_pfn_type = (m_spec.nchannels == 1) ? "f" : "F";
+    } else if (bits_per_sample == 0) {
+        switch (m_spec.format.basetype) {
+        case TypeDesc::UINT8:
+        case TypeDesc::UINT16:
+            m_pnm_type = (m_spec.nchannels == 1) ? (p_binary ? 5 : 2)
+                                                 : (p_binary ? 6 : 3);
+            break;
+        case TypeDesc::HALF:
+        case TypeDesc::FLOAT:
+        case TypeDesc::DOUBLE:
+            m_pfn_type = (m_spec.nchannels == 1) ? "f" : "F";
+            break;
+        default:
+            errorfmt("PNM does not support {}\n", m_spec.format.c_str());
+            return false;
+        }
+    } else {
+        errorfmt("PNM does not support {}\n", m_spec.format.c_str());
+        return false;
+    }
+
+    m_dither = (m_spec.format == TypeDesc::UINT8)
+                   ? m_spec.get_int_attribute("oiio:dither", 0)
+                   : 0;
 
     ioproxy_retrieve_from_config(m_spec);
     if (!ioproxy_use_or_open(name))
         return false;
 
-    m_max_val = (1 << bits_per_sample) - 1;
     // Write header
     bool ok = true;
-    ok &= iowritefmt("P{}\n", m_pnm_type);
-    ok &= iowritefmt("{} {}\n", m_spec.width, m_spec.height);
-    if (m_pnm_type != 1 && m_pnm_type != 4)  // only non-monochrome
-        ok &= iowritefmt("{}\n", m_max_val);
+    if (bits_per_sample != 0) {
+        // user specified bits per sample
+        if (m_pfn_type == "") {
+            ok &= iowritefmt("P{}\n", m_pnm_type);
+            m_max_val = (bits_per_sample == 16) ? 65535 : 255;
+        } else {
+            ok &= iowritefmt("P{}\n", m_pfn_type);
+        }
+    } else {
+        // no bits per sample specified
+        if (m_pfn_type == "") {
+            m_max_val = (m_spec.format == TypeDesc::UINT16) ? 65535 : 255;
+            ok &= iowritefmt("P{}\n", m_pnm_type);
+        } else {
+            ok &= iowritefmt("P{}\n", m_pfn_type);
+        }
+    }
 
+    ok &= iowritefmt("{} {}\n", m_spec.width, m_spec.height);
+
+
+    if (m_pnm_type != 1 && m_pnm_type != 4) {  // only non-monochrome
+        if (m_pfn_type == "")
+            ok &= iowritefmt("{}\n", m_max_val);
+        else {
+            bool big = m_spec.get_int_attribute("pnm:bigendian", 0) == 1;
+            std::string scale = big ? "1.0000" : "-1.0000";
+            ok &= iowritefmt("{}\n", scale);
+        }
+    }
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.
     if (m_spec.tile_width && m_spec.tile_height)
@@ -195,8 +329,8 @@ PNMOutput::close()
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
         OIIO_DASSERT(m_tilebuffer.size());
-        ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
-                              m_spec.format, &m_tilebuffer[0]);
+        ok &= ImageOutput::write_scanlines(m_spec.y, m_spec.y + m_spec.height,
+                                           0, m_spec.format, &m_tilebuffer[0]);
         m_tilebuffer.shrink_to_fit();
     }
 
@@ -210,6 +344,7 @@ bool
 PNMOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
                           stride_t xstride)
 {
+    //DBG std::cerr << "PNMOutput::write_scanline()\n";
     if (!ioproxy_opened())
         return false;
     if (z)
@@ -218,28 +353,70 @@ PNMOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     m_spec.auto_stride(xstride, format, spec().nchannels);
     const void* origdata = data;
     data = to_native_scanline(format, data, xstride, m_scratch, m_dither, y, z);
-    if (data != origdata)  // a conversion happened...
-        xstride = spec().nchannels;
+    if (data != origdata) {  // a conversion happened...
+        xstride = m_spec.pixel_bytes(true);
+    }
 
     switch (m_pnm_type) {
+    case 0:
+        if (m_pfn_type != "") {
+            return write_float(data, m_spec.format, xstride);
+        } else
+            return false;
     case 1: return write_ascii_binary((unsigned char*)data, xstride);
     case 2:
     case 3:
-        if (m_max_val > std::numeric_limits<unsigned char>::max())
+        if (m_max_val > std::numeric_limits<unsigned char>::max()) {
             return write_ascii((unsigned short*)data, xstride, m_max_val);
-        else
+        } else {
             return write_ascii((unsigned char*)data, xstride, m_max_val);
+        }
     case 4: return write_raw_binary((unsigned char*)data, xstride);
     case 5:
     case 6:
-        if (m_max_val > std::numeric_limits<unsigned char>::max())
+        if (m_max_val > std::numeric_limits<unsigned char>::max()) {
             return write_raw((unsigned short*)data, xstride, m_max_val);
-        else
+        } else {
             return write_raw((unsigned char*)data, xstride, m_max_val);
+        }
     default: return false;
     }
 
     return false;
+}
+
+
+
+bool
+PNMOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
+                           const void* data, stride_t xstride, stride_t ystride)
+{
+    DBG std::cerr << "PNMOutput::write_scanlines()\n";
+
+    if (m_spec.get_int_attribute("pnm:pfmflip", 1) == 1
+        && format == TypeDesc::FLOAT) {
+        DBG std::cerr << "Flipping PFM vertically\n";
+
+        // Default implementation: write each scanline individually
+        stride_t native_pixel_bytes = (stride_t)m_spec.pixel_bytes(true);
+        if (format == TypeDesc::UNKNOWN && xstride == AutoStride)
+            xstride = native_pixel_bytes;
+        stride_t zstride = AutoStride;
+        m_spec.auto_stride(xstride, ystride, zstride, format, m_spec.nchannels,
+                           m_spec.width, yend - ybegin);
+
+        // start at the last scanline
+        data    = (char*)data + (yend - ybegin - 1) * ystride;
+        bool ok = true;
+        for (int y = ybegin; ok && y < yend; ++y) {
+            ok &= write_scanline(y, z, format, data, xstride);
+            data = (char*)data - ystride;
+        }
+        return ok;
+    }
+
+    return ImageOutput::write_scanlines(ybegin, yend, z, format, data, xstride,
+                                        ystride);
 }
 
 

--- a/testsuite/pnm/ref/out.txt
+++ b/testsuite/pnm/ref/out.txt
@@ -54,15 +54,18 @@ Reading ../oiio-images/pnm/test-1.pfm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:binary: 1
 Reading ../oiio-images/pnm/test-2.pfm
 ../oiio-images/pnm/test-2.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 312B084985EF1B9C20D35A9D7A5DC8E8EAEB25A0
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:binary: 1
 Reading ../oiio-images/pnm/test-3.pfm
 ../oiio-images/pnm/test-3.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 613A9639725F51ADC8B6F8F5A38DB5EFF0B3A628
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 1
+    pnm:binary: 1

--- a/testsuite/pnm/ref/out.txt
+++ b/testsuite/pnm/ref/out.txt
@@ -5,6 +5,7 @@ src/bw-ascii.pbm     :   16 x   16, 1 channel, uint1 pnm
     oiio:BitsPerSample: 1
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/bw-ascii.pbm" and "bw-ascii.pbm"
 PASS
 Reading src/bw-binary.pbm
@@ -14,6 +15,7 @@ src/bw-binary.pbm    :   32 x   32, 1 channel, uint1 pnm
     oiio:BitsPerSample: 1
     oiio:ColorSpace: "Rec709"
     pnm:binary: 1
+    pnm:pfmflip: 1
 Comparing "src/bw-binary.pbm" and "bw-binary.pbm"
 PASS
 Reading src/grey-ascii.pgm
@@ -22,6 +24,7 @@ src/grey-ascii.pgm   :   16 x   16, 1 channel, uint8 pnm
     channel list: Y
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/grey-ascii.pgm" and "grey-ascii.pgm"
 PASS
 Reading src/grey-binary.pgm
@@ -30,6 +33,7 @@ src/grey-binary.pgm  :   32 x   32, 1 channel, uint8 pnm
     channel list: Y
     oiio:ColorSpace: "Rec709"
     pnm:binary: 1
+    pnm:pfmflip: 1
 Comparing "src/grey-binary.pgm" and "grey-binary.pgm"
 PASS
 Reading src/rgb-ascii.ppm
@@ -38,6 +42,7 @@ src/rgb-ascii.ppm    :   16 x   16, 3 channel, uint8 pnm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/rgb-ascii.ppm" and "rgb-ascii.ppm"
 PASS
 Reading src/rgb-binary.ppm
@@ -46,6 +51,7 @@ src/rgb-binary.ppm   :   32 x   32, 3 channel, uint8 pnm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
+    pnm:pfmflip: 1
 Comparing "src/rgb-binary.ppm" and "rgb-binary.ppm"
 PASS
 Reading ../oiio-images/pnm/test-1.pfm
@@ -54,15 +60,18 @@ Reading ../oiio-images/pnm/test-1.pfm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-2.pfm
 ../oiio-images/pnm/test-2.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 312B084985EF1B9C20D35A9D7A5DC8E8EAEB25A0
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-3.pfm
 ../oiio-images/pnm/test-3.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 613A9639725F51ADC8B6F8F5A38DB5EFF0B3A628
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 1
+    pnm:pfmflip: 1

--- a/testsuite/pnm/ref/out.txt
+++ b/testsuite/pnm/ref/out.txt
@@ -60,6 +60,7 @@ Reading ../oiio-images/pnm/test-1.pfm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:binary: 1
     pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-2.pfm
 ../oiio-images/pnm/test-2.pfm :  240 x  240, 3 channel, float pnm
@@ -67,6 +68,7 @@ Reading ../oiio-images/pnm/test-2.pfm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
+    pnm:binary: 1
     pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-3.pfm
 ../oiio-images/pnm/test-3.pfm :  240 x  240, 3 channel, float pnm
@@ -74,4 +76,5 @@ Reading ../oiio-images/pnm/test-3.pfm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 1
+    pnm:binary: 1
     pnm:pfmflip: 1

--- a/testsuite/pnm/ref/out.txt
+++ b/testsuite/pnm/ref/out.txt
@@ -5,7 +5,6 @@ src/bw-ascii.pbm     :   16 x   16, 1 channel, uint1 pnm
     oiio:BitsPerSample: 1
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
-    pnm:pfmflip: 1
 Comparing "src/bw-ascii.pbm" and "bw-ascii.pbm"
 PASS
 Reading src/bw-binary.pbm
@@ -15,7 +14,6 @@ src/bw-binary.pbm    :   32 x   32, 1 channel, uint1 pnm
     oiio:BitsPerSample: 1
     oiio:ColorSpace: "Rec709"
     pnm:binary: 1
-    pnm:pfmflip: 1
 Comparing "src/bw-binary.pbm" and "bw-binary.pbm"
 PASS
 Reading src/grey-ascii.pgm
@@ -24,7 +22,6 @@ src/grey-ascii.pgm   :   16 x   16, 1 channel, uint8 pnm
     channel list: Y
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
-    pnm:pfmflip: 1
 Comparing "src/grey-ascii.pgm" and "grey-ascii.pgm"
 PASS
 Reading src/grey-binary.pgm
@@ -33,7 +30,6 @@ src/grey-binary.pgm  :   32 x   32, 1 channel, uint8 pnm
     channel list: Y
     oiio:ColorSpace: "Rec709"
     pnm:binary: 1
-    pnm:pfmflip: 1
 Comparing "src/grey-binary.pgm" and "grey-binary.pgm"
 PASS
 Reading src/rgb-ascii.ppm
@@ -42,7 +38,6 @@ src/rgb-ascii.ppm    :   16 x   16, 3 channel, uint8 pnm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
-    pnm:pfmflip: 1
 Comparing "src/rgb-ascii.ppm" and "rgb-ascii.ppm"
 PASS
 Reading src/rgb-binary.ppm
@@ -51,7 +46,6 @@ src/rgb-binary.ppm   :   32 x   32, 3 channel, uint8 pnm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:binary: 0
-    pnm:pfmflip: 1
 Comparing "src/rgb-binary.ppm" and "rgb-binary.ppm"
 PASS
 Reading ../oiio-images/pnm/test-1.pfm
@@ -60,21 +54,15 @@ Reading ../oiio-images/pnm/test-1.pfm
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
-    pnm:binary: 1
-    pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-2.pfm
 ../oiio-images/pnm/test-2.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 312B084985EF1B9C20D35A9D7A5DC8E8EAEB25A0
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
-    pnm:binary: 1
-    pnm:pfmflip: 1
 Reading ../oiio-images/pnm/test-3.pfm
 ../oiio-images/pnm/test-3.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 613A9639725F51ADC8B6F8F5A38DB5EFF0B3A628
     channel list: R, G, B
     oiio:ColorSpace: "Rec709"
     pnm:bigendian: 1
-    pnm:binary: 1
-    pnm:pfmflip: 1


### PR DESCRIPTION
## Description

Fixes added:

- import/export support for 8/16 uint 32-float
- pnm:bigendian
- pnm:pfmflip for float pfm files (GIMP flip float PFM files by default, Photoshop do not)
- update in documentation

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
