### PR TITLE
api: add memsize() methods to ParamValueList and ImageSpec

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -793,6 +793,10 @@ public:
         return nchannels == 0 && format == TypeUnknown;
     }
 
+    /// Return the total memory used by the ImageSpec, including this object
+    /// itself, and all the metadata and other allocated fields within.
+    size_t memsize() const;
+
     /// Array indexing by string will create an AttrDelegate that enables a
     /// convenient shorthand for adding and retrieving values from the spec:
     ///

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -530,6 +530,12 @@ public:
         shrink_to_fit();
     }
 
+    /// Return the total memory used by the ParamValueList, including this
+    /// object itself, all the ParamValue entries (including allocated but
+    /// unused capacity of the vector), and any heap memory allocated by the
+    /// ParamValue entries to hold their data.
+    size_t memsize() const noexcept;
+
     /// Array indexing by integer will return a reference to the ParamValue
     /// in that position of the list.
     ParamValue& operator[](int index)

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1251,4 +1251,24 @@ ImageSpec::set_colorspace(string_view colorspace)
 }
 
 
+
+size_t
+ImageSpec::memsize() const
+{
+    size_t s = sizeof(this);
+    s += channelformats.capacity() * sizeof(TypeDesc);
+    s += channelnames.capacity() * sizeof(std::string);
+    // N.B. We're not counting the memory of the strings themselves. To be
+    // exact would require us to figure out which strings have heap allocation
+    // and which are stored inline using the "short string" optimization.
+    // Considering that most channel names are short strings, this is probably
+    // accurate enough.
+    s += extra_attribs.memsize() - sizeof(extra_attribs);
+    // N.B. extra_attribs.memsize() includes the size of the ParamValueList
+    // itself, so we have to subtract that out to avoid double counting it,
+    // since it's also included in sizeof(*this).
+    return s;
+}
+
+
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -313,6 +313,7 @@ test_imagespec_from_xml()
     std::cout << "test_imagespec_from_xml\n";
     ImageSpec spec;
     spec.from_xml(imagespec_xml_string);
+    print("  spec memsize = {}\n", spec.memsize());
 
     OIIO_CHECK_EQUAL(spec.nchannels, 4);
     OIIO_CHECK_EQUAL(spec.width, 1920);
@@ -331,6 +332,8 @@ test_imagespec_from_xml()
 int
 main(int /*argc*/, char* /*argv*/[])
 {
+    print("sizeof(ImageSpec) = {}\n", sizeof(ImageSpec));
+
     test_imagespec_pixels();
     test_imagespec_metadata_val();
     test_imagespec_attribute_from_string();

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1842,6 +1842,7 @@ ImageCacheImpl::getstats(int level) const
     imagesize_t total_redundant_bytes = 0;
     size_t total_untiled = 0, total_unmipped = 0, total_duplicates = 0;
     size_t total_constant              = 0;
+    size_t total_imagespec_size        = 0;
     double total_iotime                = 0;
     double total_input_mutex_wait_time = 0;
     std::vector<ImageCacheFileRef> files;
@@ -1868,6 +1869,11 @@ ImageCacheImpl::getstats(int level) const
                 found_untiled |= si.untiled;
                 found_unmipped |= si.unmipped;
                 found_const &= si.is_constant_image;
+                for (int m = 0, mend = file->miplevels(s); m < mend; ++m) {
+                    const ImageCacheFile::LevelInfo& li(file->levelinfo(s, m));
+                    total_imagespec_size += li.spec.memsize();
+                    total_imagespec_size += li.nativespec.memsize();
+                }
             }
             total_untiled += found_untiled;
             total_unmipped += found_unmipped;
@@ -1990,6 +1996,8 @@ ImageCacheImpl::getstats(int level) const
                   "    Failure reads followed by unexplained success:"
                   " {} files, {} tiles\n",
                   stats.file_retry_success, stats.tile_retry_success);
