### PR TITLE
Fix TIFF export with EXIF data and I/O proxy

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -471,7 +471,7 @@ protected:
 };
 
 
-/// IOProxy subclass for reading or writing (but not both) that wraps C
+/// IOProxy subclass for reading or writing (plus re-reading) that wraps C
 /// stdio 'FILE'.
 class OIIO_UTIL_API IOFile : public IOProxy {
 public:
@@ -521,7 +521,9 @@ public:
     {
     }
     const char* proxytype() const override { return "vecoutput"; }
+    size_t read(void* buf, size_t size) override;
     size_t write(const void* buf, size_t size) override;
+    size_t pread(void* buf, size_t size, int64_t offset) override;
     size_t pwrite(const void* buf, size_t size, int64_t offset) override;
     size_t size() const override { return m_buf.size(); }
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -1337,7 +1337,7 @@ size_t
 Filesystem::IOVecOutput::pread(void* buf, size_t size, int64_t offset)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    size = std::min(size, m_buf.size() - offset);
+    size = std::min(size, size_t(m_buf.size() - offset));
     memcpy(buf, &m_buf[offset], size);
     return size;
 }

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -1178,7 +1178,7 @@ Filesystem::IOFile::IOFile(string_view filename, Mode mode)
 {
     // Call Filesystem::fopen since it handles UTF-8 file paths on Windows,
     // which std fopen does not.
-    m_file = Filesystem::fopen(m_filename, m_mode == Write ? "wb" : "rb");
+    m_file = Filesystem::fopen(m_filename, m_mode == Write ? "w+b" : "rb");
     if (!m_file) {
         m_mode          = Closed;
         int e           = errno;
@@ -1230,7 +1230,7 @@ Filesystem::IOFile::seek(int64_t offset)
 size_t
 Filesystem::IOFile::read(void* buf, size_t size)
 {
-    if (!m_file || !size || m_mode != Read)
+    if (!m_file || !size || m_mode == Closed)
         return 0;
     size_t r = fread(buf, 1, size, m_file);
     m_pos += r;
@@ -1249,7 +1249,7 @@ Filesystem::IOFile::read(void* buf, size_t size)
 size_t
 Filesystem::IOFile::pread(void* buf, size_t size, int64_t offset)
 {
-    if (!m_file || !size || offset < 0 || m_mode != Read)
+    if (!m_file || !size || offset < 0 || m_mode == Closed)
         return 0;
 #ifdef _WIN32
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -1318,6 +1318,14 @@ Filesystem::IOFile::flush() const
 
 
 size_t
+Filesystem::IOVecOutput::read(void* buf, size_t size)
+{
+    size = pread(buf, size, m_pos);
+    m_pos += size;
+    return size;
+}
+
+size_t
 Filesystem::IOVecOutput::write(const void* buf, size_t size)
 {
     size = pwrite(buf, size, m_pos);
@@ -1325,7 +1333,14 @@ Filesystem::IOVecOutput::write(const void* buf, size_t size)
     return size;
 }
 
-
+size_t
+Filesystem::IOVecOutput::pread(void* buf, size_t size, int64_t offset)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    size = std::min(size, m_buf.size() - offset);
+    memcpy(buf, &m_buf[offset], size);
+    return size;
+}
 
 size_t
 Filesystem::IOVecOutput::pwrite(const void* buf, size_t size, int64_t offset)

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -400,9 +400,10 @@ allval(const std::vector<T>& d, T v = T(0))
 
 
 static tsize_t
-writer_readproc(thandle_t, tdata_t, tsize_t)
+writer_readproc(thandle_t handle, tdata_t data, tsize_t size)
 {
-    return 0;
+    auto io = static_cast<Filesystem::IOProxy*>(handle);
+    return io->read(data, size);
 }
 
 static tsize_t


### PR DESCRIPTION
TIFF export with EXIF metadata (e.g. oiio::ColorSpace) creates invalid TIFF files in the presence of an I/O proxy ("TIFF directory is missing required "ImageLength" field"). The reasons is that TIFFSetDirectory() requires to read some of the previously written data, but neither writer_readproc() nor the available proxy implementations support that. Note that TIFF output does not yet use this new scheme for I/O proxy that was used for many other plugins.

I think writer_readproc() should not take any shortcuts and just forward the call to the I/O proxy.

Is there a reason why IOFile (in write mode) and IOVecOutput do not allow to re-read written data? This looks like an artificial restriction of the underlying resources. An alternative not modifiying these two implementations would be to let the TIFF output use a variant of IOVecOutput that allows re-reading and forward all data at the very end to the passed-in proxy.

Is there some policy to add assertions in all methods that are not supposed to be called? This would have helped here a lot to reduce the test case.

## Tests

I did not add an explicit test. I guess the proper way would be to convert TIFF ouput to use the same I/O proxy scheme that is used by many other plugins. Small repro case is attached.
[repro.cpp.txt](https://github.com/user-attachments/files/15886829/repro.cpp.txt)

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. N/A
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary). See above.
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options). I don't see IOProxy etc. being mentioned in the Python binding and guess this kind of modification does not require a change in the Python binding.
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
