### PR TITLE
Simplify tile cache clearing.

### DIFF
--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -461,6 +461,18 @@ public:
             bin.unlock();
     }
 
+    /// Removes all items from the map.
+    void clear()
+    {
+        for (size_t b = 0; b < BINS; b++) {
+            m_bins[b].lock();
+            BinMap_t map;
+            std::swap(m_bins[b].map, map);
+            m_size -= map.size();
+            m_bins[b].unlock();
+        }
+    }
+
     /// Return true if the entire map is empty.
     bool empty() { return m_size == 0; }
 

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -464,12 +464,17 @@ public:
     /// Removes all items from the map.
     void clear()
     {
+        if (empty())
+            return;
         for (size_t b = 0; b < BINS; b++) {
-            m_bins[b].lock();
             BinMap_t map;
-            std::swap(m_bins[b].map, map);
-            m_size -= map.size();
-            m_bins[b].unlock();
+            Bin& bin(m_bins[b]);
+            bin.lock();
+            if (!bin.map.empty()) {
+                bin.map.swap(map);
+                m_size -= map.size();
+            }
+            bin.unlock();
         }
     }
 

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3532,13 +3532,7 @@ ImageCacheImpl::invalidate_all(bool force)
     // to do it all in one shot.
     if (force) {
         // Clear the whole tile cache
-        std::vector<TileID> tiles_to_delete;
-        for (TileCache::iterator t = m_tilecache.begin(), e = m_tilecache.end();
-             t != e; ++t) {
-            tiles_to_delete.push_back(t->second->id());
-        }
-        for (const TileID& id : tiles_to_delete)
-            m_tilecache.erase(id);
+        m_tilecache.clear();
         // Invalidate (close and clear spec) all individual files
         for (FilenameMap::iterator fileit = m_files.begin(), e = m_files.end();
              fileit != e; ++fileit) {


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Simplifies the clearing of the tile cache so it no longer allocates a vector of tile IDs prior to erasing them all.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
