### PR TITLE
api: deprecation cleanup in imageio.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.15)
 
-set (OpenImageIO_VERSION "2.6.2.0")
+set (OpenImageIO_VERSION "2.6.3.0")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OpenImageIO_VERSION_OVERRIDE)

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -375,8 +375,7 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
 
     bool ok                      = true;
     bool mip_to_subimage_warning = false;
-    for (int subimage = 0; ok && in->seek_subimage(subimage, 0, inspec);
-         ++subimage) {
+    for (int subimage = 0; ok && in->seek_subimage(subimage, 0); ++subimage) {
         if (subimage > 0 && !out->supports("multiimage")) {
             print(stderr,
                   "iconvert WARNING: {} does not support multiple subimages.\n"
@@ -388,6 +387,7 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
         int miplevel = 0;
         do {
             // Copy the spec, with possible change in format
+            inspec            = in->spec(subimage, miplevel);
             ImageSpec outspec = inspec;
             bool nocopy = adjust_spec(in.get(), out.get(), inspec, outspec);
             if (miplevel > 0) {
@@ -473,7 +473,7 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
             }
 
             ++miplevel;
-        } while (ok && in->seek_subimage(subimage, miplevel, inspec));
+        } while (ok && in->seek_subimage(subimage, miplevel));
     }
 
     out->close();

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -62,7 +62,6 @@ grep_file(const std::string& filename, std::regex& re,
             std::cerr << geterror() << "\n";
         return false;
     }
-    ImageSpec spec = in->spec();
 
     if (file_match) {
         bool match = false;
@@ -83,6 +82,7 @@ grep_file(const std::string& filename, std::regex& re,
     do {
         if (!all_subimages && subimage > 0)
             break;
+        ImageSpec spec = in->spec(subimage);
         for (auto&& p : spec.extra_attribs) {
             TypeDesc t = p.type();
             if (t.elementtype() == TypeDesc::STRING) {
@@ -108,7 +108,7 @@ grep_file(const std::string& filename, std::regex& re,
                 }
             }
         }
-    } while (in->seek_subimage(++subimage, 0, spec));
+    } while (in->seek_subimage(++subimage, 0));
 
     if (invert_match) {
         found = !found;

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -66,11 +66,6 @@ typedef bool (*ProgressCallback)(void *opaque_data, float portion_done);
 
 
 
-// Deprecated typedefs. Just use ParamValue and ParamValueList directly.
-typedef ParamValue ImageIOParameter;
-typedef ParamValueList ImageIOParameterList;
-
-
 // Forward declaration of IOProxy
 namespace Filesystem {
     class IOProxy;
@@ -952,18 +947,24 @@ public:
                       ioproxy, plugin_searchpath);
     }
 
-    // DEPRECATED(2.2): back compatible version
-    static unique_ptr create (const std::string& filename, bool do_open,
-                              const ImageSpec *config,
-                              string_view plugin_searchpath);
-    // DEPRECATED(2.1) This method should no longer be used, it is redundant.
-    static unique_ptr create (const std::string& filename,
-                              const std::string& plugin_searchpath);
-
     /// @}
 
-    // DEPRECATED(2.1)
-    static void destroy (ImageInput *x);
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,2,0) && OIIO_VERSION_LESS(2,7,0) \
+    && !defined(OIIO_DOXYGEN) && !defined(OIIO_INTERNAL)
+    OIIO_DEPRECATED("Use the modern form of create instead (2.2)")
+    static unique_ptr create (const std::string& filename, bool do_open,
+                              const ImageSpec *config,
+                              string_view plugin_searchpath) {
+        return create(filename, do_open, config, nullptr, plugin_searchpath);
+    }
+    OIIO_DEPRECATED("Use the modern form of create instead (2.1)")
+    static unique_ptr create (const std::string& filename,
+                              const std::string& plugin_searchpath) {
+        return create(filename, false, nullptr, nullptr, plugin_searchpath);
+    }
+    OIIO_DEPRECATED("destroy is no longer needed (2.1)")
+    static void destroy (ImageInput *x) { delete x; }
+#endif
 
 protected:
     ImageInput ();
@@ -1190,21 +1191,29 @@ public:
         return subimage == current_subimage() && miplevel == current_miplevel();
     }
 
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,0,0) && !defined(OIIO_DOXYGEN)
     // Old version for backwards-compatibility: pass reference to newspec.
     // Some day this will be deprecated.
