### PR TITLE
api: deprecate things in typedesc.h

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -336,29 +336,36 @@ struct OIIO_UTIL_API TypeDesc {
     /// precision.
     static BASETYPE basetype_merge(TypeDesc a, TypeDesc b);
 
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(1,8,0) && OIIO_VERSION_LESS(2,7,0) && !defined(OIIO_DOXYGEN)
     // DEPRECATED(1.8): These static const member functions were mildly
     // problematic because they required external linkage (and possibly
     // even static initialization order fiasco) and were a memory reference
     // that incurred some performance penalty and inability to optimize.
     // Please instead use the out-of-class constexpr versions below.  We
     // will eventually remove these.
-#ifndef OIIO_DOXYGEN
-    static const TypeDesc TypeFloat;
-    static const TypeDesc TypeColor;
-    static const TypeDesc TypeString;
-    static const TypeDesc TypeInt;
-    static const TypeDesc TypeHalf;
-    static const TypeDesc TypePoint;
-    static const TypeDesc TypeVector;
-    static const TypeDesc TypeNormal;
-    static const TypeDesc TypeMatrix;
-    static const TypeDesc TypeMatrix33;
-    static const TypeDesc TypeMatrix44;
-    static const TypeDesc TypeTimeCode;
-    static const TypeDesc TypeKeyCode;
-    static const TypeDesc TypeFloat4;
-    static const TypeDesc TypeRational;
+#ifdef __INTEL_COMPILER
+#    define OIIO_DEPRECATED_TYPEDESC_STATICS
+#else
+#    define OIIO_DEPRECATED_TYPEDESC_STATICS \
+        OIIO_DEPRECATED("Use the version that takes a tostring_formatting struct (1.8)")
 #endif
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeFloat;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeColor;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeString;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeInt;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeHalf;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypePoint;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeVector;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeNormal;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeMatrix;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeMatrix33;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeMatrix44;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeTimeCode;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeKeyCode;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeFloat4;
+    OIIO_DEPRECATED_TYPEDESC_STATICS static const TypeDesc TypeRational;
+#endif
+#undef OIIO_DEPRECATED_TYPEDESC_STATICS
 };
 
 // Validate that TypeDesc can be used directly as POD in a C interface.
@@ -410,7 +417,9 @@ OIIO_INLINE_CONSTEXPR TypeDesc TypeUstringhash(TypeDesc::USTRINGHASH);
 
 
 
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,1,0) && OIIO_VERSION_LESS(2,7,0)
 // DEPRECATED(2.1)
