### PR TITLE
build: Upgrade to more modern python3 finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,8 @@ endif ()
 
 if (USE_PYTHON AND Python3_Development_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
     add_subdirectory (src/python)
+else ()
+    message (STATUS "Not building Python bindings: USE_PYTHON=${USE_PYTHON}, Python3_Development_FOUND=${Python3_Development_FOUND}")
 endif ()
 
 add_subdirectory (src/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ if (NOT EMBEDPLUGINS AND NOT BUILD_OIIOUTIL_ONLY)
     endforeach ()
 endif ()
 
-if (USE_PYTHON AND Python_Development_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
+if (USE_PYTHON AND Python3_Development_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
     add_subdirectory (src/python)
 endif ()
 

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -19,8 +19,8 @@ endif ()
 # Python cannot be found, it will be a fatal error.
 macro (find_python)
     if (NOT VERBOSE)
-        set (PythonInterp_FIND_QUIETLY true)
-        set (PythonLibs_FIND_QUIETLY true)
+        set (PythonInterp3_FIND_QUIETLY true)
+        set (PythonLibs3_FIND_QUIETLY true)
     endif ()
 
     # Attempt to find the desired version, but fall back to other
@@ -32,23 +32,23 @@ macro (find_python)
             list (APPEND _req EXACT)
         endif ()
     endif ()
-    checked_find_package (Python ${PYTHON_VERSION}
+    checked_find_package (Python3 ${PYTHON_VERSION}
                           ${_req}
                           VERSION_MIN 3.7
                           COMPONENTS Interpreter Development
-                          PRINT Python_VERSION Python_EXECUTABLE
-                                Python_LIBRARIES
-                                Python_Development_FOUND
-                                Python_Interpreter_FOUND )
+                          PRINT Python3_VERSION Python3_EXECUTABLE
+                                Python3_LIBRARIES
+                                Python3_Development_FOUND
+                                Python3_Interpreter_FOUND )
 
     # The version that was found may not be the default or user
     # defined one.
-    set (PYTHON_VERSION_FOUND ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR})
+    set (PYTHON_VERSION_FOUND ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR})
 
     # Give hints to subsequent pybind11 searching to ensure that it finds
     # exactly the same version that we found.
-    set (PythonInterp_FIND_VERSION PYTHON_VERSION_FOUND)
-    set (PythonInterp_FIND_VERSION_MAJOR ${Python_VERSION_MAJOR})
+    set (PythonInterp_FIND_VERSION PYTHON3_VERSION_FOUND)
+    set (PythonInterp_FIND_VERSION_MAJOR ${Python3_VERSION_MAJOR})
 
     if (NOT DEFINED PYTHON_SITE_DIR)
         set (PYTHON_SITE_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_FOUND}/site-packages/OpenImageIO")

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -47,8 +47,8 @@ macro (find_python)
 
     # Give hints to subsequent pybind11 searching to ensure that it finds
     # exactly the same version that we found.
-    set (PythonInterp_FIND_VERSION PYTHON3_VERSION_FOUND)
-    set (PythonInterp_FIND_VERSION_MAJOR ${Python3_VERSION_MAJOR})
+    set (PythonInterp3_FIND_VERSION PYTHON_VERSION_FOUND)
+    set (PythonInterp3_FIND_VERSION_MAJOR ${Python3_VERSION_MAJOR})
 
     if (NOT DEFINED PYTHON_SITE_DIR)
         set (PYTHON_SITE_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_FOUND}/site-packages/OpenImageIO")

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -105,7 +105,7 @@ macro (oiio_add_tests)
                 set (_testname "${_testname}-broken")
             endif ()
 
-            set (_runtest ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/testsuite/runtest.py" ${_testdir})
+            set (_runtest ${Python3_EXECUTABLE} "${CMAKE_SOURCE_DIR}/testsuite/runtest.py" ${_testdir})
             if (MSVC_IDE)
                 set (_runtest ${_runtest} --devenv-config $<CONFIGURATION>
                                           --solution-path "${CMAKE_BINARY_DIR}" )

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # generate man pages using txt2man and a tiny python script to munge the
 # result of "$tool --help"
 find_program(TXT2MAN txt2man)
-if (UNIX AND TXT2MAN AND Python_Interpreter_FOUND)
+if (UNIX AND TXT2MAN AND Python3_Interpreter_FOUND)
     message (STATUS "Unix man page documentation will be generated")
     set (cli_tools oiiotool iinfo maketx idiff igrep iconvert)
 
@@ -34,7 +34,7 @@ if (UNIX AND TXT2MAN AND Python_Interpreter_FOUND)
         list (APPEND manpage_files ${outfile})
         add_custom_command (OUTPUT ${outfile}
             COMMAND ${tool} --help |
-            ${Python_EXECUTABLE} "${documentation_SOURCE_DIR}/help2man_preformat.py" |
+            ${Python3_EXECUTABLE} "${documentation_SOURCE_DIR}/help2man_preformat.py" |
             ${TXT2MAN} -v OpenImageIO -s 1 -t ${tool} > ${outfile}
             DEPENDS ${tool} help2man_preformat.py)
     endforeach()

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -120,7 +120,7 @@ target_compile_definitions(OpenImageIO
               PRIVATE
                   OIIO_FREETYPE_VERSION="${FREETYPE_VERSION_STRING}"
                   OIIO_OpenCV_VERSION="${OpenCV_VERSION}"
-                  OIIO_PYTHON_VERSION="${Python_VERSION}"
+                  OIIO_PYTHON_VERSION="${Python3_VERSION}"
                   OIIO_QT_VERSION="${Qt6_VERSION}${Qt5_VERSION}"
                   OIIO_TBB_VERSION="${TBB_VERSION}"
              )


### PR DESCRIPTION
Latest versions of cmake are warning about FindPython being a deprecated module, they recommend FindPython2 or FindPython3 instead. In master, we're already python3 minimum, so go ahead and switch this to the modern method.