+    OIIO_DEPRECATED("Prefer the version that doesn't take an ImageSpec argument (2.0)")
     bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) {
         bool ok = seek_subimage (subimage, miplevel);
         if (ok)
             newspec = spec();
         return ok;
     }
+#endif
 
-    // DEPRECATED(2.1)
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,1,0) && !defined(OIIO_DOXYGEN)
     // Seek to the given subimage -- backwards-compatible call that
     // doesn't worry about MIP-map levels at all.
+    OIIO_DEPRECATED("Prefer the version that takes a mipmap argument (2.1)")
     bool seek_subimage (int subimage, ImageSpec &newspec) {
-        return seek_subimage (subimage, 0 /* miplevel */, newspec);
+        bool ok = seek_subimage (subimage, 0 /* miplevel */);
+        if (ok)
+            newspec = spec(subimage);
+        return ok;
     }
+#endif
 
     /// @{
     /// @name Reading pixels
@@ -1317,7 +1326,8 @@ public:
                                  stride_t xstride=AutoStride,
                                  stride_t ystride=AutoStride);
 
-#ifndef OIIO_DOXYGEN
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,0,0) \
+    && !defined(OIIO_DOXYGEN) && !defined(OIIO_INTERNAL)
     // DEPRECATED versions of read_scanlines (pre-1.9 OIIO). These will
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_scanlines that takes an explicit subimage and
@@ -1326,13 +1336,21 @@ public:
     bool read_scanlines (int ybegin, int yend, int z,
                          TypeDesc format, void *data,
                          stride_t xstride=AutoStride,
-                         stride_t ystride=AutoStride);
+                         stride_t ystride=AutoStride) {
+        lock_guard lock(*this);
+        return read_scanlines(current_subimage(), current_miplevel(), ybegin, yend,
+                              z, 0, m_spec.nchannels, format, data, xstride, ystride);
+    }
     OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_scanlines (int ybegin, int yend, int z,
                          int chbegin, int chend,
                          TypeDesc format, void *data,
                          stride_t xstride=AutoStride,
-                         stride_t ystride=AutoStride);
+                         stride_t ystride=AutoStride) {
+        lock_guard lock(*this);
+        return read_scanlines(current_subimage(), current_miplevel(), ybegin, yend,
+                              z, chbegin, chend, format, data, xstride, ystride);
+    }
 #endif
 
     /// Read the tile whose upper-left origin is (x,y,z) into `data[]`,
@@ -1424,7 +1442,7 @@ public:
                              stride_t xstride=AutoStride, stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride);
 
-#ifndef OIIO_DOXYGEN
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,0,0) && !defined(OIIO_DOXYGEN)
     // DEPRECATED versions of read_tiles (pre-1.9 OIIO). These will
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_tiles that takes an explicit subimage and
@@ -1485,7 +1503,7 @@ public:
                              ProgressCallback progress_callback=NULL,
                              void *progress_callback_data=NULL);
 
-#ifndef OIIO_DOXYGEN
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,0,0) && !defined(OIIO_DOXYGEN)
     // DEPRECATED versions of read_image (pre-1.9 OIIO). These will
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_image that takes an explicit subimage and
@@ -1681,12 +1699,22 @@ public:
     std::string geterror(bool clear = true) const;
 
     /// Error reporting for the plugin implementation: call this with
+    /// std::format-like arguments. It is not necessary to have the error
+    /// message contain a trailing newline.
+    template<typename... Args>
+    void errorfmt(const char* fmt, const Args&... args) const {
+        append_error(Strutil::fmt::format (fmt, args...));
+    }
+
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2, 6, 3) && \
+    !defined(OIIO_INTERNAL) && !defined(OIIO_DOXYGEN)
+    /// Error reporting for the plugin implementation: call this with
     /// Strutil::format-like arguments. It is not necessary to have the
     /// error message contain a trailing newline.
     /// Use with caution! Some day this will change to be fmt-like rather
     /// than printf-like.
     template<typename... Args>
-    OIIO_FORMAT_DEPRECATED
+    OIIO_DEPRECATED("use errorfmt instead, with std::format-like arguments (3.0)")
     void error(const char* fmt, const Args&... args) const {
         append_error(Strutil::format (fmt, args...));
     }
