### PR TITLE
api: add virtual heapsize() to ImageInput and ImageOutput

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1778,6 +1778,16 @@ public:
     /// `ImageInput*`.
     typedef ImageInput* (*Creator)();
 
+    /// Memory tracking method.
+    /// Return the total heap memory allocated by `ImageInput`.
+    /// Overridable version of heapsize defined in memory.h.
+    virtual size_t heapsize() const;
+
+    /// Memory tracking method.
+    /// Return the total memory footprint of `ImageInput`.
+    /// Overridable version of footprint defined in memory.h.
+    virtual size_t footprint() const;
+
 protected:
     ImageSpec m_spec;  // format spec of the current open subimage/MIPlevel
                        // BEWARE using m_spec directly -- not thread-safe
@@ -1886,7 +1896,7 @@ private:
 
     void append_error(string_view message) const; // add to error message
 
-    /// declare a friend heapsize definition
+    /// declare friend heapsize and footprint definitions
     template <typename T> friend size_t pvt::heapsize(const T&);
 };
 
@@ -2570,6 +2580,16 @@ public:
     /// `ImageOutput*`.
     typedef ImageOutput* (*Creator)();
 
+    /// Memory tracking method.
+    /// Return the total heap memory allocated by `ImageOutput`.
+    /// Overridable version of heapsize defined in memory.h.
+    virtual size_t heapsize() const;
+
+    /// Memory tracking method.
+    /// Return the total memory footprint of `ImageOutput`.
+    /// Overridable version of footprint defined in memory.h.
+    virtual size_t footprint() const;
+
 protected:
     /// @{
     /// @name Helper functions for ImageOutput implementations.
@@ -2793,7 +2813,7 @@ private:
 
     void append_error(string_view message) const; // add to m_errmessage
 
-    /// declare a friend heapsize definition
+    /// declare friend heapsize and footprint definitions
     template <typename T> friend size_t pvt::heapsize(const T&);
 };
 
@@ -2804,11 +2824,13 @@ private:
 // heapsize specialization for `ImageSpec`
 template <> OIIO_API size_t pvt::heapsize<ImageSpec>(const ImageSpec&);
 
-// heapsize specialization for `ImageInput`
+// heapsize and footprint specializations for `ImageInput`
 template <> OIIO_API size_t pvt::heapsize<ImageInput>(const ImageInput&);
+template <> OIIO_API size_t pvt::footprint<ImageInput>(const ImageInput&);
 
-// heapsize specialization for `ImageOutput`
+// heapsize and footprint specializations for `ImageOutput`
 template <> OIIO_API size_t pvt::heapsize<ImageOutput>(const ImageOutput&);
+template <> OIIO_API size_t pvt::footprint<ImageOutput>(const ImageOutput&);
 
 
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1342,12 +1342,46 @@ ImageInput::check_open(const ImageSpec& spec, ROI range, uint64_t /*flags*/)
 
 
 template<>
+inline size_t
+pvt::heapsize<ImageInput::Impl>(const ImageInput::Impl& impl)
+{
+    return impl.m_io_local ? sizeof(Filesystem::IOProxy) : 0;
+}
+
+
+
+size_t
+ImageInput::heapsize() const
+{
+    size_t size = pvt::heapsize(m_impl);
+    size += pvt::heapsize(m_spec);
+    return size;
+}
+
+
+
+size_t
+ImageInput::footprint() const
+{
+    return sizeof(ImageInput) + heapsize();
+}
+
+
+
+template<>
 size_t
 pvt::heapsize<ImageInput>(const ImageInput& input)
 {
-    //! TODO: change ImageInput API to add a virtual heapsize() function
-    //! to allow per image input override, and call that function here.
-    return pvt::heapsize(input.m_spec);
+    return input.heapsize();
+}
+
+
+
+template<>
+size_t
+pvt::footprint<ImageInput>(const ImageInput& input)
+{
+    return input.footprint();
 }
 
 

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -1022,12 +1022,46 @@ ImageOutput::check_open(OpenMode mode, const ImageSpec& userspec, ROI range,
 
 
 template<>
+inline size_t
+pvt::heapsize<ImageOutput::Impl>(const ImageOutput::Impl& impl)
+{
+    return impl.m_io_local ? sizeof(Filesystem::IOProxy) : 0;
+}
+
+
+
+size_t
+ImageOutput::heapsize() const
+{
+    size_t size = pvt::heapsize(m_impl);
+    size += pvt::heapsize(m_spec);
+    return size;
+}
+
+
+
+size_t
+ImageOutput::footprint() const
+{
+    return sizeof(ImageOutput) + heapsize();
+}
+
+
+
+template<>
 size_t
 pvt::heapsize<ImageOutput>(const ImageOutput& output)
 {
-    //! TODO: change ImageOutput API to add a virtual heapsize() function
-    //! to allow per image output override, and call that function here.
-    return pvt::heapsize(output.m_spec);
+    return output.heapsize();
+}
+
+
+
+template<>
+size_t
+pvt::footprint<ImageOutput>(const ImageOutput& output)
+{
+    return output.footprint();
 }
 
 


### PR DESCRIPTION
Second PR of two, following @lgritz and I discussions on memory tracking in the OIIO::ImageCache.

- the memory tracking system from https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4322 is not sufficient to track OIIO public objects that can be overriden. 
- add virtual `heapsize()` method to ImageInput and ImageOutput that return the total heap allocated memory held by the structure and its members.
- [ ] **TODO**: override for every internal OIIO type (bmp, tiff, etc). 

Related PR from Larry : https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4317
First PR: https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4322

## Tests
- [ ] todo: fix CI fails
