### PR TITLE
int: Simplify openexr includes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,8 +20,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * Compilers: **gcc 9.3** - 14.1, **clang 5** - 18, MSVS 2017 - 2019 (**v19.14
    and up**), **Intel icc 19+**, Intel OneAPI C++ compiler 2022+.
  * **CMake >= 3.15** (tested through 3.29)
- * **OpenEXR/Imath >= 3.1** (tested through 3.2
-   and main) 
+ * **Imath >= 3.1** (tested through 3.1.x and main)
+ * **OpenEXR >= 3.1** (tested through 3.2 and main)
  * **libTIFF >= 4.0** (tested through 4.6)
  * libjpeg >= 8 (tested through jpeg9e), or **libjpeg-turbo >= 2.1** (tested
    through 3.0)
@@ -181,7 +181,8 @@ OpenImageIO:
 * libjpeg
 * libtiff
 * libpng
-* OpenEXR.
+* Imath
+* OpenEXR
 
 These can be installed using the standard package managers on your system.
 Optionally, to build the image viewing tools, you will need Qt and OpenGL.
@@ -273,7 +274,7 @@ Building on Windows
 
 You will need to have Git, CMake and Visual Studio installed.
 
-The minimal set of dependencies for OIIO is: zlib, libTIFF, OpenEXR, and libjpeg or libjpeg-turbo. If you have them built somewhere then you skip
+The minimal set of dependencies for OIIO is: zlib, libTIFF, Imath, OpenEXR, and libjpeg or libjpeg-turbo. If you have them built somewhere then you skip
 the section below, and will only have to point OIIO build process so their locations.
 
 * zlib: this will build it, and then delete the non-static library, so they don't get picked up:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -64,7 +64,6 @@ checked_find_package (OpenEXR REQUIRED
 # the right Imath/OpenEXR version, not some older version in the system
 # library.
 include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
-set (OIIO_USING_IMATH 3)
 set (OPENIMAGEIO_IMATH_TARGETS Imath::Imath)
 set (OPENIMAGEIO_OPENEXR_TARGETS OpenEXR::OpenEXR)
 set (OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY "PRIVATE" CACHE STRING

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -39,21 +39,6 @@ endif ()
 configure_file (${PROJECT_NAME}/${versionfile}.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}" @ONLY)
 list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}")
 
-# Generate half.h
-if (VERBOSE)
-    message(STATUS "Create half.h from half.h.in")
-endif ()
-configure_file (${PROJECT_NAME}/half.h.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/half.h" @ONLY)
-list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/half.h")
-
-
-# Generate Imath.h
-if (VERBOSE)
-    message(STATUS "Create Imath.h from Imath.h.in")
-endif ()
-configure_file (${PROJECT_NAME}/Imath.h.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/Imath.h" @ONLY)
-list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/Imath.h")
-
 
 install (FILES ${public_headers}
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}

--- a/src/include/OpenImageIO/Imath.h
+++ b/src/include/OpenImageIO/Imath.h
@@ -13,7 +13,8 @@
 #ifndef OIIO_IMATH_H_INCLUDED
 #define OIIO_IMATH_H_INCLUDED 1
 
-#define OIIO_USING_IMATH @OIIO_USING_IMATH@
+// DEPRECATED(3.0)
+#define OIIO_USING_IMATH 3
 
 #include <Imath/ImathColor.h>
 #include <Imath/ImathMatrix.h>

--- a/src/include/OpenImageIO/half.h
+++ b/src/include/OpenImageIO/half.h
@@ -5,14 +5,21 @@
 
 #pragma once
 
+// Define IMATH_HALF_NO_LOOKUP_TABLE to ensure we convert float<->half without
+// using the lookup table (and thus eliminating the need to link against
+// libImath just for half conversion).
+#ifndef IMATH_HALF_NO_LOOKUP_TABLE
+#    define IMATH_HALF_NO_LOOKUP_TABLE
+#endif
+
 #include <Imath/half.h>
 
 
 #if defined(FMT_VERSION) && !defined(OIIO_HALF_FORMATTER)
-#if FMT_VERSION >= 100000
-#define OIIO_HALF_FORMATTER
+#    if FMT_VERSION >= 100000
+#        define OIIO_HALF_FORMATTER
 FMT_BEGIN_NAMESPACE
 template<> struct formatter<half> : ostream_formatter {};
 FMT_END_NAMESPACE
-#endif
+#    endif
 #endif


### PR DESCRIPTION
In master, since we have raised the minimum Imath/OpenEXR to 3.x, no more 2.x, we no longer need generate our Imath.h and half.h from templates, they can be turned into regular header files.

Additionally, define IMATH_HALF_NO_LOOKUP_TABLE in half.h before including Imath/half.h, which ensures that the Imath code we include converts float <-> half using actual inline code and not the lookup table. This can reduce or sometimes eliminate the need to link agains Imath only for the sake of accessing that lookup table.
