### PR TITLE
cleanup: simd.h deprecations

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -4980,7 +4980,7 @@ OIIO_FORCEINLINE vint4 rotl(const vint4& x, int s) {
 }
 
 // DEPRECATED (2.1)
-OIIO_DEPRECATED("Use rotl32 instead")
+OIIO_DEPRECATED("Use rotl instead")
 OIIO_FORCEINLINE vint4 rotl32 (const vint4& x, const unsigned int k) {
     return rotl(x, k);
 }

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -306,14 +306,14 @@ class vfloat16;
 // These are removed from visibility for the OIIO codebase itself, or for any
 // downstream project that defines OIIO_DISABLE_DEPRECATED to exclude
 // declarations deprecated as of version 1.9 or later.
-typedef vbool4 mask4;    // old name
-typedef vbool4 bool4;
-typedef vbool8 bool8;
-typedef vint4 int4;
-typedef vint8 int8;
-typedef vfloat3 float3;
-typedef vfloat4 float4;
-typedef vfloat8 float8;
+OIIO_DEPRECATED("use vbool4") typedef vbool4 mask4;    // old name
+OIIO_DEPRECATED("use vbool4") typedef vbool4 bool4;
+OIIO_DEPRECATED("use vbool8") typedef vbool8 bool8;
+OIIO_DEPRECATED("use vint4") typedef vint4 int4;
+OIIO_DEPRECATED("use vint8") typedef vint8 int8;
+OIIO_DEPRECATED("use vfloat3") typedef vfloat3 float3;
+OIIO_DEPRECATED("use vfloat4") typedef vfloat4 float4;
+OIIO_DEPRECATED("use vfloat8") typedef vfloat8 float8;
 #endif
 
 } // namespace simd
@@ -964,10 +964,6 @@ public:
     typedef vbool4 vbool_t;   ///< bool type of the same length
     typedef vfloat4 vfloat_t; ///< float type of the same length
     typedef vint4 vint_t;     ///< int type of the same length
-    OIIO_DEPRECATED("use vbool_t (1.8)")
-    typedef vbool4 bool_t;   // old name (deprecated 1.8)
-    OIIO_DEPRECATED("use vfloat_t (1.8)")
-    typedef vfloat4 float_t; // old name (deprecated 1.8)
     static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
@@ -1225,6 +1221,7 @@ vint4 max (const vint4& a, const vint4& b);
 /// Circular bit rotate by s bits, for N values at once.
 vint4 rotl (const vint4& x, const int s);
 // DEPRECATED(2.1)
+OIIO_DEPRECATED("Use rotl instead")
 vint4 rotl32 (const vint4& x, const unsigned int k);
 
 /// andnot(a,b) returns ((~a) & b)
@@ -1260,10 +1257,6 @@ public:
     typedef vbool8 vbool_t;   ///< bool type of the same length
     typedef vfloat8 vfloat_t; ///< float type of the same length
     typedef vint8 vint_t;     ///< int type of the same length
-    OIIO_DEPRECATED("use vbool_t (1.8)")
-    typedef vbool8 bool_t;   // old name (deprecated 1.8)
-    OIIO_DEPRECATED("use vfloat_t (1.8)")
-    typedef vfloat8 float_t; // old name (deprecated 1.8)
     static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
@@ -1534,6 +1527,7 @@ vint8 max (const vint8& a, const vint8& b);
 /// Circular bit rotate by s bits, for N values at once.
 vint8 rotl (const vint8& x, const int s);
 // DEPRECATED(2.1)
+OIIO_DEPRECATED("Use rotl instead")
 vint8 rotl32 (const vint8& x, const unsigned int k);
 
 /// andnot(a,b) returns ((~a) & b)
@@ -1564,10 +1558,6 @@ public:
     typedef vbool16 vbool_t;   ///< bool type of the same length
     typedef vfloat16 vfloat_t; ///< float type of the same length
     typedef vint16 vint_t;     ///< int type of the same length
-    OIIO_DEPRECATED("use vbool_t (1.8)")
-    typedef vbool16 bool_t;   // old name (deprecated 1.8)
-    OIIO_DEPRECATED("use vfloat_t (1.8)")
-    typedef vfloat16 float_t; // old name (deprecated 1.8)
     static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
@@ -1850,6 +1840,7 @@ vint16 max (const vint16& a, const vint16& b);
 /// Circular bit rotate by s bits, for N values at once.
 vint16 rotl (const vint16& x, const int s);
 // DEPRECATED(2.1)