@@ -1695,27 +1723,20 @@ public:
     /// printf-like arguments. It is not necessary to have the error message
     /// contain a trailing newline.
     template<typename... Args>
-    OIIO_FORMAT_DEPRECATED
+    OIIO_DEPRECATED("use errorfmt instead, with std::format-like arguments (3.0)")
     void errorf(const char* fmt, const Args&... args) const {
         append_error(Strutil::sprintf (fmt, args...));
-    }
-
-    /// Error reporting for the plugin implementation: call this with
-    /// std::format-like arguments. It is not necessary to have the error
-    /// message contain a trailing newline.
-    template<typename... Args>
-    void errorfmt(const char* fmt, const Args&... args) const {
-        append_error(Strutil::fmt::format (fmt, args...));
     }
 
     // Error reporting for the plugin implementation: call this with
     // std::format-like arguments. It is not necessary to have the
     // error message contain a trailing newline.
     template<typename... Args>
-    OIIO_DEPRECATED("use `errorfmt` instead")
+    OIIO_DEPRECATED("use `errorfmt` instead (2.3)")
     void fmterror(const char* fmt, const Args&... args) const {
         append_error(Strutil::fmt::format (fmt, args...));
     }
+#endif
 
     /// Set the threading policy for this ImageInput, controlling the
     /// maximum amount of parallelizing thread "fan-out" that might occur
@@ -1862,10 +1883,6 @@ private:
     std::unique_ptr<Impl, decltype(&impl_deleter)> m_impl;
 
     void append_error(string_view message) const; // add to error message
-    // Deprecated:
-    OIIO_DEPRECATED("Deprecated")
-    static unique_ptr create (const std::string& filename, bool do_open,
-                              const std::string& plugin_searchpath);
 };
 
 
@@ -1924,14 +1941,19 @@ public:
                       Strutil::utf16_to_utf8(plugin_searchpath));
     }
 
-    // DEPRECATED(2.2)
-    static unique_ptr create (const std::string &filename,
-                              const std::string &plugin_searchpath);
-
     /// @}
 
-    // @deprecated
-    static void destroy (ImageOutput *x);
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,2,0) \
+    && !defined(OIIO_DOXYGEN) && !defined(OIIO_INTERNAL)
+    OIIO_DEPRECATED("Obsolete version (2.2)")
+    static unique_ptr create (const std::string &filename,
+                              const std::string &plugin_searchpath) {
+        return create(filename, nullptr, plugin_searchpath);
+    }
+
+    OIIO_DEPRECATED("destroy is no longer needed")
+    static void destroy (ImageOutput *x) { delete x; }
+#endif
 
 protected:
     ImageOutput ();
@@ -2477,12 +2499,22 @@ public:
     std::string geterror(bool clear = true) const;
 
     /// Error reporting for the plugin implementation: call this with
+    /// std::format-like arguments. It is not necessary to have the error
+    /// message contain a trailing newline.
+    template<typename... Args>
+    void errorfmt(const char* fmt, const Args&... args) const {
+        append_error(Strutil::fmt::format (fmt, args...));
+    }
+
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2, 6, 3) && \
+    !defined(OIIO_INTERNAL) && !defined(OIIO_DOXYGEN)
+    /// Error reporting for the plugin implementation: call this with
     /// `Strutil::format`-like arguments. It is not necessary to have the
     /// error message contain a trailing newline.
     /// Use with caution! Some day this will change to be fmt-like rather
     /// than printf-like.
     template<typename... Args>
-    OIIO_FORMAT_DEPRECATED
+    OIIO_DEPRECATED("use errorfmt instead, with std::format-like arguments (3.0)")
     void error(const char* fmt, const Args&... args) const {
         append_error(Strutil::format (fmt, args...));
     }
@@ -2491,27 +2523,20 @@ public:
     /// printf-like arguments. It is not necessary to have the error message
     /// contain a trailing newline.
     template<typename... Args>
-    OIIO_FORMAT_DEPRECATED
+    OIIO_DEPRECATED("use errorfmt instead, with std::format-like arguments (3.0)")
     void errorf(const char* fmt, const Args&... args) const {
         append_error(Strutil::sprintf (fmt, args...));
-    }
-
-    /// Error reporting for the plugin implementation: call this with
-    /// std::format-like arguments. It is not necessary to have the error
-    /// message contain a trailing newline.
-    template<typename... Args>
-    void errorfmt(const char* fmt, const Args&... args) const {
-        append_error(Strutil::fmt::format (fmt, args...));
     }
 
     // Error reporting for the plugin implementation: call this with
     // std::format-like arguments. It is not necessary to have the error
     // message contain a trailing newline.
     template<typename... Args>
