### PR TITLE
make_texture: only write full metadata to the first mip level

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -2301,6 +2301,10 @@ enum MakeTextureMode {
 ///                           Semicolon-separated list of alternate images
 ///                           to be used for individual MIPmap levels,
 ///                           rather than simply downsizing. (default: "")
+///    - `maketx:mipmap_metadata` (int) :
+///                           If nonzero, will propagate metadata to every MIP
+///                           level. The default (0) only writes metadata to
+///                           the highest-resolution level. (0)
 ///    - `maketx:full_command_line` (string) :
 ///                           The command or program used to generate this
 ///                           call, will be embedded in the metadata.

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -758,7 +758,9 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
                 mipimages.erase(mipimages.begin());
             } else {
                 // Resize a factor of two smaller
-                smallspec        = outspec;
+                smallspec = outspec;
+                if (!configspec.get_int_attribute("maketx:mipmap_metadata"))
+                    smallspec.extra_attribs.free();
                 smallspec.width  = img->spec().width;
                 smallspec.height = img->spec().height;
                 smallspec.depth  = img->spec().depth;


### PR DESCRIPTION
It's silly to copy the full metadata from the source (which could include big things like ICC profiles) to EVERY level of a MIPmap.

This mostly applies to TIFF textures, since OpenEXR MIPmaps don't store attributes separately for each MIP level anyway.

This can be disabled (that is, make it copy full metadata to all levels of the MIPmap) by setting a new make_texture configuration hint, "maketx:mipmap_metadata" to nonzero.
