### PR TITLE
ci: new tets: oldest, hobbled, localbuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,26 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             pybind11_ver: v2.10.0
-          - desc: oldest/hobbled gcc9.3/C++17 py3.7 exr-3.1 no-sse no-ocio
-            # Oldest versions of the dependencies that we can muster, and various
-            # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins).
+          - desc: oldest gcc9.3/C++17 py3.7 exr-3.1
+            # Oldest versions of the dependencies that we support.
             nametag: linux-oldest
+            runner: ubuntu-latest
+            container: aswf/ci-osl:2021
+            vfxyear: 2021
+            cxx_std: 17
+            fmt_ver: 7.0.1
+            openexr_ver: v3.1.0
+            pybind11_ver: v2.4.2
+            python_ver: 3.7
+            setenvs: export  CMAKE_VERSION=3.15.5
+                             PTEX_VERSION=v2.3.2
+                             WEBP_VERSION=v1.0.0
+            depcmds: sudo rm -rf /usr/local/include/OpenEXR
+          - desc: hobbled gcc9.3/C++17 py3.7 exr-3.1 no-sse no-ocio
+            # Use the oldest supported versions of required dependencies, and
+            # disable most optional dependencies and features (no SSE, OCIO,
+            # or OpenCV, don't embed plugins).
+            nametag: linux-disabled
             runner: ubuntu-latest
             container: aswf/ci-osl:2021
             vfxyear: 2021
@@ -298,10 +314,9 @@ jobs:
                             OPENJPEG_VERSION=v2.4.0
                             PTEX_VERSION=v2.4.2
                             PUGIXML_VERSION=v1.14
-                            USE_OPENVDB=0
                             WEBP_VERSION=v1.3.0
                             FREETYPE_VERSION=VER-2-13-2
-                            # The installed OpenVDB has a TLS conflict with Python 3.8
+                            EXTRA_DEP_PACKAGES="libboost-dev"
           - desc: bleeding edge gcc14 C++20 py3.12 OCIO/libtiff/exr-master avx2
             nametag: linux-bleeding-edge
             runner: ubuntu-24.04
@@ -333,6 +348,23 @@ jobs:
                             # addresses a job killing problem in the GHA Ubuntu
                             # 24.04 runners that cropped up circa May 29 2024. Maybe
                             # it will be fixed and we can do the update again later?
+          - desc: all local builds gcc12 C++17 avx2 exr3.2 ocio2.3
+            nametag: linux-local-builds
+            runner: ubuntu-22.04
+            cc_compiler: gcc-12
+            cxx_compiler: g++-12
+            cxx_std: 17
+            python_ver: "3.10"
+            simd: avx2,f16c
+            setenvs: export OpenImageIO_BUILD_LOCAL_DEPS=all
+                            LIBJPEGTURBO_VERSION=3.0.1
+                            LIBRAW_VERSION=0.21.2
+                            OPENCOLORIO_VERSION=v2.3.2
+                            OPENJPEG_VERSION=v2.4.0
+                            PTEX_VERSION=v2.4.2
+                            PUGIXML_VERSION=v1.14
+                            WEBP_VERSION=v1.3.0
+                            EXTRA_DEP_PACKAGES="libboost-dev"
           - desc: clang14 C++20 avx2 exr3.1 ocio2.1
             nametag: linux-clang14
             runner: ubuntu-20.04


### PR DESCRIPTION
Split the CI "oldest/hobbled" test into two different tests:

* oldest -- test against the oldest supported versions of all dependencies.

* hobbled -- test against most optional dependencies missing and optional feature disabled (including no SSE, no OCIO, etc.).

And add an additional test:

* local-builds -- a test that builds and uses every dependency that we know how to build locally/automatically.