+        print(out, "    Total ImageSpec size : {}\n",
+              Strutil::memformat(total_imagespec_size));
     }
 
     if (level >= 2 && files.size()) {

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -656,6 +656,19 @@ ParamValueList::merge(const ParamValueList& other, bool override)
 
 
 
+size_t
+ParamValueList::memsize() const noexcept
+{
+    size_t s = sizeof(*this);              // Size of the ParamValueList itself
+    s += capacity() * sizeof(ParamValue);  // Size of the PV vector
+    for (const auto& pv : *this)
+        if (pv.is_nonlocal())
+            s += pv.datasize();  // Size of heap-allocated data
+    return s;
+}
+
+
+
 ParamValueSpan::const_iterator
 ParamValueSpan::find(ustring name, TypeDesc type, bool casesensitive) const
 {

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -274,14 +274,29 @@ test_from_string()
 
 
 
+void
+populate_pvl(ParamValueList& pl)
+{
+    pl["foo"]  = 42;
+    pl["pi"]   = float(M_PI);
+    pl["bar"]  = "barbarbar?";
+    pl["bar2"] = std::string("barbarbar?");
+    pl["bar3"] = ustring("barbarbar?");
+    pl["bar4"] = string_view("barbarbar?");
+    pl["red"]  = Imath::Color3f(1.0f, 0.0f, 0.0f);
+    pl["xy"]   = Imath::V3f(0.5f, 0.5f, 0.0f);
+    pl["Tx"]   = Imath::M44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 42, 0, 0, 1);
+}
+
+
+
 static void
 test_paramlist()
 {
     std::cout << "test_paramlist\n";
     ParamValueList pl;
-    pl.emplace_back("foo", int(42));
-    pl.emplace_back("pi", float(M_PI));
-    pl.emplace_back("bar", "barbarbar?");
+    populate_pvl(pl);
+    print("ParamValueList pl memsize is: {}\n", pl.memsize());
 
     OIIO_CHECK_EQUAL(pl.get_int("foo"), 42);
     OIIO_CHECK_EQUAL(pl.get_int("pi", 4), 4);  // should fail int
@@ -344,15 +359,7 @@ test_delegates()
 {
     std::cout << "test_delegates\n";
     ParamValueList pl;
-    pl["foo"]  = 42;
-    pl["pi"]   = float(M_PI);
-    pl["bar"]  = "barbarbar?";
-    pl["bar2"] = std::string("barbarbar?");
-    pl["bar3"] = ustring("barbarbar?");
-    pl["bar4"] = string_view("barbarbar?");
-    pl["red"]  = Imath::Color3f(1.0f, 0.0f, 0.0f);
-    pl["xy"]   = Imath::V3f(0.5f, 0.5f, 0.0f);
-    pl["Tx"]   = Imath::M44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 42, 0, 0, 1);
+    populate_pvl(pl);
 
     OIIO_CHECK_EQUAL(pl["absent"].get<int>(), 0);
     OIIO_CHECK_EQUAL(pl["absent"].type(), TypeUnknown);
@@ -402,15 +409,7 @@ test_paramlistspan()
 {
     std::cout << "test_paramlistspan\n";
     ParamValueList pvlist;
-    pvlist.emplace_back("foo", int(42));
-    pvlist.emplace_back("pi", float(M_PI));
-    pvlist.emplace_back("bar", "barbarbar?");
-    pvlist["bar2"] = std::string("barbarbar?");
-    pvlist["bar3"] = ustring("barbarbar?");
-    pvlist["bar4"] = string_view("barbarbar?");
-    pvlist["red"]  = Imath::Color3f(1.0f, 0.0f, 0.0f);
-    pvlist["xy"]   = Imath::V3f(0.5f, 0.5f, 0.0f);
-    pvlist["Tx"] = Imath::M44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 42, 0, 0, 1);
+    populate_pvl(pvlist);
 
     ParamValueSpan pl(pvlist);
     OIIO_CHECK_EQUAL(pl.get_int("foo"), 42);
@@ -526,7 +525,9 @@ test_implied_construction()
 int
 main(int /*argc*/, char* /*argv*/[])
 {
-    std::cout << "ParamValue size = " << sizeof(ParamValue) << "\n";
+    print("sizeof(ParamValue) is: {}\n", sizeof(ParamValue));
+    print("sizeof(ParamValueList) is: {}\n", sizeof(ParamValueList));
+
     test_value_types();
     test_from_string();
     test_paramlist();


### PR DESCRIPTION
To aid some memory accounting, add a method to ParamValueList and
ImageSpec that return the memory cost (the size of the struct and all
the allocated things hanging off of it). We're trying to be more
careful about understanding how much memory is used by having many
copies of ImageSpec's lying around.

Have ImageCache stats estimate how much mem is tied up in ImageSpecs.
