### PR TITLE
fix: iv should enable the ImageCache

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -798,6 +798,8 @@ ImageViewer::readSettings(bool ui_is_set_up)
     slideShowDuration->setValue(
         settings.value("slideShowDuration", 10).toInt());
 
+    OIIO::attribute("imagebuf:use_imagecache", 1);
+
     ImageCache* imagecache = ImageCache::create(true);
     imagecache->attribute("automip", autoMipmap->isChecked());
     imagecache->attribute("max_memory_MB", (float)maxMemoryIC->value());


### PR DESCRIPTION
## Description

Enable the ImageCache for the `iv` tool. It more or less expects it to be present and certain features, like loading the Image's mip-levels, requires the ImageCache to be used.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