+OIIO_DEPRECATED("Use rotl instead")
 vint16 rotl32 (const vint16& x, const unsigned int k);
 
 /// andnot(a,b) returns ((~a) & b)
@@ -1881,10 +1872,6 @@ public:
     typedef vfloat4 vfloat_t; ///< SIMD int type
     typedef vint4 vint_t;     ///< SIMD int type
     typedef vbool4 vbool_t;   ///< SIMD bool type
-    OIIO_DEPRECATED("use vbool_t (1.8)")
-    typedef vint4 int_t;      // old name (deprecated 1.8)
-    OIIO_DEPRECATED("use vfloat_t (1.8)")
-    typedef vbool4 bool_t;    // old name (deprecated 1.8)
     static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
@@ -2556,10 +2543,6 @@ public:
     typedef vfloat8 vfloat_t; ///< SIMD int type
     typedef vint8 vint_t;     ///< SIMD int type
     typedef vbool8 vbool_t;   ///< SIMD bool type
-    OIIO_DEPRECATED("use vint_t (1.8)")
-    typedef vint8 int_t;      // old name (deprecated 1.8)
-    OIIO_DEPRECATED("use vbool_t (1.8)")
-    typedef vbool8 bool_t;    // old name (deprecated 1.8)
     static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
@@ -2823,6 +2806,7 @@ vfloat8 sign (const vfloat8& a);   ///< 1.0 when value >= 0, -1 when negative
 vfloat8 ceil (const vfloat8& a);
 vfloat8 floor (const vfloat8& a);
 vint8 ifloor (const vfloat8& a);    ///< (int)floor
+OIIO_DEPRECATED("Use ifloor instead")
 inline vint8 floori (const vfloat8& a) { return ifloor(a); }  // DEPRECATED(1.8) alias
 
 /// Per-element round to nearest integer.
@@ -2874,10 +2858,6 @@ public:
     typedef vfloat16 vfloat_t; ///< SIMD int type
     typedef vint16 vint_t;     ///< SIMD int type
     typedef vbool16 vbool_t;   ///< SIMD bool type
-    OIIO_DEPRECATED("use vint_t (1.8)")
-    typedef vint16 int_t;      // old name (deprecated 1.8)
-    OIIO_DEPRECATED("use vbool_t (1.8)")
-    typedef vbool16 bool_t;    // old name (deprecated 1.8)
     static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
@@ -4849,9 +4829,6 @@ OIIO_FORCEINLINE vint4 bitcast_to_int (const vbool4& x)
 #endif
 }
 
-// Old names: (DEPRECATED 1.8)
-OIIO_DEPRECATED("use bitcast_to_int() (1.8)")
-inline vint4 bitcast_to_int4 (const vbool4& x) { return bitcast_to_int(x); }
 
 
 OIIO_FORCEINLINE vint4 vreduce_add (const vint4& v) {
@@ -5003,6 +4980,7 @@ OIIO_FORCEINLINE vint4 rotl(const vint4& x, int s) {
 }
 
 // DEPRECATED (2.1)
+OIIO_DEPRECATED("Use rotl32 instead")
 OIIO_FORCEINLINE vint4 rotl32 (const vint4& x, const unsigned int k) {
     return rotl(x, k);
 }
@@ -5831,6 +5809,7 @@ OIIO_FORCEINLINE vint8 rotl(const vint8& x, int s) {
 }
 
 // DEPRECATED (2.1)
+OIIO_DEPRECATED("Use rotl instead")
 OIIO_FORCEINLINE vint8 rotl32 (const vint8& x, const unsigned int k) {
     return rotl(x, k);
 }
@@ -6638,6 +6617,7 @@ OIIO_FORCEINLINE vint16 rotl(const vint16& x, int s) {
 }
 
 // DEPRECATED (2.1)
+OIIO_DEPRECATED("Use rotl instead")
 OIIO_FORCEINLINE vint16 rotl32 (const vint16& x, const unsigned int k) {
     return rotl(x, k);
 }


### PR DESCRIPTION
Fully remove some things that have had deprecation warnings for a long, long time (mostly since 1.x), so we think it can't possibly break anyone.

Add deprecation warnings to some things that have been nominally deprecated for some time. The build warnings will serve as final notice that they will fully disappear by OIIO 3.0 release.

This is part of a series of small steps to fully deprecate a whole lot of cruft between now and the 3.0 release.