-    OIIO_DEPRECATED("use `errorfmt` instead")
+    OIIO_DEPRECATED("use `errorfmt` instead (2.3)")
     void fmterror(const char* fmt, const Args&... args) const {
         append_error(Strutil::fmt::format (fmt, args...));
     }
+#endif
 
     /// Set the threading policy for this ImageOutput, controlling the
     /// maximum amount of parallelizing thread "fan-out" that might occur
@@ -3237,12 +3262,6 @@ get_extension_map()
 OIIO_API bool convert_pixel_values (TypeDesc src_type, const void *src,
                                     TypeDesc dst_type, void *dst, int n = 1);
 
-/// DEPRECATED(2.1): old name
-inline bool convert_types (TypeDesc src_type, const void *src,
-                           TypeDesc dst_type, void *dst, int n = 1) {
-    return convert_pixel_values (src_type, src, dst_type, dst, n);
-}
-
 
 /// Helper routine for data conversion: Convert an image of nchannels x
 /// width x height x depth from src to dst.  The src and dst may have
@@ -3260,18 +3279,6 @@ OIIO_API bool convert_image (int nchannels, int width, int height, int depth,
                              void *dst, TypeDesc dst_type,
                              stride_t dst_xstride, stride_t dst_ystride,
                              stride_t dst_zstride);
-/// DEPRECATED(2.0) -- the alpha_channel, z_channel were never used
-inline bool convert_image(int nchannels, int width, int height, int depth,
-            const void *src, TypeDesc src_type,
-            stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
-            void *dst, TypeDesc dst_type,
-            stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
-            int /*alpha_channel*/, int /*z_channel*/ = -1)
-{
-    return convert_image(nchannels, width, height, depth, src, src_type,
-                         src_xstride, src_ystride, src_zstride, dst, dst_type,
-                         dst_xstride, dst_ystride, dst_zstride);
-}
 
 
 /// A version of convert_image that will break up big jobs into multiple
@@ -3284,19 +3291,7 @@ OIIO_API bool parallel_convert_image (
                void *dst, TypeDesc dst_type,
                stride_t dst_xstride, stride_t dst_ystride,
                stride_t dst_zstride, int nthreads=0);
-/// DEPRECATED(2.0) -- the alpha_channel, z_channel were never used
-inline bool parallel_convert_image(
-            int nchannels, int width, int height, int depth,
-            const void *src, TypeDesc src_type,
-            stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
-            void *dst, TypeDesc dst_type,
-            stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
-            int /*alpha_channel*/, int /*z_channel*/, int nthreads=0)
-{
-    return parallel_convert_image (nchannels, width, height, depth,
-           src, src_type, src_xstride, src_ystride, src_zstride,
-           dst, dst_type, dst_xstride, dst_ystride, dst_zstride, nthreads);
-}
+
 
 /// Add random [-ditheramplitude,ditheramplitude] dither to the color channels
 /// of the image.  Dither will not be added to the alpha or z channel.  The
@@ -3368,18 +3363,80 @@ void debugfmt (const char* fmt, Args&&... args)
     Strutil::debug(fmt, std::forward<Args>(args)...);
 }
 
