### PR TITLE
Rudimentary CUDA support infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,8 @@ include (pythonutils)
 # Dependency finding utilities and all dependency-related options
 include (externalpackages)
 
+include (cuda_macros)
+
 # Include all our testing apparatus and utils, but not if it's a subproject
 if (PROJECT_IS_TOP_LEVEL)
     include (testing)

--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -72,7 +72,8 @@ fi
 export PAR_MAKEFLAGS=-j${PARALLEL}
 export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL:=${PARALLEL}}
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:=${PARALLEL}}
-
+export OIIO_USE_CUDA=1
+export CUDAToolkit_ROOT=/usr/local/cuda
 
 mkdir -p build dist
 

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -37,6 +37,12 @@ message (STATUS "Building with C++${CMAKE_CXX_STANDARD}, downstream minimum C++$
 if (CMAKE_CXX_STANDARD VERSION_LESS CMAKE_CXX_MINIMUM)
     message (FATAL_ERROR "C++${CMAKE_CXX_STANDARD} is not supported, minimum is C++${CMAKE_CXX_MINIMUM}")
 endif ()
+# Remember the -std flags we need will be used later for custom Cuda builds
+set (CSTD_FLAGS "")
+if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_INTEL)
+    set (CSTD_FLAGS "-std=c++${CMAKE_CXX_STANDARD}")
+endif ()
+
 
 ###########################################################################
 # Figure out which compiler we're using
@@ -218,7 +224,6 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
     # this allows native instructions to be used for sqrtf instead of a function call
     add_compile_options ("-fno-math-errno")
 endif ()
-
 
 # We will use this for ccache and timing
 set (MY_RULE_LAUNCH "")

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -1,0 +1,36 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
+set_option (OIIO_USE_CUDA "Include Cuda support if found" OFF)
+set_cache (CUDA_TARGET_ARCH "sm_60" "CUDA GPU architecture (e.g. sm_60)")
+set_cache (CUDAToolkit_ROOT "" "Path to CUDA toolkit")
+
+if (OIIO_USE_CUDA)
+    if (OIIO_USE_CUDA AND CMAKE_VERSION VERSION_LESS 3.18)
+        message (WARNING "CMake >= 3.18 is required to correctly find the CUDA dependency")
+    endif ()
+    set (CUDA_PROPAGATE_HOST_FLAGS ON)
+    set (CUDA_VERBOSE_BUILD ${VERBOSE})
+    checked_find_package(CUDAToolkit
+                         VERSION_MIN 9.0
+                         RECOMMEND_MIN 11.0
+                         RECOMMEND_MIN_REASON
+                            "We don't actively test CUDA older than 11"
+                         )
+    list (APPEND CUDA_NVCC_FLAGS ${CSTD_FLAGS} -expt-relaxed-constexpr)
+    if (CUDAToolkit_FOUND)
+        add_compile_definitions (OIIO_USE_CUDA=1)
+    endif ()
+endif ()
+
+
+# Add necessary ingredients to make `target` include and link against Cuda.
+function (oiio_cuda_target target)
+    if (CUDAToolkit_FOUND)
+        target_link_libraries (${target} PRIVATE
+                               CUDA::cudart_static
+                              )
+    endif ()
+endfunction()

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -929,6 +929,13 @@ output each one to a different file, with names `sub0001.tif`,
     default (also if n=0) is to use as many threads as there are cores
     present in the hardware.
 
+.. option:: --gpu <n>
+
+    EXPERIMENTAL: Enable a GPU or other compute acceleration device, if
+    available.
+
+    This was added in OIIO 3.0.
+
 .. option:: --cache <size>
 
     Causes images to be read through an ImageCache and set the underlying

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -59,6 +59,7 @@ OIIO_API const std::vector<std::string>&
 font_list();
 
 
+
 // For internal use - use error() below for a nicer interface.
 void
 append_error(string_view message);
@@ -229,6 +230,53 @@ compute_sha1(ImageInput* input, int subimage, int miplevel, std::string& err);
 OIIO_API bool
 print_stats(std::ostream& out, string_view indent, const ImageBuf& input,
             const ImageSpec& spec, ROI roi, std::string& err);
