### PR TITLE
Add missing includes to libutil CMake target.

### DIFF
--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -47,6 +47,7 @@ function (setup_oiio_util_library targetname)
 
     target_include_directories (${targetname}
             PUBLIC
+                $<BUILD_INTERFACE:${OpenImageIO_LOCAL_DEPS_ROOT}/include>
                 $<INSTALL_INTERFACE:include>
             PRIVATE
                 ${ROBINMAP_INCLUDES}


### PR DESCRIPTION
This is the continuation of [4305 ](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4305)(Add extra step to Makefile config target to force CMake to rescan). 
The error occurs when configuring with `make OpenImageIO_BUILD_MISSING_DEPS=all` option which fails the build as `libuitil` does not have `./dep/dist/include` on the path.
The original solution was to rerun cmake and let it rescan paths. This step was only required to run once - after the initial CMake configuration step. This kind off worked but I'm still unsure why. So instead of that we can just add the missing location to CMakeLists.