+
+
+// to force correct linkage on some systems
+OIIO_API void _ImageIO_force_link ();
+
+
+//////////////////////////////////////////////////////////////////////////
+// DEPRECATED things
+//
+// These are all hidden from ocumentation and internal use, and should trigger
+// deprecation warnings if used externally. They will most likely be removed
+// entirely before the final release of OIIO 3.0.
+//
+#if !defined(OIIO_INTERNAL) && !defined(OIIO_DOXYGEN)
+
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(1,9,0) && !defined(OIIO_INTERNAL)
+// Deprecated typedefs. Just use ParamValue and ParamValueList directly.
+OIIO_DEPRECATED("Use ParamValue instead") typedef ParamValue ImageIOParameter;
+OIIO_DEPRECATED("Use ParamValueList instead") typedef ParamValueList ImageIOParameterList;
+#endif
+
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2, 0, 0)
+// DEPRECATED(2.0) -- the alpha_channel, z_channel were never used
+OIIO_DEPRECATED("Deprecated version (2.0)")
+inline bool convert_image(int nchannels, int width, int height, int depth,
+            const void *src, TypeDesc src_type,
+            stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
+            void *dst, TypeDesc dst_type,
+            stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
+            int /*alpha_channel*/, int /*z_channel*/ = -1)
+{
+    return convert_image(nchannels, width, height, depth, src, src_type,
+                         src_xstride, src_ystride, src_zstride, dst, dst_type,
+                         dst_xstride, dst_ystride, dst_zstride);
+}
+
+// DEPRECATED(2.0) -- the alpha_channel, z_channel were never used
+OIIO_DEPRECATED("Deprecated version (2.0)")
+inline bool parallel_convert_image(
+            int nchannels, int width, int height, int depth,
+            const void *src, TypeDesc src_type,
+            stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
+            void *dst, TypeDesc dst_type,
+            stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
+            int /*alpha_channel*/, int /*z_channel*/, int nthreads=0)
+{
+    return parallel_convert_image (nchannels, width, height, depth,
+           src, src_type, src_xstride, src_ystride, src_zstride,
+           dst, dst_type, dst_xstride, dst_ystride, dst_zstride, nthreads);
+}
+#endif
+
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2, 1, 0)
+// DEPRECATED(2.1): old name
+OIIO_DEPRECATED("use convert_pixel_values instead (2.1)")
+inline bool convert_types (TypeDesc src_type, const void *src,
+                           TypeDesc dst_type, void *dst, int n = 1) {
+    return convert_pixel_values (src_type, src, dst_type, dst, n);
+}
+#endif
+
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2, 6, 3)
 // (Unfortunate old synonym)
 template<typename... Args>
 OIIO_DEPRECATED("use `debugfmt` instead")
-void fmtdebug (const char* fmt, const Args&... args)
+inline void fmtdebug (const char* fmt, const Args&... args)
 {
     debug (Strutil::fmt::format(fmt, args...));
 }
 
 /// debug output with printf conventions.
 template<typename... Args>
-OIIO_FORMAT_DEPRECATED
-void debugf (const char* fmt, const Args&... args)
+OIIO_DEPRECATED("use `debugfmt` instead, with std::format-like arguments (3.0)")
+inline void debugf (const char* fmt, const Args&... args)
 {
     debug (Strutil::sprintf(fmt, args...));
 }
@@ -3387,15 +3444,16 @@ void debugf (const char* fmt, const Args&... args)
 /// debug output with the same conventions as Strutil::format. Beware, this
 /// will change one day!
 template<typename T1, typename... Args>
-OIIO_FORMAT_DEPRECATED
-void debug (const char* fmt, const T1& v1, const Args&... args)
+OIIO_DEPRECATED("use `debugfmt` instead, with std::format-like arguments (3.0)")
+inline void debug (const char* fmt, const T1& v1, const Args&... args)
 {
     debug (Strutil::format(fmt, v1, args...));
 }
+#endif
 
-
-// to force correct linkage on some systems
-OIIO_API void _ImageIO_force_link ();
+#endif
+//
+//////////////////////////////////////////////////////////////////////////
 
 OIIO_NAMESPACE_END
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -167,8 +167,10 @@ namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
 /// Version 24 Added a PIMPL pointers to ImageInput and ImageOutput and
 ///     removed some unnecessary fields that were exposed.
 /// Version 25 added the thumbnail retrieval and set. (OIIO 2.3)
+/// Version 26 deprecated the old stateful ImageInput::read_* methods.
+///     (OIIO 2.6.3/3.0)
 
-#define OIIO_PLUGIN_VERSION 25
+#define OIIO_PLUGIN_VERSION 26
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_BEGIN
 #define OIIO_PLUGIN_NAMESPACE_END OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -269,7 +269,7 @@ ImageBufAlgo::from_OpenCV(const cv::Mat& mat, TypeDesc convert, ROI roi,
     parallel_convert_image(spec.nchannels, spec.width, spec.height, 1,
                            mat.ptr(), srcformat, pixelsize, linestep, 0,
                            dst.pixeladdr(roi.xbegin, roi.ybegin), dstformat,
-                           spec.pixel_bytes(), spec.scanline_bytes(), 0, -1, -1,
+                           spec.pixel_bytes(), spec.scanline_bytes(), 0,
                            nthreads);
 
     // OpenCV uses BGR ordering

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -593,54 +593,6 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
 
 
 
