### PR TITLE
api: add pvt::heapsize() and pvt::footprint() methods and image cache memory tracking

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -257,6 +257,8 @@ public:
     ///           all files referenced by calls to the ImageCache. (The
     ///           array is of `ustring` or `char*`.)
     ///
+    /// - `int64 stat:cache_footprint` :
+    ///           Total bytes used by image cache.
     /// - `int64 stat:cache_memory_used` :
     ///           Total bytes used by tile cache.
     ///

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -36,6 +36,7 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/typedesc.h>
+#include <OpenImageIO/memory.h>
 
 OIIO_NAMESPACE_BEGIN
 
@@ -1884,6 +1885,9 @@ private:
     std::unique_ptr<Impl, decltype(&impl_deleter)> m_impl;
 
     void append_error(string_view message) const; // add to error message
+
+    /// declare a friend heapsize definition
+    template <typename T> friend size_t pvt::heapsize(const T&);
 };
 
 
@@ -2788,7 +2792,23 @@ private:
     std::unique_ptr<Impl, decltype(&impl_deleter)> m_impl;
 
     void append_error(string_view message) const; // add to m_errmessage
+
+    /// declare a friend heapsize definition
+    template <typename T> friend size_t pvt::heapsize(const T&);
 };
+
+
+
+/// Memory tracking. Specializes the base memory tracking functions from memory.h.
+
+// heapsize specialization for `ImageSpec`
+template <> OIIO_API size_t pvt::heapsize<ImageSpec>(const ImageSpec&);
+
+// heapsize specialization for `ImageInput`
+template <> OIIO_API size_t pvt::heapsize<ImageInput>(const ImageInput&);
+
+// heapsize specialization for `ImageOutput`
+template <> OIIO_API size_t pvt::heapsize<ImageOutput>(const ImageOutput&);
 
 
 

--- a/src/include/OpenImageIO/memory.h
+++ b/src/include/OpenImageIO/memory.h
@@ -1,0 +1,117 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
+/////////////////////////////////////////////////////////////////////////
+/// @file   memory.h
+///
+/// @brief  Utilities for memory tracking.
+/////////////////////////////////////////////////////////////////////////
+
+
+#pragma once
+
+#define OPENIMAGEIO_MEMORY_H
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+OIIO_NAMESPACE_BEGIN
+
+namespace pvt {
+
+/// Return the total heap memory allocated by `object`.
+/// The template specialization can be used to give improved results for non trivial types
+/// that perform heap allocation, and to include members allocations recursively.
+template<typename T>
+inline size_t
+heapsize(const T& t)
+{
+    return 0;
+}
+
+/// Return the total memory footprint of `object`. If possible, including any heap
+/// allocations done by any constituent parts. The default implementation just reduces
+/// to sizeof(object), given that heapsize(object) would return 0.
+/// The template specialization can be used to give improved results for non trivial types
+/// that perform heap allocation.
+template<typename T>
+inline size_t
+footprint(const T& t)
+{
+    return sizeof(T) + heapsize(t);
+}
+
+template<typename T>
+inline size_t
+footprint(const T* t)
+{
+    return sizeof(T) + (t ? footprint(*t) : 0);
+}
+
+/// Specializations for common STL types
+
+
+// heapsize specialization for std::string
+template<>
+inline size_t
+heapsize<std::string>(const std::string& s)
+{
+    // accounts for small string optimization that does not
+    // use any heap allocations
+    const char* const sbegin = (const char*)&s;
+    const char* const send   = sbegin + sizeof(std::string);
+    const char* const sdata  = s.data();
+    const bool is_small      = sdata >= sbegin && sdata < send;
+    return is_small ? 0 : s.capacity();
+}
+
+// heapsize specialization for std::vector
+template<typename T>
+inline size_t
+heapsize(const std::vector<T>& vec)
+{
+    size_t size = 0;
+    for (const T& elem : vec)
+        size += footprint(elem);
+    return size;
+}
+
+// heapsize specialization for std::shared_ptr
+template<typename T>
+inline size_t
+heapsize(const std::shared_ptr<T>& ref)
+{
+    return ref ? footprint(*ref.get()) : 0;
+}
+
+// footprint specialization for std::shared_ptr
+template<typename T>
+inline size_t
+footprint(const std::shared_ptr<T>& ref)
+{
+    return sizeof(std::shared_ptr<T>) + heapsize(ref);
+}
+
+// heapsize specialization for std::unique_ptr
+template<typename T>
+inline size_t
+heapsize(const std::unique_ptr<T>& ref)
+{
+    return ref ? footprint(*ref.get()) : 0;
+}
+
+// footprint specialization for std::unique_ptr
+template<typename T>
+inline size_t
+footprint(const std::unique_ptr<T>& ref)
+{
+    return sizeof(std::unique_ptr<T>) + heapsize(ref);
+}
+
+}  // namespace pvt
+
+
+OIIO_NAMESPACE_END

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -16,6 +16,7 @@
 
 #include <OpenImageIO/attrdelegate.h>
 #include <OpenImageIO/export.h>
