### PR TITLE
Add extra step to Makefile config target to force CMake rescan installed packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ ifneq (${CLANG_FORMAT_EXCLUDES},)
 endif
 
 ifneq (${BUILD_MISSING_DEPS},)
-  MY_CMAKE_FLAGS += -DBUILD_MISSING_DEPS:BOOL=${BUILD_MISSING_DEPS}
+  MY_CMAKE_FLAGS += -DOpenImageIO_BUILD_MISSING_DEPS:STRING=all
 endif
 
 
@@ -236,6 +236,8 @@ profile:
 # generating makefiles to build the project.  For speed, it only does this when
 # ${build_dir}/Makefile doesn't already exist, in which case we rely on the
 # cmake generated makefiles to regenerate themselves when necessary.
+# When building missing dependencies, once configuration step completes,
+# rerun the configuration so that CMake rescans newly installed packages.
 config:
 	@ (if [ ! -e ${build_dir}/${BUILDSENTINEL} ] ; then \
 		${CMAKE} -E make_directory ${build_dir} ; \
@@ -243,6 +245,9 @@ config:
 		${CMAKE} -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE} \
 			 -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
 			 ${MY_CMAKE_FLAGS} ${working_dir} ; \
+		if [ "${BUILD_MISSING_DEPS}" = "1" ] ; then \
+				${CMAKE} ${working_dir} ; \
+			  fi ; \
 	 fi)
 
 


### PR DESCRIPTION
Something for consideration as I'm not sure what would be the best way to handle this.

Building with -DOpenImageIO_BUILD_MISSING_DEPS=all fails on Linux with the following error:
```
In file included from /home/kuba/SRC/OpenImageIO/__build2/include/OpenImageIO/Imath.h:11,
                 from /home/kuba/SRC/OpenImageIO/src/libutil/strutil_test.cpp:8:
/home/kuba/SRC/OpenImageIO/__build2/include/OpenImageIO/half.h:8:10: fatal error: Imath/half.h: No such file or directory
    8 | #include <Imath/half.h>
```

Steps to reproduce:
```
make config MY_CMAKE_FLAGS="-DOpenImageIO_BUILD_MISSING_DEPS=all"
make build
```

Initially I thought this is related with OpenImageIO/Imath.h expecting system includes: `include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})`
As it turns out this was redherring and the problem could be with CMake "state?" (Maybe a specific CMake version `3.27.7` to blame).
A potential fix - after the initial configuration completes - is to reconfigure the project one more time: `cmake ..` which resolves the error. 
The second reconfiguration command is also protected by `${build_dir}/${BUILDSENTINEL}` hence runs only once - during the initial configuration. If anyone is able to reproduce this or have any thoughts what the root problem may be - please chime in.