### PR TITLE
build: Avoid rebuilds due to processing of fmt headers

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -86,7 +86,7 @@ if (OIIO_INTERNALIZE_FMT OR fmt_LOCAL_BUILD)
     add_custom_command (OUTPUT ${fmt_headers_internal}
                         DEPENDS ${fmt_headers} ${fmt_internal_directory}
                         COMMAND
-                            ${CMAKE_COMMAND} -E copy
+                            ${CMAKE_COMMAND} -E copy_if_different
                             ${fmt_headers}
                             ${fmt_internal_directory})
     add_custom_target (fmt_internal_target DEPENDS ${fmt_headers_internal})
@@ -96,13 +96,17 @@ else ()
          ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/ostream.h
          ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/printf.h )
     foreach (f format.h ostream.h printf.h)
-        file (WRITE "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/${f}"
-                    "#include <fmt/${f}>")
+        if (NOT EXISTS "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/${f}")
+            file (WRITE "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/${f}"
+                        "#include <fmt/${f}>")
+        endif ()
     endforeach ()
     if (fmt_VERSION VERSION_GREATER_EQUAL 9)
         list (APPEND fmt_headers ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/std.h)
-        file (WRITE "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/std.h"
-                    "#include <fmt/std.h>")
+        if (NOT EXISTS "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/std.h")
+            file (WRITE "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/std.h"
+                        "#include <fmt/std.h>")
+        endif ()
     endif ()
 endif ()
 install (FILES ${fmt_headers}


### PR DESCRIPTION
## Description
This continues the adventure from #4082 where the processing of fmt headers, both locally built and externally referenced, causes large rebuilds to occur when making small or even zero changes between builds.

Since that previous PR is stuck I'll try again here.

This makes two sets of changes:
 - Check if our generated files exist before writing to them (in the externally referenced case)
 - Use `copy_if_different` to prevent redundant copies from occuring, and triggering timestamp updates (in the local build case)

Note that while this seems to fix the problem, the build is still not "clean" wrt fmt processing. The following will be be seen when triggering a build, with zero changes since the last build, within VS:
```
1>------ Build started: Project: ZERO_CHECK, Configuration: Debug x64 ------
1>1>Checking Build System
2>------ Build started: Project: fmt_internal_target, Configuration: Debug x64 ------
3>------ Build started: Project: CopyFiles, Configuration: Debug x64 ------

2>Generating ../../include/OpenImageIO/detail/fmt
2>Building Custom Rule C:/Users/jesse/source/oiio/src/include/CMakeLists.txt
2>Generating ../../include/OpenImageIO/detail/fmt/core.h, ../../include/OpenImageIO/detail/fmt/format-inl.h, ../../include/OpenImageIO/detail/fmt/format.h, ../../include/OpenImageIO/detail/fmt/ostream.h, ../../include/OpenImageIO/detail/fmt/printf.h, ../../include/OpenImageIO/detail/fmt/std.h, ../../include/OpenImageIO/detail/fmt/chrono.h
2>C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): warning MSB8065: Custom build for item "C:\Users\jesse\source\oiio\build\CMakeFiles\b19a1b09c2e7eaa53ca90801840dfdd0\fmt.rule" succeeded, but specified output "c:\users\jesse\source\oiio\build\include\openimageio\detail\fmt" has not been created. This may cause incremental build to work incorrectly.
2>C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): warning MSB8064: Custom build for item "C:\Users\jesse\source\oiio\build\CMakeFiles\b253238471e54ff57d14ae397110f40e\core.h.rule" succeeded, but specified dependency "c:\users\jesse\source\oiio\build\include\openimageio\detail\fmt" does not exist. This may cause incremental build to work incorrectly.

2>Done building project "fmt_internal_target.vcxproj".
4>------ Build started: Project: OpenImageIO_Util, Configuration: Debug x64 ------
```
Whatever it is, the VS generator doesn't much like the way we're handling the processing but I don't know enough cmake-fu to ascertain why that might be.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
