### PR TITLE
build: More warning elimination for clang18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
             !build/testsuite/j2kp4files_v1_5
 
 
-  macrunner:
+  macos:
     name: "${{matrix.runner}} appleclang${{matrix.aclang}}/C++${{matrix.cxx_std}} py${{matrix.python_ver}} ${{matrix.desc}}"
     strategy:
       fail-fast: false
@@ -439,12 +439,16 @@ jobs:
           - desc: MacOS-12
             runner: macos-12
             nametag: macos12-py310
+            cc_compiler: clang
+            cxx_compiler: clang++
             cxx_std: 17
             python_ver: "3.10"
             aclang: 13
           - desc: MacOS-13
             runner: macos-13
             nametag: macos13-py311
+            cc_compiler: clang
+            cxx_compiler: clang++
             cxx_std: 17
             python_ver: "3.11"
             aclang: 14
@@ -452,13 +456,15 @@ jobs:
           - desc: MacOS-14-ARM
             runner: macos-14
             nametag: macos14-arm-py311
+            cc_compiler: clang
+            cxx_compiler: clang++
             cxx_std: 20
             python_ver: "3.11"
             aclang: 15
     runs-on: ${{ matrix.runner }}
     env:
-      CC: clang
-      CXX: clang++
+      CXX: ${{matrix.cxx_compiler}}
+      CC: ${{matrix.cc_compiler}}
       CMAKE_CXX_STANDARD: ${{ matrix.cxx_std }}
       PYTHON_VERSION: ${{ matrix.python_ver }}
       USE_SIMD: ${{matrix.simd}}

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -20,7 +20,9 @@ if [[ `which brew` == "" ]] ; then
 fi
 
 
-#brew update >/dev/null
+if [[ "${DO_BREW_UPDATE:=0}" != "0" ]] ; then
+    brew update >/dev/null
+fi
 echo ""
 echo "Before my brew installs:"
 brew list --versions
@@ -48,6 +50,10 @@ fi
 if [[ "${USE_QT}" != "0" ]] ; then
     brew install --display-times -q qt${QT_VERSION}
 fi
+if [[ "${USE_LLVM:=0}" != "0" ]] || [[ "${LLVMBREWVER}" != "" ]]; then
+    brew install --display-times -q llvm${LLVMBREWVER}
+    export PATH=/usr/local/opt/llvm/bin:$PATH
+fi
 
 echo ""
 echo "After brew installs:"
@@ -61,7 +67,6 @@ pip${PYTHON_VERSION} install numpy
 export PATH=/usr/local/opt/qt5/bin:$PATH
 export PATH=/usr/local/opt/python/libexec/bin:$PATH
 export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH
-#export PATH=/usr/local/opt/llvm/bin:$PATH
 
 # Save the env for use by other stages
 src/build-scripts/save-env.bash

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -2,10 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+#include <OpenImageIO/platform.h>
+
+OIIO_PRAGMA_WARNING_PUSH
+OIIO_CLANG_PRAGMA(clang diagnostic ignored "-Wdeprecated-declarations")
+// Force include of locale header with deprecated warnings turned off to
+// combat clang18 vs unicode deprecation warnings.
+#include <locale>
+OIIO_PRAGMA_WARNING_POP
+
 #include <cstdlib>
 #include <string>
-
-#include <OpenImageIO/platform.h>
 
 #ifdef _WIN32
 #    include <windows.h>


### PR DESCRIPTION
This is a continuation of PR 4246, had one more spot where we needed to disable warnings for unity builds involving clang18 and deprecated unicode conversion functions.

There's some changes included to ci.yml and install_homebrew_deps.bash that are part of work I did to make it easier for me to force it to use clang-18 for certain tests while working on this.
