### PR TITLE
ci: deal with CentOS 7 EOL and disappearance of yum mirrors

### DIFF
--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -13,9 +13,16 @@ set -ex
 # Install system packages when those are acceptable for dependencies.
 #
 if [[ "$ASWF_ORG" != ""  ]] ; then
-    # Using ASWF CentOS container
+    # Using ASWF container
 
     #ls /etc/yum.repos.d
+
+    if [[ "$ASWF_VFXPLATFORM_VERSION" == "2021" || "$ASWF_VFXPLATFORM_VERSION" == "2022" ]] ; then
+        # CentOS 7 based containers need the now-nonexistant centos repo to be
+        # excluded or all the subsequent yum install commands will fail.
+        yum-config-manager --disable centos-sclo-rh && true
+        sed -i 's,^mirrorlist=,#,; s,^#baseurl=http://mirror\.centos\.org/centos/$releasever,baseurl=https://vault.centos.org/7.9.2009,' /etc/yum.repos.d/CentOS-Base.repo
+    fi
 
     sudo yum install -y giflib giflib-devel && true
     if [[ "${USE_OPENCV}" != "0" ]] ; then


### PR DESCRIPTION
This was breaking CI for us. Hard break for icc/icx tests, since those REQUIRED a yum install of the intel compilers. Softer undetected break for all the ASWF <= 2022 containers based on CentOS 7, which were not failing outright but were failing to install certain optional packages.

The solution (for now) is to configure yum to exclude the missing repo.