-// DEPRECATED(2.2)
-std::unique_ptr<ImageOutput>
-ImageOutput::create(const std::string& filename,
-                    const std::string& plugin_searchpath)
-{
-    return create(filename, nullptr, plugin_searchpath);
-}
-
-
-
-void
-ImageOutput::destroy(ImageOutput* x)
-{
-    delete x;
-}
-
-
-
-// DEPRECATED(2.1)
-std::unique_ptr<ImageInput>
-ImageInput::create(const std::string& filename,
-                   const std::string& plugin_searchpath)
-{
-    return create(filename, false, nullptr, plugin_searchpath);
-}
-
-
-
-// DEPRECATED(2.1)
-std::unique_ptr<ImageInput>
-ImageInput::create(const std::string& filename, bool do_open,
-                   const std::string& plugin_searchpath)
-{
-    return create(filename, do_open, nullptr, plugin_searchpath);
-}
-
-
-
-// DEPRECATED(2.2)
-std::unique_ptr<ImageInput>
-ImageInput::create(const std::string& filename, bool do_open,
-                   const ImageSpec* config, string_view plugin_searchpath)
-{
-    return create(filename, do_open, config, nullptr, plugin_searchpath);
-}
-
-
-
 std::unique_ptr<ImageInput>
 ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
                    Filesystem::IOProxy* ioproxy, string_view plugin_searchpath)
@@ -835,14 +787,6 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
     }
 
     return std::unique_ptr<ImageInput>(create_function());
-}
-
-
-
-void
-ImageInput::destroy(ImageInput* x)
-{
-    delete x;
 }
 
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -884,11 +884,13 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
                 const char* data;
                 if (tile
                     && (data = (const char*)tile->data(x, y, z, chbegin))) {
-                    convert_types(texfile->datatype(subimage), data, format,
-                                  result, actualchannels);
+                    convert_pixel_values(texfile->datatype(subimage), data,
+                                         format, result, actualchannels);
                     for (int c = actualchannels; c < nchannels; ++c)
-                        convert_types(TypeDesc::FLOAT, &options.fill, format,
-                                      (char*)result + c * formatchannelsize, 1);
+                        convert_pixel_values(TypeFloat, &options.fill, format,
+                                             (char*)result
+                                                 + c * formatchannelsize,
+                                             1);
                 } else {
                     memset(result, 0, formatpixelsize);
                 }

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -320,8 +320,8 @@ NullInput::open(const std::string& name, ImageSpec& newspec,
         // Convert float to the native type
         fvalue.resize(m_topspec.nchannels, 0.0f);
         m_value.resize(m_topspec.pixel_bytes());
-        convert_types(TypeFloat, fvalue.data(), m_topspec.format,
-                      m_value.data(), m_topspec.nchannels);
+        convert_pixel_values(TypeFloat, fvalue.data(), m_topspec.format,
+                             m_value.data(), m_topspec.nchannels);
     }
 
     bool ok = seek_subimage(0, 0);

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -331,10 +331,10 @@ print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
                 mipdesc += format(" {}x{}", mipspec->width, mipspec->height);
             }
         } else if (input) {
-            ImageSpec mipspec;
-            for (int m = 1; input->seek_subimage(current_subimage, m, mipspec);
-                 ++m)
+            for (int m = 1; input->seek_subimage(current_subimage, m); ++m) {
+                ImageSpec mipspec = input->spec_dimensions(current_subimage, m);
                 mipdesc += format(" {}x{}", mipspec.width, mipspec.height);
+            }
         }
         lines.insert(lines.begin() + 1, mipdesc);
     }
@@ -398,7 +398,7 @@ print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
             if (img)
                 spec = *img->nativespec(i);
             if (input)
-                input->seek_subimage(i, 0, spec);
+                spec = input->spec(i, 0);
             int bits = spec.get_int_attribute("oiio:BitsPerSample",
                                               spec.format.size() * 8);
             if (i)
@@ -446,8 +446,6 @@ print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
     out << ser;
 
     if (input && opt.dumpdata) {
-        ImageSpec tmp;
-        input->seek_subimage(current_subimage, 0, tmp);
         dump_data(out, input, opt, current_subimage);
     }
 
