### PR TITLE
fix(fmath.h): One more fast_exp fix

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1852,7 +1852,7 @@ template<typename T>
 OIIO_FORCEINLINE OIIO_HOSTDEVICE T fast_exp2 (const T& xval) {
     using namespace simd;
     typedef typename T::vint_t intN;
-#if OIIO_SIMD_SSE || OIIO_SIMD_NEON
+#if (OIIO_SIMD_SSE || OIIO_SIMD_NEON) && !OIIO_MSVS_BEFORE_2022
     // See float specialization for explanations
     T x = clamp (xval, T(-126.0f), T(126.0f));
     intN m (x); x -= T(m);


### PR DESCRIPTION
In PR #4268, I accidentally changed the clause addressing what is seemingly a bug with older MSVS. I'm just putting things back the way they were. It's not a new change, just restoring this line closer to the way it was about 3 commits back.