+#include <OpenImageIO/memory.h>
 #include <OpenImageIO/strongparam.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
@@ -276,9 +277,15 @@ private:
                       Copy _copy                = Copy(true),
                       FromUstring _from_ustring = FromUstring(false)) noexcept;
     void clear_value() noexcept;
+
+    /// declare a friend heapsize definition
+    template<typename T> friend size_t pvt::heapsize(const T&);
 };
 
-
+/// heapsize specialization for `ParamValue`
+template<>
+OIIO_API size_t
+pvt::heapsize<ParamValue>(const ParamValue&);
 
 /// Factory for a ParamValue that holds a single value of any type supported
 /// by a corresponding ParamValue constructor (such as int, float, string).

--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -16,6 +16,7 @@
 
 #include <OpenImageIO/atomic.h>
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/memory.h>
 
 
 OIIO_NAMESPACE_BEGIN
@@ -230,6 +231,27 @@ intrusive_ptr_release(T* x)
 
 // Preprocessor flags for some capabilities added incrementally.
 #define OIIO_REFCNT_HAS_RELEASE 1 /* intrusive_ptr::release() */
+
+
+/// Memory tracking. Specializes the base memory tracking functions from memory.h.
+
+// heapsize specialization for `intrusive_ptr`
+namespace pvt {
+template<typename T>
+inline size_t
+heapsize(const intrusive_ptr<T>& ref)
+{
+    return ref ? footprint(*ref.get()) : 0;
+}
+
+// footprint specialization for `intrusive_ptr`
+template<typename T>
+inline size_t
+footprint(const intrusive_ptr<T>& ref)
+{
+    return sizeof(intrusive_ptr<T>) + heapsize(ref);
+}
+}  // namespace pvt
 
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1251,4 +1251,17 @@ ImageSpec::set_colorspace(string_view colorspace)
 }
 
 
+
+template<>
+size_t
+pvt::heapsize<ImageSpec>(const ImageSpec& is)
+{
+    size_t size = pvt::heapsize(is.channelformats);
+    size += pvt::heapsize(is.channelnames);
+    size += pvt::heapsize(is.extra_attribs);
+    return size;
+}
+
+
+
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1337,4 +1337,17 @@ ImageInput::check_open(const ImageSpec& spec, ROI range, uint64_t /*flags*/)
     return true;  // all is ok
 }
 
