### PR TITLE
fix: Address ignored annotation nvcc warnings on explicitly-defaulted functions

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -164,8 +164,7 @@ struct OIIO_UTIL_API TypeDesc {
     TypeDesc (string_view typestring);
 
     /// Copy constructor.
-    OIIO_HOSTDEVICE constexpr TypeDesc (const TypeDesc &t) noexcept = default;
-
+    constexpr TypeDesc (const TypeDesc &t) noexcept = default;
 
     /// Return the name, for printing and whatnot.  For example,
     /// "float", "int[5]", "normal"

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -796,11 +796,10 @@ public:
     ~ustringhash() noexcept = default;
 
     /// Copy construct a ustringhash from another ustringhash.
-    OIIO_HOSTDEVICE constexpr ustringhash(const ustringhash& str) noexcept
-        = default;
+    constexpr ustringhash(const ustringhash& str) noexcept = default;
 
     /// Move construct a ustringhash from another ustringhash.
-    OIIO_HOSTDEVICE ustringhash(ustringhash&& str) noexcept = default;
+    ustringhash(ustringhash&& str) noexcept = default;
 
     /// Construct from a ustring
     ustringhash(const ustring& str) noexcept
@@ -864,9 +863,8 @@ public:
     }
 
     /// Assign from a ustringhash
-    OIIO_HOSTDEVICE constexpr ustringhash& operator=(const ustringhash& str)
-        = default;
-    OIIO_HOSTDEVICE ustringhash& operator=(ustringhash&& str) = default;
+    constexpr ustringhash& operator=(const ustringhash& str) = default;
+    ustringhash& operator=(ustringhash&& str)                = default;
 
     /// Assign from a ustring
     ustringhash& operator=(const ustring& str)


### PR DESCRIPTION
## Description

We're seeing nvcc compilation warnings like the following:
```
ustring.h(869): warning #20012-D: __device__ annotation is ignored on a function("operator=") that is explicitly defaulted on its first declaration
     __attribute__((host)) __attribute__((device)) 
```

According to nvidia's documentation (https://docs.nvidia.com/cuda/archive/10.1/cuda-c-programming-guide/index.html#compiler-generated-functions), functions that are explicitly-defaulted should not have execution space specifiers like \_\_device\_\_ or \_\_host\_\_. Instead the compiler will determine the annotations from the functions that invoke it.

This patch goes through the ustring and typedesc headers and removes OIIO_HOSTDEVICE from all defaulted functions.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