+
+
+enum class ComputeDevice : int {
+    CPU  = 0,
+    CUDA = 1,
+    // Might expand later...
+};
+
+// Which compute device is currently active, and should be used by any
+// OIIO facilities that know how to use it.
+OIIO_API ComputeDevice
+compute_device();
+
+#if 0
+/// Return true if CUDA is available to OpenImageIO at this time -- support
+/// enabled at build time, and has already been turned on with enable_cuda()
+/// or with OIIO::attribute("cuda", 1), and hardware is present and was
+/// successfully initialized.
+OIIO_API bool
+openimageio_cuda();
+#endif
+
+// Set an attribute related to OIIO's use of GPUs/compute devices. This is a
+// strictly internal function. User code should just call OIIO::attribute()
+// and GPU-related attributes will be directed here automatically.
+OIIO_API bool
+gpu_attribute(string_view name, TypeDesc type, const void* val);
+
+// Retrieve an attribute related to OIIO's use of GPUs/compute devices. This
+// is a strictly internal function. User code should just call
+// OIIO::getattribute() and GPU-related attributes will be directed here
+// automatically.
+OIIO_API bool
+gpu_getattribute(string_view name, TypeDesc type, void* val);
+
+
+/// Allocate compute device memory
+OIIO_API void*
+device_malloc(size_t size);
+
+/// Allocate unified compute device memory -- visible on both CPU & GPU
+OIIO_API void*
+device_unified_malloc(size_t size);
+
+/// Free compute device memory
+OIIO_API void
+device_free(void* mem);
 
 }  // namespace pvt
 

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -66,6 +66,7 @@ set (libOpenImageIO_srcs
                           maketexture.cpp
                           bluenoise.cpp
                           printinfo.cpp
+                          oiio_gpu.cpp
                           ../libtexture/texturesys.cpp
                           ../libtexture/texture3d.cpp
                           ../libtexture/environment.cpp
@@ -174,6 +175,8 @@ endif()
 if (MINGW)
     target_link_libraries (OpenImageIO PRIVATE ws2_32)
 endif()
+
+oiio_cuda_target (OpenImageIO)
 
 file (GLOB iba_sources "imagebufalgo_*.cpp")
 if (MSVC)

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -386,6 +386,12 @@ attribute(string_view name, TypeDesc type, const void* val)
         default_thread_pool()->resize(ot - 1);
         return true;
     }
+    if (Strutil::starts_with(name, "gpu:")
+        || Strutil::starts_with(name, "cuda:")) {
+        return pvt::gpu_attribute(name, type, val);
+    }
+
+    // Things below here need to buarded by the attrib_mutex
     spin_lock lock(attrib_mutex);
     if (name == "read_chunk" && type == TypeInt) {
         oiio_read_chunk = *(const int*)val;
@@ -485,6 +491,12 @@ getattribute(string_view name, TypeDesc type, void* val)
         *(ustring*)val = ustring(OIIO_VERSION_STRING);
         return true;
     }
