### PR TITLE
Add proxy support for EXR multipart output (#4263)

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -582,8 +582,8 @@ OpenEXROutput::open(const std::string& name, int subimages,
             // If the proxy couldn't be opened in write mode, try to
             // return an error.
             std::string e = m_io->error();
-            errorf("Could not open \"%s\" (%s)", name,
-                   e.size() ? e : std::string("unknown error"));
+            errorfmt("Could not open \"{}\" ({})", name,
+                     e.size() ? e : std::string("unknown error"));
             return false;
         }
         m_output_stream.reset(new OpenEXROutputStream(name.c_str(), m_io));

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -393,7 +393,6 @@ OpenEXROutput::open(const std::string& name, const ImageSpec& userspec,
                 m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Write);
                 m_local_io.reset(m_io);
             }
-            OIIO_ASSERT(m_io);
             if (m_io->mode() != Filesystem::IOProxy::Write) {
                 // If the proxy couldn't be opened in write mode, try to
                 // return an error.
@@ -577,7 +576,6 @@ OpenEXROutput::open(const std::string& name, int subimages,
             m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Write);
             m_local_io.reset(m_io);
         }
-        OIIO_ASSERT(m_io);
         if (m_io->mode() != Filesystem::IOProxy::Write) {
             // If the proxy couldn't be opened in write mode, try to
             // return an error.


### PR DESCRIPTION
## Description

Add proxy support for EXR multipart output by taking the setup code from the other open() overload and calling the constructor accepting a stream instead of a filename.

## Tests

I did not add any new tests. Is proxy support tested by the testsuite?

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.