### PR TITLE
cleanup: change raw cerr stream output to print

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -50,7 +50,8 @@ static const Imath::C3f test_colors[n_test_colors]
 
 
 #if 0 || !defined(NDEBUG) /* allow color configuration debugging */
-static bool colordebug = Strutil::stoi(Sysutil::getenv("OIIO_COLOR_DEBUG"));
+static bool colordebug = Strutil::stoi(Sysutil::getenv("OIIO_DEBUG_COLOR"))
+                       || Strutil::stoi(Sysutil::getenv("OIIO_DEBUG_ALL"));
 #    define DBG(...)    \
         if (colordebug) \
         Strutil::print(__VA_ARGS__)

--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -10,6 +10,8 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/string_view.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/typedesc.h>
 
 #include <ImathBox.h>
@@ -24,25 +26,21 @@
 
 #define OPENEXR_HAS_FLOATVECTOR 1
 
-#define ENABLE_READ_DEBUG_PRINTS 0
-
+#define ENABLE_EXR_DEBUG_PRINTS 0
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-#if OIIO_CPLUSPLUS_VERSION >= 17 || defined(__cpp_lib_gcd_lcm)
-using std::gcd;
+// Lots of debugging printf turned on for DEBUG builds or if you define
+// ENABLE_EXR_DEBUG_PRINTS above, *AND* the "OIIO_DEBUG_OPENEXR" environment
+// variable is set to something numerically non-zero.
+#if ENABLE_EXR_DEBUG_PRINTS || !defined(NDEBUG) /* allow debugging */
+static bool exrdebug = Strutil::stoi(Sysutil::getenv("OIIO_DEBUG_OPENEXR"))
+                       || Strutil::stoi(Sysutil::getenv("OIIO_DEBUG_ALL"));
+#    define DBGEXR(...) \
+        if (exrdebug)   \
+        Strutil::print(__VA_ARGS__)
 #else
-template<class M, class N, class T = std::common_type_t<M, N>>
-inline T
-gcd(M a, N b)
-{
-    while (b) {
-        T t = b;
-        b   = a % b;
-        a   = t;
-    }
-    return a;
-}
+#    define DBGEXR(...)
 #endif
 
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -583,7 +583,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
                 r[1] = static_cast<int>(d);
                 spec.attribute(oname, TypeRational, r);
             } else {
-                int f = static_cast<int>(gcd(int64_t(n), int64_t(d)));
+                int f = static_cast<int>(std::gcd(int64_t(n), int64_t(d)));
                 if (f > 1) {
                     int r[2];
                     r[0] = n / f;
@@ -598,7 +598,8 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
             }
         } else {
 #if 0
-            std::cerr << "  unknown attribute " << type << ' ' << name << "\n";
+            print(std::cerr, "  unknown attribute '{}' name '{}'\n",
+                  type, name);
 #endif
         }
     }
@@ -1128,8 +1129,8 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     if (!seek_subimage(subimage, miplevel))
         return false;
     chend = clamp(chend, chbegin + 1, m_spec.nchannels);
-    //    std::cerr << "openexr rns " << ybegin << ' ' << yend << ", channels "
-    //              << chbegin << "-" << (chend-1) << "\n";
+    DBGEXR("openexr rns {} {}-{}, channels {}-{}", ybegin, yend, chbegin,
+           chend - 1);
 
     // Compute where OpenEXR needs to think the full buffers starts.
     // OpenImageIO requires that 'data' points to where the client wants
@@ -1258,11 +1259,8 @@ OpenEXRInput::read_native_tiles(int subimage, int miplevel, int xbegin,
             "OpenEXRInput::read_native_tiles is not supported for luminance-chroma images");
         return false;
     }
-#if 0
-    std::cerr << "openexr rnt " << xbegin << ' ' << xend << ' ' << ybegin 
-              << ' ' << yend << ", chans " << chbegin
-              << "-" << (chend-1) << "\n";
-#endif
+    DBGEXR("openexr rnt {} {}-{}, chans {}-{}", xbegin, xend, ybegin, yend,
+           chend - 1);
     if (!m_tiled_input_part
         || !m_spec.valid_tile_range(xbegin, xend, ybegin, yend, zbegin, zend)) {
         errorfmt("called OpenEXRInput::read_native_tiles without an open file");


### PR DESCRIPTION
A small piece of the ongoing switch to std::format/print style text output. This part is for error and debugging output when reading/writing exr images.

I also switched conditional compilation to the DBG macro idiom that I've used elsewhere, where it takes a combination of DEBUG compile and setting of environment variable OIIO_DEBUG_OPENEXR to trigger the printf style debugging (the first use case of this was in our color management code, which I also modify slightly here to conform).

Also opportunistically simplify gcd declaration now that we're C++17 minimum.