+    if (Strutil::starts_with(name, "gpu:")
+        || Strutil::starts_with(name, "cuda:")) {
+        return pvt::gpu_getattribute(name, type, val);
+    }
+
+    // Things below here need to buarded by the attrib_mutex
     spin_lock lock(attrib_mutex);
     if (name == "read_chunk" && type == TypeInt) {
         *(int*)val = oiio_read_chunk;

--- a/src/libOpenImageIO/oiio_gpu.cpp
+++ b/src/libOpenImageIO/oiio_gpu.cpp
@@ -1,0 +1,298 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+#include <cstdlib>
+#include <mutex>
+
+#ifdef OIIO_USE_CUDA
+#    include <cuda.h>
+#    include <cuda_runtime.h>
+#else
+#    define CUDA_VERSION 0
+#endif
+
+#include "imageio_pvt.h"
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/thread.h>
+
+
+OIIO_NAMESPACE_BEGIN
+
+// Global private data
+namespace pvt {
+
+static ComputeDevice oiio_compute_device(ComputeDevice::CPU);
+
+
+ComputeDevice
+compute_device()
+{
+    return oiio_compute_device;
+}
+
+
+// These MUST match the order of enum ComputeDevice
+static const char* device_type_names[] = { "CPU", "CUDA" };
+
+
+
+std::mutex compute_mutex;
+
+// Cuda specific things
+// Was Cuda support enabled at build time?
+[[maybe_unused]] constexpr bool cuda_build_time_enabled = bool(CUDA_VERSION);
+
+constexpr int cuda_build_version
+    = (10000 * (CUDA_VERSION / 1000)         // major
+       + 100 * ((CUDA_VERSION % 1000) / 10)  // minor
+       + (CUDA_VERSION % 10));               // patch
+
+bool cuda_supported = false;  // CUDA present at runtime and initialized
+ustring cuda_device_name;
+int cuda_driver_version  = 0;
+int cuda_runtime_version = 0;
+int cuda_compatibility   = 0;
+size_t cuda_total_memory = 0;
+
+
+
+#ifdef OIIO_USE_CUDA
+
+thread_local std::string saved_cuda_error_message;
+
+inline std::string
+cuda_geterror()
+{
+    std::string e;
+    std::swap(e, saved_cuda_error_message);
+    return e;
+}
+
+static CUstream cuda_stream;
+
+
+// This will call a Cuda function and output the proper CUDA error strings in
+// the event that a CUDA host call returns an error.
+#    define checkCudaErrors(call) \
+        __checkCudaErrors(call, #call, __FILE__, __LINE__)
+#    define CUDA_CHECK(call) __checkCudaErrors(call, #call, __FILE__, __LINE__)
+
+static bool
+__checkCudaErrors(cudaError_t err, const char* call, const char* file,
+                  const int line)
+{
+    if (err != cudaSuccess) {
+        saved_cuda_error_message += Strutil::fmt::format(
+            "CUDA runtime API error {}: {} ({} @ {}:{})\n", (int)err,
+            cudaGetErrorString(err), call, file, line);
+    }
+    return (err == cudaSuccess);
+}
+
+
+
+static void
+initialize_cuda()
+{
+    std::lock_guard lock(compute_mutex);
+
+    // Environment OPENIMAGEIO_CUDA=0 trumps everything else, turns off
+    // Cuda functionality. We don't even initialize in this case.
+    std::string env = Sysutil::getenv("OPENIMAGEIO_CUDA");
+    if (env.size() && Strutil::eval_as_bool(env) == false) {
+        OIIO::debugfmt("CUDA disabled by $OPENIMAGEIO_CUDA\n");
+        return;
+    }
+
+    // Get number of devices supporting CUDA
+    int deviceCount = 0;
+    if (!checkCudaErrors(cudaGetDeviceCount(&deviceCount))) {
+        return;
+    }
+
+    // Initialize CUDA
+    if (!CUDA_CHECK(cudaFree(0))) {
+        cuda_geterror();  // clear the error
+        return;
+    }
+
+    CUDA_CHECK(cudaSetDevice(0));
+    CUDA_CHECK(cudaStreamCreate(&cuda_stream));
+
+    OIIO::debugfmt("Number of CUDA devices: {}\n", deviceCount);
+    for (int dev = 0; dev < deviceCount; ++dev) {
+        cudaDeviceProp deviceProp;
+        CUDA_CHECK(cudaGetDeviceProperties(&deviceProp, dev));
+        CUDA_CHECK(cudaDriverGetVersion(&cuda_driver_version));
+        CUDA_CHECK(cudaRuntimeGetVersion(&cuda_runtime_version));
+        cuda_device_name   = ustring(deviceProp.name);
+        cuda_compatibility = 100 * deviceProp.major + deviceProp.minor;
+        cuda_total_memory  = deviceProp.totalGlobalMem;
+        OIIO::debugfmt(
+            "CUDA device \"{}\": driver {}, runtime {}, Cuda compat {}\n",
+            deviceProp.name, cuda_driver_version, cuda_runtime_version,
+            cuda_compatibility);
+        OIIO::debugfmt(" total mem {:g} MB\n",
+                       cuda_total_memory / (1024.0 * 1024.0));
+        break;  // only inventory the first Cuda device. FIXME?
+    }
+    cuda_supported = true;
+}
+
+#endif /* defined(OIIO_USE_CUDA) */
+
+
+
+/// Initialize CUDA if it has not already been initialized. Return true if
+/// CUDA facilities are available.
+bool
+enable_cuda()
+{
+#ifdef OIIO_USE_CUDA
+    static std::once_flag cuda_initialized;
+    std::call_once(cuda_initialized, initialize_cuda);
+#endif
+    return cuda_supported;
+}
+
+
+
+// Trick to fire up a CUDA device at static initialization time.
+struct cuda_force_initializer {
+    cuda_force_initializer() { (void)enable_cuda(); }
+};
+cuda_force_initializer init;
+
+
+
+void*
+device_malloc(size_t size)
+{
+#ifdef OIIO_USE_CUDA
+    if (oiio_compute_device == ComputeDevice::CUDA) {
+        char* cudaptr = nullptr;
+        checkCudaErrors(cudaMalloc(&cudaptr, size));
+        return cudaptr;
+    }
+#endif
+    return malloc(size);
+}
+
+
+
+void*
+device_unified_malloc(size_t size)
+{
+#ifdef OIIO_USE_CUDA
+    if (oiio_compute_device == ComputeDevice::CUDA) {
+        char* cudaptr = nullptr;
+        checkCudaErrors(cudaMallocManaged(&cudaptr, size));
+        return cudaptr;
+    }
+#endif
+    return malloc(size);
+}
+
+
+
+void
+device_free(void* mem)
+{
+#ifdef OIIO_USE_CUDA
+    if (oiio_compute_device == ComputeDevice::CUDA) {
+        // cudaDeviceSynchronize();
+        checkCudaErrors(cudaFree(mem));
+        return;
+    }
+#endif
+    return free(mem);
+}
+
+
+bool
+gpu_attribute(string_view name, TypeDesc type, const void* val)
+{
+    if (name == "gpu:device" && type == TypeString) {
+        // If requesting a device by name, find the index of the name in the
+        // list of device names and then request the device by index.
+        const char* request = (*(const char**)val);
+        int i               = 0;
+        for (auto& n : device_type_names) {
+            if (Strutil::iequals(request, n))
+                return gpu_attribute("gpu:device", TypeInt, &i);
+            ++i;
+        }
+        return false;
+    }
+    if (name == "gpu:device" && type == TypeInt) {
+        ComputeDevice request = ComputeDevice(*(const int*)val);
+        if (request == oiio_compute_device)
+            return true;  // Already using the requested device
+        if (request == ComputeDevice::CUDA) {
+            if (enable_cuda()) {
+                oiio_compute_device = request;
+                return true;
+            }
+        }
+        return false;  // Unsatisfiable request
+    }
+
+    // Below here needs mutual exclusion
+    std::lock_guard lock(compute_mutex);
+
+    return false;
+}
+
+
+
+bool
+gpu_getattribute(string_view name, TypeDesc type, void* val)
+{
+    if (name == "gpu:device" && type == TypeInt) {
+        *(int*)val = int(oiio_compute_device);
+        return true;
+    }
+    if (name == "cuda:build_version" && type == TypeInt) {
+        // Return encoded CUDA version as 10000*MAJOR + 100*MINOR + PATCH for
+        // the version of CUDA that we compiled against.
+        *(int*)val = cuda_build_version;
+        return true;
+    }
+    if (name == "cuda:driver_version" && type == TypeInt) {
+        *(int*)val = cuda_driver_version;
+        return true;
+    }
+    if (name == "cuda:runtime_version" && type == TypeInt) {
+        *(int*)val = cuda_runtime_version;
+        return true;
+    }
+    if (name == "cuda:compatibility" && type == TypeInt) {
+        *(int*)val = cuda_compatibility;
+        return true;
+    }
+    if (name == "cuda:total_memory_MB" && type == TypeInt) {
+        *(int*)val = int(cuda_total_memory >> 20);
+        return true;
+    }
+    if (name == "cuda:device_name" && type == TypeString) {
+        *(ustring*)val = cuda_device_name;
+        return true;
+    }
+    if (name == "cuda:devices_found" && type == TypeInt) {
+        *(int*)val = int(cuda_supported);
+        return true;
+    }
+
+    // Below here needs mutual exclusion for safety
+    std::lock_guard lock(compute_mutex);
+
+    return false;
+}
+
+
+}  // end namespace pvt
+
+OIIO_NAMESPACE_END

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -6160,8 +6160,8 @@ Oiiotool::getargs(int argc, char* argv[])
     ap.arg("--threads %d:N")
       .help("Number of threads (default 0 == #cores)")
       .OTACTION(set_threads);
-    ap.arg("--cuda")
-      .help("Enable CUDA if available")
+    ap.arg("--gpu")
+      .help("[EXPERIMENTAL] Use GPU if available (options: device=...)")
       .action([&](cspan<const char*>){
                   OIIO::attribute("gpu:device", "CUDA");
               });

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5931,17 +5931,24 @@ print_build_info(Oiiotool& ot, std::ostream& out)
 
     auto platform = format("OIIO {} | {}", OIIO_VERSION_STRING,
                            OIIO::get_string_attribute("build:platform"));
-    print("{}\n", Strutil::wordwrap(platform, columns, 4));
+    print(out, "{}\n", Strutil::wordwrap(platform, columns, 4));
 
     auto buildinfo = format("    Build compiler: {} | C++{}/{}",
                             OIIO::get_string_attribute("build:compiler"),
                             OIIO_CPLUSPLUS_VERSION, __cplusplus);
-    print("{}\n", Strutil::wordwrap(buildinfo, columns, 4));
+    print(out, "{}\n", Strutil::wordwrap(buildinfo, columns, 4));
 
     auto hwbuildfeats
         = format("    HW features enabled at build: {}",
                  OIIO::get_string_attribute("build:simd", "no SIMD"));
-    print("{}\n", Strutil::wordwrap(hwbuildfeats, columns, 4));
+    print(out, "{}\n", Strutil::wordwrap(hwbuildfeats, columns, 4));
+#ifdef OIIO_USE_CUDA
+    int cudaver = OIIO::get_int_attribute("cuda:build_version");
+    print(out, "    CUDA {}.{}.{} support enabled at build time\n",
+          cudaver / 10000, (cudaver / 100) % 100, cudaver % 100);
+#else
+    print(out, "    No CUDA support (disabled / unavailable at build time)\n");
+#endif
 
     std::string libs = OIIO::get_string_attribute("build:dependencies");
     if (libs.size()) {
@@ -5991,7 +5998,23 @@ print_help_end(Oiiotool& ot, std::ostream& out)
                                        Sysutil::physical_memory()
                                            / float(1 << 30),
                                        OIIO::get_string_attribute("hw:simd"));
-    print(out, "{}\n", Strutil::wordwrap(hwinfo, columns, 4));
+    print(out, "{}\n", Strutil::wordwrap(hwinfo, columns, 4, " ", ","));
+    if (OIIO::get_int_attribute("cuda:devices_found")
+        /*pvt::compute_device() == pvt::ComputeDevice::CUDA*/) {
+        auto compinfo = Strutil::fmt::format(
+            "Compute hardware available{}: CUDA on {}, driver {}, runtime {}, compat {}, memory {:.1f} GB",
+            pvt::compute_device() == pvt::ComputeDevice::CUDA
+                ? ""
+                : " (but not enabled)",
+            OIIO::get_string_attribute("cuda:device_name"),
+            OIIO::get_int_attribute("cuda:driver_version"),
+            OIIO::get_int_attribute("cuda:runtime_version"),
+            OIIO::get_int_attribute("cuda:compatibility"),
+            OIIO::get_int_attribute("cuda:total_memory_MB") / 1024.0);
+        print(out, "{}\n", Strutil::wordwrap(compinfo, columns, 4, " ", ","));
+    } else {
+        print(out, "    No compute specific hardware enabled.\n");
+    }
 
     // Print the path to the docs. If found, use the one installed in the
     // same area is this executable, otherwise just point to the copy on
@@ -6137,6 +6160,11 @@ Oiiotool::getargs(int argc, char* argv[])
     ap.arg("--threads %d:N")
       .help("Number of threads (default 0 == #cores)")
       .OTACTION(set_threads);
+    ap.arg("--cuda")
+      .help("Enable CUDA if available")
+      .action([&](cspan<const char*>){
+                  OIIO::attribute("gpu:device", "CUDA");
+              });
     ap.arg("--no-autopremult")
       .help("Turn off automatic premultiplication of images with unassociated alpha")
       .OTACTION(unset_autopremult);


### PR DESCRIPTION
Build-time check for Cuda toolkit as optional dependency.  This can be explicitly disabled with OIIO_USE_CUDA=OFF (though currently, it defaults to off, you have to turn it on at build time because this is all still experimental).  When this is enabled at build time, C++ preprocessor symbol OIIO_USE_CUDA will be defined within the OIIO codebase.

OIIO global `attribute("gpu:device", "CUDA")` can be used to enable CUDA functionality, which at this point doesn't do anything other than initialize the CUDA device and find out information about it.  Several global `getattribute("cuda:*")` queries let you find out some information about any device found.

I'm trying to keep a lot of the approaches fairly generic, so that the interface won't need to change much to allow OpenCL or Metal or whatever else comes along, though for now I'm trying to flesh out the implementation mostly with CUDA.

oiiotool adds a new `--cuda` option, reserved for enabling CUDA functionality. Currently the only way this is used is to print information about the CUDA device in the `oiiotool --help` messages. An example of that is:

```
$ oiiotool --cuda --help
oiiotool -- simple image processing operations
...

OIIO 2.6.2.0spi | Linux/x86_64
    Build compiler: gcc 9.3 | C++17/201703
    HW features enabled at build: sse2,sse3,ssse3,sse41,sse42
    CUDA 11.6.0 support enabled at build time
...
Running on 32 cores 187.3GB sse2,sse3,ssse3,sse41,sse42,avx,avx2,avx512f,
    avx512dq,avx512cd,avx512bw,avx512vl,fma,f16c,popcnt,rdrand
Compute hardware available: CUDA on Quadro RTX 6000, driver 12020,
    runtime 11060, compat 705, memory 23.6 GB
```

Note that at this point, we aren't actually *using* CUDA for anything. This is just setting up some basics for future expansion. It's all hidden in the pvt namespace for internal use only, and any of the functions or nomenclature may change as we continue to add functionality. I want to iterate on it a bit before it's in any way exposed in public headers or interfaces.

I'm a big fan of introducing even big strategic changes in the form of a series of MVP easy to review discrete steps. This step's only goals are: (a) allowing the build system to find and link against the CUDA Toolkit; (b) allowing runtime initialization and querying of a few basic facts about the device found; (c) start noodling around just a bit with function and attribute interfaces to gain a little experience that will guide what we eventually want.

LONG TERM goals of this initiative include:

* A full TextureSystem work-alike that can be used from CUDA (and possibly other compute device APIs) based renderers and with OSL's OptiX back and, having an analogous (ideally identical) interface and as close as possible to feature parity with CPU TextureSystem.

* Augment ImageBuf with the ability to store its images in GPU (or unified) memory and for IBA functions to be able to operate on those GPU-side buffers with GPU compute kernels, somewhat analogously to how libraries like PyTorch provides optional GPU support for tensor operations. (The hope is that this improves impage processing performance, though it's possible that it'll turn out that typical OIIO image processing workflows are so I/O dominated that there's not a lot of potential upside.  I think we'll have to try before we really find out if it's going to be worth it.)

* Allow image reading/writing plugins (or other parts of OIIO functionality) to leverage a GPU if available, and if there is something productive they can do with it.
