### PR TITLE
build: Add CMath target for the sake of static libtiff

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -36,6 +36,17 @@ include (FindThreads)
 # that we will not complete the build if they are not found.
 
 checked_find_package (ZLIB REQUIRED)  # Needed by several packages
+
+# Help set up this target for libtiff config file when using static libtiff
+if (NOT TARGET CMath::CMath)
+    find_library (MATH_LIBRARY m)
+    if (NOT MATH_LIBRARY-NOTFOUND)
+        add_library (CMath::CMath UNKNOWN IMPORTED)
+        set_property (TARGET CMath::CMath
+                      APPEND PROPERTY IMPORTED_LOCATION  ${MATH_LIBRARY})
+    endif ()
+endif ()
+
 checked_find_package (TIFF REQUIRED
                       VERSION_MIN 3.9
                       RECOMMEND_MIN 4.0


### PR DESCRIPTION
Recent libtiff versions export cmake configs that, if you built libtiff as a static library, will reference targets it set up when it built, but which are nonstandard names and won't exist when you build and consume their config exports. Ugh!

Some can be swept under the rug by turning off some libtiff optional dependencies, but I can't seem to get rid of a target CMath::CMath that static libtiff target wants. It just points to the math library. So I'm just setting that up so it will be found when we do the find_package(tiff). Oh, the hoops we jump through for badly constructed packges.