+
+
+template<>
+size_t
+pvt::heapsize<ImageInput>(const ImageInput& input)
+{
+    //! TODO: change ImageInput API to add a virtual heapsize() function
+    //! to allow per image input override, and call that function here.
+    return pvt::heapsize(input.m_spec);
+}
+
+
+
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -1021,4 +1021,15 @@ ImageOutput::check_open(OpenMode mode, const ImageSpec& userspec, ROI range,
 
 
 
+template<>
+size_t
+pvt::heapsize<ImageOutput>(const ImageOutput& output)
+{
+    //! TODO: change ImageOutput API to add a virtual heapsize() function
+    //! to allow per image output override, and call that function here.
+    return pvt::heapsize(output.m_spec);
+}
+
+
+
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -313,6 +313,8 @@ test_imagespec_from_xml()
     std::cout << "test_imagespec_from_xml\n";
     ImageSpec spec;
     spec.from_xml(imagespec_xml_string);
+    print("  spec heapsize = {}\n", pvt::heapsize(spec));
+    print("  spec footprint = {}\n", pvt::footprint(spec));
 
     OIIO_CHECK_EQUAL(spec.nchannels, 4);
     OIIO_CHECK_EQUAL(spec.width, 1920);
@@ -331,6 +333,8 @@ test_imagespec_from_xml()
 int
 main(int /*argc*/, char* /*argv*/[])
 {
+    print("sizeof(ImageSpec) = {}\n", sizeof(ImageSpec));
+
     test_imagespec_pixels();
     test_imagespec_metadata_val();
     test_imagespec_attribute_from_string();

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -30,6 +30,8 @@
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
 
+#include "imagecache_memory_print.h"
+#include "imagecache_memory_pvt.h"
 #include "imagecache_pvt.h"
 #include "imageio_pvt.h"
 
@@ -2004,6 +2006,8 @@ ImageCacheImpl::getstats(int level) const
                   "    Failure reads followed by unexplained success:"
                   " {} files, {} tiles\n",
                   stats.file_retry_success, stats.tile_retry_success);
+
+        printImageCacheMemory(out, *this);
     }
 
     if (level >= 2 && files.size()) {
@@ -2464,6 +2468,7 @@ ImageCacheImpl::getattribute(string_view name, TypeDesc type, void* val) const
 
     if (Strutil::starts_with(name, "stat:")) {
         // Stats we can just grab
+        ATTR_DECODE("stat:cache_footprint", long long, footprint(*this));
         ATTR_DECODE("stat:cache_memory_used", long long, m_mem_used);
         ATTR_DECODE("stat:tiles_created", int, m_stat_tiles_created);
         ATTR_DECODE("stat:tiles_current", int, m_stat_tiles_current);

--- a/src/libtexture/imagecache_memory_print.h
+++ b/src/libtexture/imagecache_memory_print.h
@@ -1,0 +1,234 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
+/// \file
+//// Memory printing utilities specific to the ImageCacheImpl.
+
+
+#pragma once
+#define OPENIMAGEIO_IMAGECACHE_MEMORY_PRINT_H
+
+#include "imagecache_memory_pvt.h"
+
+#include <sstream>
+
+OIIO_NAMESPACE_BEGIN
+
+namespace pvt {
+
+//// Memory tracking helper to get ImageCacheImpl statistics
+
+//! recorded entries per file format
+enum FileFootprintEnty : uint8_t {
+    kMem = 0,
+    kCount,
+    kSpecMem,
+    kSpecCount,
+    kInputMem,
+    kInputCount,
+    kSubImageMem,
+    kSubImageCount,
+    kLevelInfoMem,
+    kLevelInfoCount,
+    kLevelInfoSpecMem,
+    kLevelInfoSpecMembMem,
+    kLevelInfoSpecParmsMem,
+    kLevelInfoSpecChanMem,
+    kFootprintEntrySize
+};
+
+typedef std::array<size_t, FileFootprintEnty::kFootprintEntrySize> FileFootprint;
+typedef tsl::robin_map<ustring, FileFootprint> FileFootprintMap;
+
+struct ImageCacheFootprint {
+    static const ustring utotal;
+    static const ustring uconstant;
+
+    // basic infos
+    size_t ic_mem     = 0;                      // image cache
+    size_t ic_str_mem = 0, ic_str_count = 0;    // std::string
+    size_t ic_tile_mem = 0, ic_tile_count = 0;  // tile
+    size_t ic_thdi_mem = 0, ic_thdi_count = 0;  // thread info
+    size_t ic_fgpt_mem = 0, ic_fgpt_count = 0;  // fingerprint
+
+    FileFootprintMap fmap;
+    template<FileFootprintEnty entry>
+    void add(const size_t size, const ustring& format)
+    {
+        addInternal<entry>(size, utotal);
+        addInternal<entry>(size, format);
+    }
+
+    template<FileFootprintEnty entry>
+    void addInternal(const size_t size, const ustring& key)
+    {
+        std::pair<FileFootprintMap::iterator, bool> insert = fmap.insert(
+            { key, FileFootprint() });
+        FileFootprint& array = insert.first.value();
+        if (insert.second)
+            std::fill(array.begin(), array.end(),
+                      0ul);  // std::array has no default init to zero
+
+        // update memory entry
+        array[entry] += size;
+
+        // update memory entry counter if exists
+        if constexpr (entry % 2 == 0 && entry <= kLevelInfoMem)
+            array[entry + 1] += 1;
+    }
+};
+
+const ustring ImageCacheFootprint::utotal    = ustring("total");
+const ustring ImageCacheFootprint::uconstant = ustring("constant");
+
+/// Fills the parameter with a memory breakdown of the ImageCache.
+inline size_t
+footprint(const ImageCacheImpl& ic, ImageCacheFootprint& output)
+{
+    // strings
+    output.ic_str_count = ic.m_searchdirs.size() + 2;
+    output.ic_str_mem   = heapsize(ic.m_searchdirs) + heapsize(ic.m_searchpath)
+                        + heapsize(ic.m_plugin_searchpath);
+
+    // thread info
+    output.ic_thdi_count = ic.m_all_perthread_info.size();
+    output.ic_thdi_mem   = heapsize(ic.m_all_perthread_info);
+
+    // tile cache
+    output.ic_tile_count = ic.m_tilecache.size();
+    for (TileCache::iterator t = ic.m_tilecache.begin(),
+                             e = ic.m_tilecache.end();
+         t != e; ++t)
+        output.ic_tile_mem += footprint(t->first) + footprint(t->second);
+
+    // finger prints; we only account for references, this map does not own the files.
+    constexpr size_t sizeofFingerprintPair = sizeof(ustring)
+                                             + sizeof(ImageCacheFileRef);
+    output.ic_fgpt_count = ic.m_fingerprints.size();
+    output.ic_fgpt_mem   = output.ic_fgpt_count * sizeofFingerprintPair;
+
+    // files; count the footprint of files, subimages, level infos, image inputs, image specs
+    for (FilenameMap::iterator t = ic.m_files.begin(), e = ic.m_files.end();
+         t != e; ++t) {
+        // get file format ustring; files with empty file format are simply constant valued.
+        const ImageCacheFile& file(*t->second);
+        const ustring& format = !file.fileformat().empty()
+                                    ? file.fileformat()
+                                    : ImageCacheFootprint::uconstant;
+
+        const size_t fileftp = footprint(t->first) + footprint(t->second);
+        output.add<kMem>(fileftp, format);
+
+        const size_t specftp = footprint(file.m_configspec);
+        output.add<kSpecMem>(specftp, format);
+
+        const size_t inputftp = footprint(file.m_input);
+        output.add<kInputMem>(inputftp, format);
+
+        // subimages
+        for (int s = 0, send = file.subimages(); s < send; ++s) {
+            const ImageCacheFile::SubimageInfo& sub(file.subimageinfo(s));
+            const size_t subftp = footprint(sub);
+            output.add<kSubImageMem>(subftp, format);
+
+            // level infos
+            for (const auto& level : sub.levels) {
+                const size_t lvlftp = footprint(level);
+                output.add<kLevelInfoMem>(lvlftp, format);
+
+                // extra infos; there are two ImageSpec structures stored in each LevelInfos,
+                // and they turn out to be memory heavy, so we further break that down next.
+                const size_t lvlspecftp = footprint(level.m_spec)
+                                          + footprint(level.nativespec);
+                const size_t lvlattrftp
+                    = (level.m_spec ? footprint(level.m_spec->extra_attribs)
+                                    : 0)
+                      + footprint(level.nativespec.extra_attribs);
+                const size_t lvlchanftp
+                    = (level.m_spec ? footprint(level.m_spec->channelnames) : 0)
+                      + footprint(level.nativespec.channelnames);
+                output.add<kLevelInfoSpecMem>(lvlspecftp, format);
+                output.add<kLevelInfoSpecMembMem>(2 * sizeof(ImageSpec),
+                                                  format);
+                output.add<kLevelInfoSpecParmsMem>(lvlattrftp, format);
+                output.add<kLevelInfoSpecChanMem>(lvlchanftp, format);
+            }
+        }
+    }
+
+    // update total memory
+    output.ic_mem += output.ic_str_mem;
+    output.ic_mem += output.ic_tile_mem;
+    output.ic_mem += output.ic_thdi_mem;
+    output.ic_mem += output.fmap.find(ImageCacheFootprint::utotal)->second[kMem];
+    output.ic_mem += output.ic_fgpt_mem;
+
+    return output.ic_mem;
+}
+
+inline void
+printImageCacheMemory(std::ostream& out, const ImageCacheImpl& ic)
+{
+    // get memory data
+    pvt::ImageCacheFootprint data;
+    pvt::footprint(ic, data);
+
+    // print image cache memory usage
+    print(out, "  Cache : {}\n", Strutil::memformat(data.ic_mem));
+    print(out, "    Strings : {}, count : {}\n",
+          Strutil::memformat(data.ic_str_mem), data.ic_str_count);
+    print(out, "    Thread info : {}, count : {}\n",
+          Strutil::memformat(data.ic_thdi_mem), data.ic_thdi_count);
+    print(out, "    Fingerprints : {}, count : {}\n",
+          Strutil::memformat(data.ic_fgpt_mem), data.ic_fgpt_count);
+    print(out, "    Tiles : {}, count : {}\n",
+          Strutil::memformat(data.ic_tile_mem), data.ic_tile_count);
+    print(out, "    Files : {}, count : {}\n",
+          Strutil::memformat(data.fmap[ImageCacheFootprint::utotal][kMem]),
+          data.fmap[ImageCacheFootprint::utotal][kCount]);
+
+    // print file formats memory usage
+    for (pvt::FileFootprintMap::const_iterator t = data.fmap.begin(),
+                                               e = data.fmap.end();
+         t != e; ++t) {
+        if (t.key() == ImageCacheFootprint::utotal)
+            continue;
+        print(out, "      Format '{}' : {}, count : {}\n", t->first,
+              Strutil::memformat(t.value()[kMem]), t.value()[kCount]);
+        if (t.value()[kInputMem] > 0ul)
+            print(out, "        Image inputs : {}, count : {}\n",
+                  Strutil::memformat(t.value()[kInputMem]),
+                  t.value()[kInputCount]);
+        if (t.value()[kSpecMem] > 0ul)
+            print(out, "        Image specs : {}, count : {}\n",
+                  Strutil::memformat(t.value()[kSpecMem]),
+                  t.value()[kSpecCount]);
+        if (t.value()[kSubImageMem] > 0ul)
+            print(out, "        Subimages : {}, count : {}\n",
+                  Strutil::memformat(t.value()[kSubImageMem]),
+                  t.value()[kSubImageCount]);
+        if (t.value()[kLevelInfoMem] > 0ul)
+            print(out, "          Level infos : {}, count : {}\n",
+                  Strutil::memformat(t.value()[kLevelInfoMem]),
+                  t.value()[kLevelInfoCount]);
+        if (t.value()[kLevelInfoSpecMem] > 0ul)
+            print(out, "            Image specs : {}, count : {}\n",
+                  Strutil::memformat(t.value()[kLevelInfoSpecMem]),
+                  t.value()[kLevelInfoCount] * 2);
+        if (t.value()[kLevelInfoSpecMembMem] > 0ul)
+            print(out, "              Members : {}\n",
+                  Strutil::memformat(t.value()[kLevelInfoSpecMembMem]));
+        if (t.value()[kLevelInfoSpecParmsMem] > 0ul)
+            print(out, "              Extra attributes : {}\n",
+                  Strutil::memformat(t.value()[kLevelInfoSpecParmsMem]));
+        if (t.value()[kLevelInfoSpecChanMem] > 0ul)
+            print(out, "              Channel names : {}\n",
+                  Strutil::memformat(t.value()[kLevelInfoSpecChanMem]));
+    }
+}
+
+}  // namespace pvt
+
+OIIO_NAMESPACE_END

--- a/src/libtexture/imagecache_memory_pvt.h
+++ b/src/libtexture/imagecache_memory_pvt.h
@@ -1,0 +1,109 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
+/// \file
+//// Memory tracking utilities specific to the ImageCacheImpl.
+
+
+#pragma once
+#define OPENIMAGEIO_IMAGECACHE_MEMORY_PVT_H
+
+#include <OpenImageIO/memory.h>
+
+#include "imagecache_pvt.h"
+
+OIIO_NAMESPACE_BEGIN
+
+namespace pvt {
+
+// heapsize specialization for ImageCacheFile::LevelInfo
+template<>
+inline size_t
+heapsize<ImageCacheFile::LevelInfo>(const ImageCacheFile::LevelInfo& lvl)
+{
+    size_t size = heapsize(lvl.polecolor);
+    size += heapsize(lvl.m_spec);
+    size += heapsize(lvl.nativespec);
+    if (lvl.tiles_read) {
+        const size_t total_tiles   = lvl.nxtiles * lvl.nytiles * lvl.nztiles;
+        const size_t bitfield_size = round_to_multiple(total_tiles, 64) / 64;
+        size += sizeof(atomic_ll) * bitfield_size;
+    }
+    return size;
+}
+
+// heapsize specialization for ImageCacheFile::SubimageInfo
+template<>
+inline size_t
+heapsize<ImageCacheFile::SubimageInfo>(const ImageCacheFile::SubimageInfo& sub)
+{
+    size_t size = heapsize(sub.levels);
+    size += heapsize(sub.average_color);
+    size += (sub.minwh ? sub.n_mip_levels * sizeof(int) : 0);
+    size += (sub.Mlocal ? sizeof(Imath::M44f) : 0);
+    return size;
+}
+
+// heapsize specialization for ImageCacheFile
+template<>
+inline size_t
+heapsize<ImageCacheFile>(const ImageCacheFile& file)
+{
+    size_t size = heapsize(file.m_subimages);
+    size += heapsize(file.m_configspec);
+    size += heapsize(file.m_input);
+    size += heapsize(file.m_mipreadcount);
+    size += heapsize(file.m_udim_lookup);
+    return size;
+}
+
+// heapsize specialization for ImageCacheTile
+template<>
+inline size_t
+heapsize<ImageCacheTile>(const ImageCacheTile& tile)
+{
+    return tile.memsize();
+}
+
+// heapsize specialization for ImageCachePerThreadInfo
+template<>
+inline size_t
+heapsize<ImageCachePerThreadInfo>(const ImageCachePerThreadInfo& info)
+{
+    /// TODO: this should take into account the two last tiles, if their refcount is zero.
+    constexpr size_t sizeofPair = sizeof(ustring) + sizeof(ImageCacheFile*);
+    return info.m_thread_files.size() * sizeofPair;
+}
+
+// heapsize specialization for ImageCacheImpl
+template<>
+inline size_t
+heapsize<ImageCacheImpl>(const ImageCacheImpl& ic)
+{
+    size_t size = 0;
+    // strings
+    size += heapsize(ic.m_searchpath) + heapsize(ic.m_plugin_searchpath)
+            + heapsize(ic.m_searchdirs);
+    // thread info
+    size += heapsize(ic.m_all_perthread_info);
+    // tile cache
+    for (TileCache::iterator t = ic.m_tilecache.begin(),
+                             e = ic.m_tilecache.end();
+         t != e; ++t)
+        size += footprint(t->first) + footprint(t->second);
+    // files
+    for (FilenameMap::iterator t = ic.m_files.begin(), e = ic.m_files.end();
+         t != e; ++t)
+        size += footprint(t->first) + footprint(t->second);
+    // finger prints; we only account for references, this map does not own the files.
+    constexpr size_t sizeofFingerprintPair = sizeof(ustring)
+                                             + sizeof(ImageCacheFileRef);
+    size += ic.m_fingerprints.size() * sizeofFingerprintPair;
+    return size;
+}
+
+}  // namespace pvt
+
+OIIO_NAMESPACE_END

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -383,6 +383,17 @@ ParamValue::clear_value() noexcept
 
 
 
+template<>
+size_t
+pvt::heapsize<ParamValue>(const ParamValue& pv)
+{
+    return (pv.m_nonlocal && pv.m_copy)
+               ? pv.m_nvalues * static_cast<int>(pv.m_type.size())
+               : 0;
+}
+
+
+
 ParamValueList::const_iterator
 ParamValueList::find(ustring name, TypeDesc type, bool casesensitive) const
 {

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -274,14 +274,30 @@ test_from_string()
 
 
 
+void
+populate_pvl(ParamValueList& pl)
+{
+    pl["foo"]  = 42;
+    pl["pi"]   = float(M_PI);
+    pl["bar"]  = "barbarbar?";
+    pl["bar2"] = std::string("barbarbar?");
+    pl["bar3"] = ustring("barbarbar?");
+    pl["bar4"] = string_view("barbarbar?");
+    pl["red"]  = Imath::Color3f(1.0f, 0.0f, 0.0f);
+    pl["xy"]   = Imath::V3f(0.5f, 0.5f, 0.0f);
+    pl["Tx"]   = Imath::M44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 42, 0, 0, 1);
+}
+
+
+
 static void
 test_paramlist()
 {
     std::cout << "test_paramlist\n";
     ParamValueList pl;
-    pl.emplace_back("foo", int(42));
-    pl.emplace_back("pi", float(M_PI));
-    pl.emplace_back("bar", "barbarbar?");
+    populate_pvl(pl);
+    print("ParamValueList pl heapsize is: {}\n", pvt::heapsize(pl));
+    print("ParamValueList pl footprint is: {}\n", pvt::footprint(pl));
 
     OIIO_CHECK_EQUAL(pl.get_int("foo"), 42);
     OIIO_CHECK_EQUAL(pl.get_int("pi", 4), 4);  // should fail int
@@ -344,15 +360,7 @@ test_delegates()
 {
     std::cout << "test_delegates\n";
     ParamValueList pl;
-    pl["foo"]  = 42;
-    pl["pi"]   = float(M_PI);
-    pl["bar"]  = "barbarbar?";
-    pl["bar2"] = std::string("barbarbar?");
-    pl["bar3"] = ustring("barbarbar?");
-    pl["bar4"] = string_view("barbarbar?");
-    pl["red"]  = Imath::Color3f(1.0f, 0.0f, 0.0f);
-    pl["xy"]   = Imath::V3f(0.5f, 0.5f, 0.0f);
-    pl["Tx"]   = Imath::M44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 42, 0, 0, 1);
+    populate_pvl(pl);
 
     OIIO_CHECK_EQUAL(pl["absent"].get<int>(), 0);
     OIIO_CHECK_EQUAL(pl["absent"].type(), TypeUnknown);
@@ -402,15 +410,7 @@ test_paramlistspan()
 {
     std::cout << "test_paramlistspan\n";
     ParamValueList pvlist;
-    pvlist.emplace_back("foo", int(42));
-    pvlist.emplace_back("pi", float(M_PI));
-    pvlist.emplace_back("bar", "barbarbar?");
-    pvlist["bar2"] = std::string("barbarbar?");
-    pvlist["bar3"] = ustring("barbarbar?");
-    pvlist["bar4"] = string_view("barbarbar?");
-    pvlist["red"]  = Imath::Color3f(1.0f, 0.0f, 0.0f);
-    pvlist["xy"]   = Imath::V3f(0.5f, 0.5f, 0.0f);
-    pvlist["Tx"] = Imath::M44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 42, 0, 0, 1);
+    populate_pvl(pvlist);
 
     ParamValueSpan pl(pvlist);
     OIIO_CHECK_EQUAL(pl.get_int("foo"), 42);
@@ -526,7 +526,9 @@ test_implied_construction()
 int
 main(int /*argc*/, char* /*argv*/[])
 {
-    std::cout << "ParamValue size = " << sizeof(ParamValue) << "\n";
+    print("sizeof(ParamValue) is: {}\n", sizeof(ParamValue));
+    print("sizeof(ParamValueList) is: {}\n", sizeof(ParamValueList));
+
     test_value_types();
     test_from_string();
     test_paramlist();


### PR DESCRIPTION
## Description

First PR of two, following @lgritz and I discussions on memory tracking in the OIIO::ImageCache.
- Add two template methods and their specializations for types various to help memory tracking:
```c++
// return the total heap allocated memory held by the object and its members
template<typename T> inline size_t heapsize(const T& t);
// return the total memory footprint including the size of the structure itself
template<typename T> inline size_t footprint(const T& t);
```
- Specialized for: ParamValue, ParamValueList, ImageSpec, ImageInput, ImageOutput, std::vector, std::shared_ptr, std::unique_ptr, oiio::intrusive_ptr, ImageCacheImpl related objects.
- New files: 
   - `include/memory.h` : adds base and few types specialization of heapsize and footprint.
   - `libtexture/imagecache_memory_pvt.h` :  adds specilializations for ImageCacheImpl and related objects.
   - `libtexture/imagecache_memory_print.h` : adds a helper function that print a breakdown of the ImageCacheImpl total memory usage as well, as well as per image format. Note: this is slow, but gives accurate memory estimation.  

Related PR from Larry : https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4317

## Tests
- [ ] todo: fix CI fails

