### PR TITLE
cleanup: deprecations in fmath.h

### DIFF
--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -143,9 +143,9 @@ read_input(const std::string& filename, ImageBuf& img, ImageCache* cache,
 inline void
 safe_double_print(double val)
 {
-    if (OIIO::isnan(val))
+    if (std::isnan(val))
         print("nan\n");
-    else if (OIIO::isinf(val))
+    else if (std::isinf(val))
         print("inf\n");
     else
         print("{:g}\n", val);

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -58,8 +58,10 @@ private:
         if (!ioread(buf, sizeof(T), nitems))
             return false;
         if (littleendian()
-            && (is_same<T, uint16_t>::value || is_same<T, int16_t>::value
-                || is_same<T, uint32_t>::value || is_same<T, int32_t>::value)) {
+            && (std::is_same<T, uint16_t>::value
+                || std::is_same<T, int16_t>::value
+                || std::is_same<T, uint32_t>::value
+                || std::is_same<T, int32_t>::value)) {
             swap_endian(buf, nitems);
         }
         return true;

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -50,8 +50,10 @@ private:
     template<typename T> bool write(const T* buf, size_t nitems = 1)
     {
         if (littleendian()
-            && (is_same<T, uint16_t>::value || is_same<T, int16_t>::value
-                || is_same<T, uint32_t>::value || is_same<T, int32_t>::value)) {
+            && (std::is_same<T, uint16_t>::value
+                || std::is_same<T, int16_t>::value
+                || std::is_same<T, uint32_t>::value
+                || std::is_same<T, int32_t>::value)) {
             T* newbuf = OIIO_ALLOCA(T, nitems);
             memcpy(newbuf, buf, nitems * sizeof(T));
             swap_endian(newbuf, nitems);

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -79,17 +79,19 @@ OIIO_NAMESPACE_BEGIN
 #endif
 
 
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,0,0) \
+    && OIIO_VERSION_LESS(2,7,0) && !defined(OIIO_INTERNAL)
 // Helper template to let us tell if two types are the same.
 // C++11 defines this, keep in OIIO namespace for back compat.
 // DEPRECATED(2.0) -- clients should switch OIIO::is_same -> std::is_same.
 using std::is_same;
-
 
 // For back compatibility: expose these in the OIIO namespace.
 // DEPRECATED(2.0) -- clients should switch OIIO:: -> std:: for these.
 using std::isfinite;
 using std::isinf;
 using std::isnan;
+#endif
 
 
 // Define math constants just in case they aren't included (Windows is a
@@ -196,9 +198,14 @@ floor2(int x) noexcept
 }
 
 
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,1,0) \
+    && OIIO_VERSION_LESS(2,7,0) && !defined(OIIO_INTERNAL)
 // Old names -- DEPRECATED(2.1)
+OIIO_DEPRECATED("use ceil2")
 inline OIIO_HOSTDEVICE int pow2roundup(int x) { return ceil2(x); }
+OIIO_DEPRECATED("use floor2")
 inline OIIO_HOSTDEVICE int pow2rounddown(int x) { return floor2(x); }
+#endif
 
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1957,7 +1957,7 @@ copy_pixels_impl(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads = 0)
     std::atomic<bool> ok(true);
     ImageBufAlgo::parallel_image(roi, { "copy_pixels", nthreads }, [&](ROI roi) {
         int nchannels = roi.nchannels();
-        if (is_same<D, S>::value) {
+        if (std::is_same<D, S>::value) {
             // If both bufs are the same type, just directly copy the values
             if (src.localpixels() && roi.chbegin == 0
                 && roi.chend == dst.nchannels()

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -25,8 +25,10 @@ mad_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, const ImageBuf& C,
          ROI roi, int nthreads)
 {
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
-        if ((is_same<Rtype, float>::value || is_same<Rtype, half>::value)
-            && (is_same<ABCtype, float>::value || is_same<ABCtype, half>::value)
+        if ((std::is_same<Rtype, float>::value
+             || std::is_same<Rtype, half>::value)
+            && (std::is_same<ABCtype, float>::value
+                || std::is_same<ABCtype, half>::value)
             // && R.localpixels() // has to be, because it's writable
             && A.localpixels() && B.localpixels()
             && C.localpixels()

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -724,9 +724,10 @@ resize_(ImageBuf& dst, const ImageBuf& src, const Filter2D* filter, ROI roi,
         // Special case: src and dst are local memory, float buffers, and we're
         // operating on all channels, <= 4.
         bool special
-            = ((is_same<DSTTYPE, float>::value || is_same<DSTTYPE, half>::value)
-               && (is_same<SRCTYPE, float>::value
-                   || is_same<SRCTYPE, half>::value)
+            = ((std::is_same<DSTTYPE, float>::value
+                || std::is_same<DSTTYPE, half>::value)
+               && (std::is_same<SRCTYPE, float>::value
+                   || std::is_same<SRCTYPE, half>::value)
                // && dst.localpixels() // has to be, because it's writable
                && src.localpixels()
                // && R.contains_roi(roi)  // has to be, because IBAPrep

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1017,7 +1017,7 @@ void test_arithmetic ()
     benchmark2 ("operator/", do_div<VEC>, a, b);
     benchmark  ("abs", do_abs<VEC>, a);
     benchmark  ("reduce_add", [](const VEC& a){ return vreduce_add(a); }, a);
-    if (is_same<VEC,vfloat3>::value) {  // For vfloat3, compare to Imath
+    if (std::is_same<VEC,vfloat3>::value) {  // For vfloat3, compare to Imath
         Imath::V3f a(2.51f,1.0f,1.0f), b(3.1f,1.0f,1.0f);
         benchmark2 ("add Imath::V3f", do_add<Imath::V3f>, a, b, 3 /*work*/);
         benchmark2 ("add Imath::V3f with simd", add_vec_simd, a, b, 3 /*work*/);

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -63,8 +63,10 @@ private:
         if (!ioread(buf, sizeof(T), nitems))
             return false;
         if (littleendian()
-            && (is_same<T, uint16_t>::value || is_same<T, int16_t>::value
-                || is_same<T, uint32_t>::value || is_same<T, int32_t>::value)) {
+            && (std::is_same<T, uint16_t>::value
+                || std::is_same<T, int16_t>::value
+                || std::is_same<T, uint32_t>::value
+                || std::is_same<T, int32_t>::value)) {
             swap_endian(buf, nitems);
         }
         return true;

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -69,8 +69,10 @@ private:
     template<typename T> bool write(const T* buf, size_t nitems = 1)
     {
         if (littleendian()
-            && (is_same<T, uint16_t>::value || is_same<T, int16_t>::value
-                || is_same<T, uint32_t>::value || is_same<T, int32_t>::value)) {
+            && (std::is_same<T, uint16_t>::value
+                || std::is_same<T, int16_t>::value
+                || std::is_same<T, uint32_t>::value
+                || std::is_same<T, int32_t>::value)) {
             T* newbuf = OIIO_ALLOCA(T, nitems);
             memcpy(newbuf, buf, nitems * sizeof(T));
             swap_endian(newbuf, nitems);


### PR DESCRIPTION
In several places, we still used OIIO versions of isnan/isinf/isfinite and is_same.  All of there for some time have been aliased to the std versions (having our own was mostly a pre-C++11 artifact). Change those OIIO::foo to std::foo throughout the codebase, and hide the old declarations themselves behind some guards that:

1. Will eliminate them completely as soon as the version is higher than 2.6.x.

2. Makes them invisible now internally to OIIO (so we aren't accidentally using them ourselves), and to external projects (like OSL) that define OIIO_DISABLE_DEPRECATED to hide deprecated things.

3. Add deprecation warnings if they are not hidden by the logic of (2) above.

Before 3.0 release is final, we will truly remove them entirely, but these staged warnings will help people with the transition.
