### PR TITLE
build: gcc-14 support, testing, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,16 +295,16 @@ jobs:
                             USE_OPENVDB=0
                             WEBP_VERSION=v1.3.0
                             # The installed OpenVDB has a TLS conflict with Python 3.8
-          - desc: bleeding edge gcc13 C++20 py3.10 OCIO/libtiff/exr-master avx2
+          - desc: bleeding edge gcc14 C++20 py3.12 OCIO/libtiff/exr-master avx2
             nametag: linux-bleeding-edge
-            runner: ubuntu-22.04
-            cc_compiler: gcc-13
-            cxx_compiler: g++-13
+            runner: ubuntu-24.04
+            cc_compiler: gcc-14
+            cxx_compiler: g++-14
             cxx_std: 20
             fmt_ver: master
             openexr_ver: main
             pybind11_ver: master
-            python_ver: "3.10"
+            python_ver: "3.12"
             simd: avx2,f16c
             setenvs: export LIBJPEGTURBO_VERSION=main
                             LIBRAW_VERSION=master
@@ -313,9 +313,12 @@ jobs:
                             OPENJPEG_VERSION=master
                             PTEX_VERSION=main
                             PUGIXML_VERSION=master
-                            USE_OPENVDB=0
                             WEBP_VERSION=main
                             OIIO_CMAKE_FLAGS="-DFORTIFY_SOURCE=2"
+                            QT_VERSION=6
+                            EXTRA_DEP_PACKAGES="python3.12-dev python3-numpy"
+                            PIP_INSTALLS="none"
+                            USE_OPENVDB=0
                             # The installed OpenVDB has a TLS conflict with Python 3.8
           - desc: clang14 C++20 avx2 exr3.1 ocio2.1
             nametag: linux-clang14
@@ -403,6 +406,7 @@ jobs:
           path: /tmp/ccache
           key: ${{github.job}}-${{matrix.nametag}}-${{ steps.ccache_cache_keys.outputs.date }}
           restore-keys: ${{github.job}}-
+          save-always: true
       - name: Build setup
         run: |
             ${{matrix.setenvs}}
@@ -481,6 +485,7 @@ jobs:
           path: /Users/runner/.ccache
           key: ${{github.job}}-${{matrix.nametag}}-${{ steps.ccache_cache_keys.outputs.date }}
           restore-keys: ${{github.job}}-
+          save-always: true
       - name: Build setup
         run: |
             ${{matrix.setenvs}}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,9 +17,9 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * **C++17 or higher** (also builds with C++20)
      * The default build mode is C++17. This can be controlled by via the
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=20`, etc.
- * Compilers: **gcc 9.3** - 13.1, **clang 5** - 18, MSVS 2017 - 2019 (**v19.14
+ * Compilers: **gcc 9.3** - 14.1, **clang 5** - 18, MSVS 2017 - 2019 (**v19.14
    and up**), **Intel icc 19+**, Intel OneAPI C++ compiler 2022+.
- * **CMake >= 3.15** (tested through 3.28)
+ * **CMake >= 3.15** (tested through 3.29)
  * **OpenEXR/Imath >= 3.1** (tested through 3.2
    and main) 
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.6)

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -101,7 +101,9 @@ else
         time sudo apt-get -q install -y python3.9-dev python3-numpy
         pip3 --version
     fi
-    pip3 install numpy
+    if [[ "${PIP_INSTALLS:=numpy}" != "none" ]] ; then
+        time pip3 install ${PIP_INSTALLS}
+    fi
 
     if [[ "$USE_LIBHEIF" != "0" ]] ; then
        sudo add-apt-repository ppa:strukturag/libde265 || true
@@ -123,6 +125,8 @@ else
         time sudo apt-get install -y g++-12
     elif [[ "$CXX" == "g++-13" ]] ; then
         time sudo apt-get install -y g++-13
+    elif [[ "$CXX" == "g++-14" ]] ; then
+        time sudo apt-get install -y g++-14
     fi
 
     if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$USE_ICX" != "" ]] ; then

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -363,11 +363,16 @@ private:
     bool m_broken;                 ///< has errors; can't be used properly
     bool m_allow_release = true;   ///< Allow the file to release()?
     std::string m_broken_message;  ///< Error message for why it's broken
+#if __cpp_lib_atomic_shared_ptr >= 201711L /* C++20 has atomic<shared_pr> */
+    // Open ImageInput, NULL if closed
+    std::atomic<std::shared_ptr<ImageInput>> m_input;
+#else
     std::shared_ptr<ImageInput> m_input;  ///< Open ImageInput, NULL if closed
         // Note that m_input, the shared pointer itself, is NOT safe to
         // access directly. ALWAYS retrieve its value with get_imageinput
         // (it's thread-safe to use that result) and set its value with
         // set_imageinput -- those are guaranteed thread-safe.
+#endif
     std::vector<SubimageInfo> m_subimages;  ///< Info on each subimage
     TexFormat m_texformat;                  ///< Which texture format
     TextureOpt::Wrap m_swrap;               ///< Default wrap modes

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -117,7 +117,7 @@ declare_imagecache(py::module& m)
         .def("resolve_filename",
              [](ImageCacheWrap& ic, const std::string& filename) {
                  py::gil_scoped_release gil;
-                 return PY_STR(ic.m_cache->resolve_filename(filename));
+                 return ic.m_cache->resolve_filename(filename);
              })
         // .def("get_image_info", &ImageCacheWrap::get_image_info)
         .def(
@@ -147,14 +147,14 @@ declare_imagecache(py::module& m)
         .def(
             "geterror",
             [](ImageCacheWrap& self, bool clear) {
-                return PY_STR(self.m_cache->geterror(clear));
+                return self.m_cache->geterror(clear);
             },
             "clear"_a = true)
         .def(
             "getstats",
             [](ImageCacheWrap& ic, int level) {
                 py::gil_scoped_release gil;
-                return PY_STR(ic.m_cache->getstats(level));
+                return ic.m_cache->getstats(level);
             },
             "level"_a = 1)
         .def(


### PR DESCRIPTION
* Switch runner type for bleeding edge, use gcc14 and python 3.12

* Various minor gcc-14 + C++20 + Python 3.12 fixes

Notable: gcc14 warns about std::atomic_load for share_ptr as deprecated, since C++20 provides a true atomic shared pointer.

