### PR TITLE
ci: For Windows CI, build only release of vcpkg packages

### DIFF
--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -13,10 +13,10 @@ VCPKG_INSTALLATION_ROOT=/c/vcpkg
 
 export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:=.}
 export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$DEP_DIR"
-export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
-export PATH="$PATH:$DEP_DIR/bin:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin:/bin:$PWD/ext/dist/bin:$PWD/ext/dist/lib"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
+export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release"
+export PATH="$PATH:$DEP_DIR/bin:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/bin:/bin:$PWD/ext/dist/bin:$PWD/ext/dist/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/bin"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/lib"
 
 # export MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 # export OPENEXR_CMAKE_FLAGS="$OPENEXR_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
@@ -48,33 +48,33 @@ echo "---------------"
 # vcpkg update
 # 
 
-#vcpkg install libdeflate:x64-windows
-#vcpkg install zlib:x64-windows
-vcpkg install tiff:x64-windows
-# vcpkg install libpng:x64-windows
-# vcpkg install giflib:x64-windows
-vcpkg install freetype:x64-windows
-# # vcpkg install openexr:x64-windows
-vcpkg install libjpeg-turbo:x64-windows
+#vcpkg install libdeflate:x64-windows-release
+#vcpkg install zlib:x64-windows-release
+vcpkg install tiff:x64-windows-release
+# vcpkg install libpng:x64-windows-release
+# vcpkg install giflib:x64-windows-release
+vcpkg install freetype:x64-windows-release
+# # vcpkg install openexr:x64-windows-release
+vcpkg install libjpeg-turbo:x64-windows-release
 # 
-# vcpkg install libraw:x64-windows
-# vcpkg install openjpeg:x64-windows
-# # vcpkg install ffmpeg:x64-windows   # takes FOREVER!
-# # vcpkg install webp:x64-windows  # No such vcpkg package?a
+# vcpkg install libraw:x64-windows-release
+# vcpkg install openjpeg:x64-windows-release
+# # vcpkg install ffmpeg:x64-windows-release   # takes FOREVER!
+# # vcpkg install webp:x64-windows-release  # No such vcpkg package?a
 # 
 # #echo "$VCPKG_INSTALLATION_ROOT"
 # #ls "$VCPKG_INSTALLATION_ROOT"
-# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
-# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
-# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
-# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
-# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
-# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
+# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release"
+# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release"
+# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/lib"
+# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/lib"
+# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/bin"
+# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/bin"
 # 
-# # export PATH="$PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
-# export PATH="$DEP_DIR/lib:$DEP_DIR/bin:$PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
-export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
-# export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib:$DEP_DIR/lib:$DEP_DIR/bin"
+# # export PATH="$PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/bin"
+# export PATH="$DEP_DIR/lib:$DEP_DIR/bin:$PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/lib"
+export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release"
+# export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-release/lib:$DEP_DIR/lib:$DEP_DIR/bin"
 # 
 echo "All VCPkg installs:"
 vcpkg list


### PR DESCRIPTION
This cuts down CI time, as before we were building both release and debug versions of the packages.

The dependency building step of our CI typically took around 6.5-7 minutes previously, and with this patch, now typically is about 5 minutes and sometimes slightly less.

Thanks so much to @cedrik-fuoco who pointed me at this feature of vcpkg which had eluded me for a long time!