@@ -456,7 +454,7 @@ print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
         for (int m = 0; m < nmip; ++m) {
             ImageSpec mipspec;
             if (input)
-                input->seek_subimage(current_subimage, m, mipspec);
+                mipspec = input->spec(current_subimage, m);
             else if (img)
                 mipspec = *img->spec(current_subimage, m);
             if (opt.filenameprefix)

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -176,7 +176,8 @@ declare_imageinput(py::module& m)
             "create",
             [](const std::string& filename,
                const std::string& searchpath) -> py::object {
-                auto in = ImageInput::create(filename, searchpath);
+                auto in = ImageInput::create(filename, false, nullptr, nullptr,
+                                             searchpath);
                 return in ? py::cast(in.release()) : py::none();
             },
             "filename"_a, "plugin_searchpath"_a = "")

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -198,7 +198,7 @@ declare_imageoutput(py::module& m)
             "create",
             [](const std::string& filename,
                const std::string& searchpath) -> py::object {
-                auto out(ImageOutput::create(filename, searchpath));
+                auto out(ImageOutput::create(filename, nullptr, searchpath));
                 return out ? py::cast(out.release()) : py::none();
             },
             "filename"_a, "plugin_searchpath"_a = "")

--- a/testsuite/iinfo/ref/out-fmt6.txt
+++ b/testsuite/iinfo/ref/out-fmt6.txt
@@ -312,7 +312,7 @@ uint8_t foo[2][2][3] =
     /* (1, 1): */ { 64, 128, 191 /* (0.2509804, 0.5019608, 0.7490196) */ } },
 };
 Reading tmp.tif
-<ImageSpec version="25">
+<ImageSpec version="26">
 <SHA1>39754B9B5BF224DA2869627680D5853D787E794F</SHA1>
 <x>0</x>
 <y>0</y>

--- a/testsuite/iinfo/ref/out.txt
+++ b/testsuite/iinfo/ref/out.txt
@@ -312,7 +312,7 @@ uint8_t foo[2][2][3] =
     /* (1, 1): */ { 64, 128, 191 /* (0.2509804, 0.5019608, 0.7490196) */ } },
 };
 Reading tmp.tif
-<ImageSpec version="25">
+<ImageSpec version="26">
 <SHA1>39754B9B5BF224DA2869627680D5853D787E794F</SHA1>
 <x>0</x>
 <y>0</y>

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -125,7 +125,7 @@ extra_attribs size is 10
 99.5
 
 seralize(xml):
-<ImageSpec version="25">
+<ImageSpec version="26">
 <x>1</x>
 <y>2</y>
 <z>3</z>

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -125,7 +125,7 @@ extra_attribs size is 10
 99.5
 
 seralize(xml):
-<ImageSpec version="25">
+<ImageSpec version="26">
 <x>1</x>
 <y>2</y>
 <z>3</z>


### PR DESCRIPTION
Track down and fix many places internal to OIIO where we were still using deprecated API calls.

Add deprecation warnings to some things that have been nominally deprecated, but weren't already tagged as such.

Guard deprecated things behind OIIO_DISABLE_DEPRECATED so that downstream projects can hide them to help them find and change any use of the deprecated calls, and behind !defined(OIIO_INTERNAL) so they are hidden from the rest of the internals of our code base.

Make some of the deprecated things inline, so that their final removal later doesn't constitute a link ABI compatibility change. (We do absorb an ABI compatibility boundary with this PR, so I've bumped the version number appropriately.) Move all the OIIO-namespace level deprecated items to the end of imageio.h so they're as out of the way as possible.

A lot of the things that are still present here, just guarded by the deprecation warnings, will be removed entirely before the final OIIO 3.0 release.

Please note some particular things in imageio that have been deprecated for a while and that we expect to disappear entirely by 3.0:

* The old style `ImageInput::read_*` functions that don't take explicit subimage and miplevel paramters, because they aren't thread-safe due to their implied statefulness. You are expected to use the ones that take those parameters and are stateless.

* The variety of seek_subimage that takes an `ImageSpec&` to fill in.

* Some obsolete varieties of ImageInput and ImageOutput create() static methods.

* The `destroy` methods that are no longer needed (plain old `delete` is fine).

* The various error-setting functions that use the old printf-like formatting conventions. Use `errorfmt()` and friends that use the std::format conventions.
