### PR TITLE
api: Add TypeDesc::Vector3i

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -48,7 +48,7 @@ in the outer OpenImageIO scope:
     TypeMatrix33 TypeMatrix44 TypeMatrix TypeHalf
     TypeInt TypeUInt TypeInt32 TypeUInt32 TypeInt64 TypeUInt64
     TypeInt16 TypeUInt16 TypeInt8 TypeUInt8
-    TypeFloat2 TypeVector2 TypeVector2i TypeFloat4
+    TypeFloat2 TypeVector2 TypeVector2i TypeVector3i TypeFloat4
     TypeString TypeTimeCode TypeKeyCode
     TypeBox2 TypeBox2i TypeBox3 TypeBox3i
     TypeRational TypePointer

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -125,7 +125,8 @@ described in detail in Section :ref:`sec-typedesc`, is replicated for Python.
 .. py:data:: TypeUnknown TypeString TypeFloat TypeHalf
              TypeInt TypeUInt TypeInt16 TypeUInt16
              TypeColor TypePoint TypeVector TypeNormal
-             TypeFloat2 TypeVector2 TypeFloat4 TypeVector2i
+             TypeFloat2 TypeVector2 TypeFloat4
+             TypeVector2i TypeVector3i
              TypeMatrix TypeMatrix33
              TypeTimeCode TypeKeyCode TypeRational TypePointer
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -404,6 +404,7 @@ OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt8 (TypeDesc::UINT8);
 OIIO_INLINE_CONSTEXPR TypeDesc TypeInt64 (TypeDesc::INT64);
 OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt64 (TypeDesc::UINT64);
 OIIO_INLINE_CONSTEXPR TypeDesc TypeVector2i(TypeDesc::INT, TypeDesc::VEC2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeVector3i(TypeDesc::INT, TypeDesc::VEC3);
 OIIO_INLINE_CONSTEXPR TypeDesc TypeBox2(TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::BOX, 2);
 OIIO_INLINE_CONSTEXPR TypeDesc TypeBox3(TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::BOX, 2);
 OIIO_INLINE_CONSTEXPR TypeDesc TypeBox2i(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX, 2);
@@ -483,6 +484,7 @@ template<> struct TypeDescFromC<Imath::V3f> { static const constexpr TypeDesc va
 template<> struct TypeDescFromC<Imath::V2f> { static const constexpr TypeDesc value() { return TypeVector2; } };
 template<> struct TypeDescFromC<Imath::V4f> { static const constexpr TypeDesc value() { return TypeVector4; } };
 template<> struct TypeDescFromC<Imath::V2i> { static const constexpr TypeDesc value() { return TypeVector2i; } };
+template<> struct TypeDescFromC<Imath::V3i> { static const constexpr TypeDesc value() { return TypeVector3i; } };
 #endif
 #ifdef INCLUDED_IMATHCOLOR_H
 template<> struct TypeDescFromC<Imath::Color3f> { static const constexpr TypeDesc value() { return TypeColor; } };

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -188,7 +188,7 @@ TypeDesc::c_str() const
     //     result = "float2";
     // else if (aggregate == VEC4 && basetype == FLOAT && vecsemantics == NOXFORM)
     //     result = "float4";
-    else if (vecsemantics == NOXFORM) {
+    else if (vecsemantics == NOXFORM && basetype == FLOAT) {
         switch (aggregate) {
         case VEC2: result = "float2"; break;
         case VEC3: result = "float3"; break;
@@ -198,6 +198,22 @@ TypeDesc::c_str() const
         }
         if (basetype != FLOAT)
             result += basetype_code[basetype];
+    } else if (vecsemantics == NOXFORM) {
+        switch (aggregate) {
+        case VEC2:
+        case VEC3:
+        case VEC4:
+            result = Strutil::fmt::format("vector{}{}", int(aggregate),
+                                          basetype_code[basetype]);
+            break;
+        case MATRIX33:
+            result = Strutil::fmt::format("matrix33{}",
+                                          basetype_code[basetype]);
+            break;
+        case MATRIX44:
+            result = Strutil::fmt::format("matrix{}", basetype_code[basetype]);
+            break;
+        }
     } else {
         // Special names for vector semantics
         const char* vec = "";

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -150,6 +150,7 @@ declare_typedesc(py::module& m)
         .def_readonly_static("TypeFloat2", &TypeFloat2)
         .def_readonly_static("TypeVector2", &TypeVector2)
         .def_readonly_static("TypeVector2i", &TypeVector2i)
+        .def_readonly_static("TypeVector3i", &TypeVector3i)
         .def_readonly_static("TypeFloat4", &TypeFloat4)
         .def_readonly_static("TypeVector4", &TypeVector4);
 
@@ -192,6 +193,7 @@ declare_typedesc(py::module& m)
     m.attr("TypeFloat4")   = TypeFloat4;
     m.attr("TypeVector4")  = TypeVector4;
     m.attr("TypeVector2i") = TypeVector2i;
+    m.attr("TypeVector3i") = TypeVector3i;
     m.attr("TypeBox2")     = TypeBox2;
     m.attr("TypeBox3")     = TypeBox3;
     m.attr("TypeBox2i")    = TypeBox2i;

--- a/testsuite/python-typedesc/ref/out-python2.txt
+++ b/testsuite/python-typedesc/ref/out-python2.txt
@@ -194,7 +194,9 @@ type 'TypeFloat4'
 type 'TypeVector4'
     c_str "float4"
 type 'TypeVector2i'
-    c_str "float2i"
+    c_str "int2"
+type 'TypeVector3i'
+    c_str "int3"
 type 'TypeHalf'
     c_str "half"
 
@@ -249,7 +251,9 @@ type 'TypeFloat4'
 type 'TypeVector4'
     c_str "float4"
 type 'TypeVector2i'
-    c_str "float2i"
+    c_str "vector2i"
+type 'TypeVector3i'
+    c_str "vector3i"
 type 'TypeHalf'
     c_str "half"
 type 'TypeRational'

--- a/testsuite/python-typedesc/ref/out.txt
+++ b/testsuite/python-typedesc/ref/out.txt
@@ -194,7 +194,9 @@ type 'TypeFloat4'
 type 'TypeVector4'
     c_str "float4"
 type 'TypeVector2i'
-    c_str "float2i"
+    c_str "vector2i"
+type 'TypeVector3i'
+    c_str "vector3i"
 type 'TypeHalf'
     c_str "half"
 
@@ -249,7 +251,9 @@ type 'TypeFloat4'
 type 'TypeVector4'
     c_str "float4"
 type 'TypeVector2i'
-    c_str "float2i"
+    c_str "vector2i"
+type 'TypeVector3i'
+    c_str "vector3i"
 type 'TypeHalf'
     c_str "half"
 type 'TypeRational'

--- a/testsuite/python-typedesc/src/test_typedesc.py
+++ b/testsuite/python-typedesc/src/test_typedesc.py
@@ -159,6 +159,7 @@ try:
     breakdown_test (oiio.TypeDesc.TypeFloat4,   "TypeFloat4",   verbose=False)
     breakdown_test (oiio.TypeDesc.TypeVector4,  "TypeVector4",  verbose=False)
     breakdown_test (oiio.TypeDesc.TypeVector2i, "TypeVector2i", verbose=False)
+    breakdown_test (oiio.TypeDesc.TypeVector3i, "TypeVector3i", verbose=False)
     breakdown_test (oiio.TypeDesc.TypeHalf,     "TypeHalf",     verbose=False)
     print ("")
 
@@ -189,6 +190,7 @@ try:
     breakdown_test (oiio.TypeFloat4,   "TypeFloat4",   verbose=False)
     breakdown_test (oiio.TypeVector4,  "TypeVector4",  verbose=False)
     breakdown_test (oiio.TypeVector2i, "TypeVector2i", verbose=False)
+    breakdown_test (oiio.TypeVector3i, "TypeVector3i", verbose=False)
     breakdown_test (oiio.TypeHalf,     "TypeHalf",     verbose=False)
     breakdown_test (oiio.TypeRational, "TypeRational", verbose=False)
     breakdown_test (oiio.TypeUInt,     "TypeUInt",     verbose=False)


### PR DESCRIPTION
Like the existing Vector2i, but, you know, 3.

Along the way, fixed a bug in the way the Vector2i type is represented as a string.