+OIIO_DEPRECATED("Use the version that takes a tostring_formatting struct")
 OIIO_UTIL_API
 std::string tostring (TypeDesc type, const void *data,
                       const char *float_fmt,                // E.g. "%g"
@@ -419,7 +428,7 @@ std::string tostring (TypeDesc type, const void *data,
                       const char *aggregate_sep = ",",      // E.g. ", "
                       const char array_delim[2] = "{}",     // Both sides of array
                       const char *array_sep = ",");         // E.g. "; "
-
+#endif
 
 
 /// A template mechanism for getting the a base type from C type

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -286,45 +286,45 @@ TypeDesc::fromstring(string_view typestring)
     if (t.basetype != UNKNOWN) {
         // already solved
     } else if (type == "color")
-        t = TypeColor;
+        t = OIIO::TypeColor;
     else if (type == "point")
-        t = TypePoint;
+        t = OIIO::TypePoint;
     else if (type == "vector")
-        t = TypeVector;
+        t = OIIO::TypeVector;
     else if (type == "normal")
-        t = TypeNormal;
+        t = OIIO::TypeNormal;
     else if (type == "matrix33")
-        t = TypeMatrix33;
+        t = OIIO::TypeMatrix33;
     else if (type == "matrix" || type == "matrix44")
-        t = TypeMatrix44;
+        t = OIIO::TypeMatrix44;
     else if (type == "vector2")
-        t = TypeVector2;
+        t = OIIO::TypeVector2;
     else if (type == "vector4")
-        t = TypeVector4;
+        t = OIIO::TypeVector4;
     else if (type == "float2")
-        t = TypeFloat2;
+        t = OIIO::TypeFloat2;
     else if (type == "float4")
-        t = TypeFloat4;
+        t = OIIO::TypeFloat4;
     else if (type == "timecode")
-        t = TypeTimeCode;
+        t = OIIO::TypeTimeCode;
     else if (type == "rational")
-        t = TypeRational;
+        t = OIIO::TypeRational;
     else if (type == "box2i")
-        t = TypeBox2i;
+        t = OIIO::TypeBox2i;
     else if (type == "box3i")
-        t = TypeBox3i;
+        t = OIIO::TypeBox3i;
     else if (type == "box2" || type == "box2f")
-        t = TypeBox2;
+        t = OIIO::TypeBox2;
     else if (type == "box3" || type == "box3f")
-        t = TypeBox3;
+        t = OIIO::TypeBox3;
     else if (type == "timecode")
-        t = TypeTimeCode;
+        t = OIIO::TypeTimeCode;
     else if (type == "keycode")
-        t = TypeKeyCode;
+        t = OIIO::TypeKeyCode;
     else if (type == "pointer")
-        t = TypePointer;
+        t = OIIO::TypePointer;
     else if (type == "ustringhash")
-        t = TypeUstringhash;
+        t = OIIO::TypeUstringhash;
     else {
         return 0;  // unknown
     }
@@ -653,6 +653,7 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
 
 
 
+#if OIIO_VERSION_LESS(2, 7, 0)
 // Old deprecated one
 std::string
 tostring(TypeDesc type, const void* data, const char* float_fmt,
@@ -668,6 +669,7 @@ tostring(TypeDesc type, const void* data, const char* float_fmt,
                             std::string(array_delim + 1, 1).c_str(), array_sep);
     return tostring(type, data, fmt);
 }
+#endif
 
 
 
@@ -913,8 +915,11 @@ TypeDesc::basetype_merge(TypeDesc at, TypeDesc bt)
 
 
 
+#if OIIO_VERSION_LESS(2, 7, 0)
 // Static members of pre-constructed types
 // DEPRECATED(1.8)
+OIIO_PRAGMA_WARNING_PUSH
+OIIO_GCC_PRAGMA(GCC diagnostic ignored "-Wdeprecated-declarations")
 const TypeDesc TypeDesc::TypeFloat(TypeDesc::FLOAT);
 const TypeDesc TypeDesc::TypeColor(TypeDesc::FLOAT, TypeDesc::VEC3,
                                    TypeDesc::COLOR);
@@ -937,6 +942,7 @@ const TypeDesc TypeDesc::TypeKeyCode(TypeDesc::INT, TypeDesc::SCALAR,
 const TypeDesc TypeDesc::TypeFloat4(TypeDesc::FLOAT, TypeDesc::VEC4);
 const TypeDesc TypeDesc::TypeRational(TypeDesc::INT, TypeDesc::VEC2,
                                       TypeDesc::RATIONAL);
-
+OIIO_PRAGMA_WARNING_PUSH
+#endif
 
 OIIO_NAMESPACE_END

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -181,16 +181,16 @@ parse_param(string_view paramname, string_view val, ImageSpec& spec)
             // Surrounded by quotes? it's a string (strip off the quotes)
             val.remove_prefix(1);
             val.remove_suffix(1);
-            type = TypeDesc::TypeString;
+            type = TypeString;
         } else if (Strutil::string_is<int>(val)) {
             // Looks like an int, is an int
-            type = TypeDesc::TypeInt;
+            type = TypeInt;
         } else if (Strutil::string_is<float>(val)) {
             // Looks like a float, is a float
-            type = TypeDesc::TypeFloat;
+            type = TypeFloat;
         } else {
             // Everything else is assumed a string
-            type = TypeDesc::TypeString;
+            type = TypeString;
         }
     }
 


### PR DESCRIPTION
Fully remove some things that have had deprecation warnings for a long, long time (mostly since 1.x), so we think it can't possibly break anyone.

Add deprecation warnings to some things that have been nominally deprecated for some time. The build warnings will serve as final notice that they will fully disappear by OIIO 3.0 release.
