### PR TITLE
fix: Update INSTALL.md for windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -281,9 +281,9 @@ the section below, and will only have to point OIIO build process so their locat
   ```
   cd {ZLIB_ROOT}
   git clone https://github.com/madler/zlib .
-  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.
+  cmake -S . -B build -DCMAKE_INSTALL_PREFIX=.
   cmake --build build --config Release --target install
-  del build\lib\zlib.lib
+  del build\Release\zlib.lib
   ```
 * libTIFF:
   ```
@@ -296,8 +296,6 @@ the section below, and will only have to point OIIO build process so their locat
   ```
   cd {JPEG_ROOT}
   git clone https://github.com/libjpeg-turbo/libjpeg-turbo .
-  mkdir build
-  cd build
   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_SHARED=OFF -DCMAKE_INSTALL_PREFIX=.
   cmake --build build --config Release --target install
   ```
@@ -322,12 +320,13 @@ cd {OIIO_ROOT}
 git clone https://github.com/AcademySoftwareFoundation/OpenImageIO .
 cmake -S . -B build -DVERBOSE=ON -DCMAKE_BUILD_TYPE=Release ^
   -DZLIB_ROOT={ZLIB_ROOT}\build ^
-  -DTIFF_ROOT={TIFF_ROOT}\build ^
+  -DTIFF_ROOT={TIFF_ROOT} ^
   -DOpenEXR_ROOT={EXR_ROOT}\dist ^
   -DImath_DIR={EXR_ROOT}\dist\lib\cmake\Imath ^
   -DImath_INCLUDE_DIR={EXR_ROOT}\dist\include\Imath ^
   -DImath_LIBRARY={EXR_ROOT}\dist\lib\Imath-3_2.lib ^
-  -DJPEG_ROOT={JPEG_ROOT}\build ^
+  -DJPEG_ROOT={JPEG_ROOT} ^
+  -Dlibjpeg-turbo_ROOT={JPEG_ROOT} ^
   -DUSE_PYTHON=0 -DUSE_QT=0 -DBUILD_SHARED_LIBS=0 -DLINKSTATIC=1
 ```
 


### PR DESCRIPTION
While making a CI to build python wheels for OIIO on windows I spotted a few issues in the instructions, these edits made it work for me.

## Description

Small adjustment to expected paths for the manual instructions.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [-] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [-] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [-] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
