### PR TITLE
api: Make span::size() return size_t

### DIFF
--- a/src/dpx.imageio/libdpx/EndianSwap.h
+++ b/src/dpx.imageio/libdpx/EndianSwap.h
@@ -55,9 +55,9 @@ SwapBytes(T& value)
 
 template<typename T>
 void
-SwapBuffer(T* buf, unsigned int len)
+SwapBuffer(T* buf, size_t len)
 {
-    OIIO::byteswap_span(OIIO::span<T>(buf, len));
+    OIIO::byteswap_span(OIIO::span<T>(buf, OIIO::span_size_t(len)));
 }
 
 #else

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1942,7 +1942,7 @@ bool OIIO_API colorconvert (span<float> color,
 // DEPRECATED(2.1): Less safe version with raw pointer and length.
 inline bool colorconvert (float *color, int nchannels,
                           const ColorProcessor *processor, bool unpremult) {
-    return colorconvert ({color,nchannels}, processor, unpremult);
+    return colorconvert ({color,span_size_t(nchannels)}, processor, unpremult);
 }
 
 /// @}
@@ -2546,21 +2546,21 @@ bool OIIO_API deep_holdout (ImageBuf &dst, const ImageBuf &src,
 inline bool fill (ImageBuf &dst, const float *values,
                   ROI roi={}, int nthreads=0) {
     int nc (roi.defined() ? roi.nchannels() : dst.nchannels());
-    return fill (dst, {values, nc}, roi, nthreads);
+    return fill (dst, {values, span_size_t(nc)}, roi, nthreads);
 }
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool fill (ImageBuf &dst, const float *top, const float *bottom,
                   ROI roi={}, int nthreads=0) {
     int nc (roi.defined() ? roi.nchannels() : dst.nchannels());
-    return fill (dst, {top, nc}, {bottom, nc}, roi, nthreads);
+    return fill (dst, {top, span_size_t(nc)}, {bottom, span_size_t(nc)}, roi, nthreads);
 }
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool fill (ImageBuf &dst, const float *topleft, const float *topright,
                   const float *bottomleft, const float *bottomright,
                   ROI roi={}, int nthreads=0) {
     int nc (roi.defined() ? roi.nchannels() : dst.nchannels());
-    return fill (dst, {topleft, nc}, {topright, nc}, {bottomleft, nc},
-                 {bottomright, nc}, roi, nthreads);
+    return fill (dst, {topleft, span_size_t(nc)}, {topright, span_size_t(nc)}, {bottomleft, span_size_t(nc)},
+                 {bottomright, span_size_t(nc)}, roi, nthreads);
 }
 
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
@@ -2569,7 +2569,8 @@ inline bool checker (ImageBuf &dst, int width, int height, int depth,
                      int xoffset=0, int yoffset=0, int zoffset=0,
                      ROI roi={}, int nthreads=0) {
     int nc (roi.defined() ? roi.nchannels() : dst.nchannels());
-    return checker (dst, width, height, depth, {color1,nc}, {color2,nc},
+    return checker (dst, width, height, depth,
+                    {color1,span_size_t(nc)}, {color2,span_size_t(nc)},
                     xoffset, yoffset, zoffset, roi, nthreads);
 }
 
@@ -2586,22 +2587,22 @@ inline bool sub (ImageBuf &dst, const ImageBuf &A, const float *B,
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool absdiff (ImageBuf &dst, const ImageBuf &A, const float *B,
                      ROI roi={}, int nthreads=0) {
-    return absdiff (dst, A, cspan<float>(B,A.nchannels()), roi, nthreads);
+    return absdiff (dst, A, cspan<float>(B,span_size_t(A.nchannels())), roi, nthreads);
 }
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mul (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
-    return mul (dst, A, {B, A.nchannels()}, roi, nthreads);
+    return mul (dst, A, {B, int(A.nchannels())}, roi, nthreads);
 }
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool div (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
-    return div (dst, A, {B, A.nchannels()}, roi, nthreads);
+    return div (dst, A, {B, int(A.nchannels())}, roi, nthreads);
 }
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mad (ImageBuf &dst, const ImageBuf &A, const float *B,
                  const ImageBuf &C, ROI roi={}, int nthreads=0) {
-    return mad (dst, A, {B, A.nchannels()}, C, roi, nthreads);
+    return mad (dst, A, {B, int(A.nchannels())}, C, roi, nthreads);
 }
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mad (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
@@ -2611,20 +2612,20 @@ inline bool mad (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mad (ImageBuf &dst, const ImageBuf &A, const float *B,
                  const float *C, ROI roi={}, int nthreads=0) {
-    return mad (dst, A, {B, A.nchannels()}, {C, A.nchannels()}, roi, nthreads);
+    return mad (dst, A, {B, int(A.nchannels())}, {C, int(A.nchannels())}, roi, nthreads);
 }
 
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool pow (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
-    return pow (dst, A, {B, A.nchannels()}, roi, nthreads);
+    return pow (dst, A, {B, span_size_t(A.nchannels())}, roi, nthreads);
 }
 
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool channel_sum (ImageBuf &dst, const ImageBuf &src,
                          const float *weights=nullptr, ROI roi={},
                          int nthreads=0) {
-    return channel_sum (dst, src, {weights, src.nchannels()},
+    return channel_sum (dst, src, {weights, span_size_t(src.nchannels())},
                         roi, nthreads);
 }
 
@@ -2635,9 +2636,9 @@ inline bool channels (ImageBuf &dst, const ImageBuf &src,
                       const std::string *newchannelnames=nullptr,
                       bool shuffle_channel_names=false, int nthreads=0) {
     return channels (dst, src, nchannels,
-                     { channelorder, channelorder?nchannels:0 },
-                     { channelvalues, channelvalues?nchannels:0 },
-                     { newchannelnames, newchannelnames?nchannels:0},
+                     { channelorder, span_size_t(channelorder?nchannels:0) },
+                     { channelvalues, span_size_t(channelvalues?nchannels:0) },
+                     { newchannelnames, span_size_t(newchannelnames?nchannels:0) },
                      shuffle_channel_names, nthreads);
 }
 
@@ -2646,8 +2647,8 @@ inline bool clamp (ImageBuf &dst, const ImageBuf &src,
                    const float *min=nullptr, const float *max=nullptr,
                    bool clampalpha01 = false,
                    ROI roi={}, int nthreads=0) {
-    return clamp (dst, src, { min, min ? src.nchannels() : 0 },
-                  { max, max ? src.nchannels() : 0 }, clampalpha01,
+    return clamp (dst, src, { min, span_size_t(min ? src.nchannels() : 0) },
+                  { max, span_size_t(max ? src.nchannels() : 0) }, clampalpha01,
                   roi, nthreads);
 }
 
@@ -2655,7 +2656,8 @@ inline bool clamp (ImageBuf &dst, const ImageBuf &src,
 inline bool isConstantColor (const ImageBuf &src, float *color,
                              ROI roi={}, int nthreads=0) {
     int nc = roi.defined() ? std::min(roi.chend,src.nchannels()) : src.nchannels();
-    return isConstantColor (src, {color, color ? nc : 0}, roi, nthreads);
+    return isConstantColor (src, {color, span_size_t(color ? nc : 0) },
+                            roi, nthreads);
 }
 
 //OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
@@ -2664,8 +2666,8 @@ inline bool color_count (const ImageBuf &src, imagesize_t *count,
                          const float *eps=nullptr,
                          ROI roi={}, int nthreads=0) {
     return color_count (src, count, ncolors,
-                        { color, ncolors*src.nchannels() },
-                        eps ? cspan<float>(eps,src.nchannels()) : cspan<float>(),
+                        { color, span_size_t(ncolors*src.nchannels()) },
+                        eps ? cspan<float>(eps,span_size_t(src.nchannels())) : cspan<float>(),
                         roi, nthreads);
 }
 
@@ -2675,7 +2677,7 @@ inline bool color_range_check (const ImageBuf &src, imagesize_t *lowcount,
                                const float *low, const float *high,
                                ROI roi={}, int nthreads=0) {
     return color_range_check (src, lowcount, highcount, inrangecount,
-                              {low,src.nchannels()}, {high,src.nchannels()},
+                              {low,span_size_t(src.nchannels())}, {high,span_size_t(src.nchannels())},
                               roi, nthreads);
 }
 
@@ -2684,7 +2686,7 @@ inline bool render_text (ImageBuf &dst, int x, int y, string_view text,
                          int fontsize, string_view fontname,
                          const float *textcolor) {
     return render_text (dst, x, y, text, fontsize, fontname,
-                        {textcolor, textcolor?dst.nchannels():0});
+                        {textcolor, textcolor?span_size_t(dst.nchannels()):0});
 }
 
 

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -588,12 +588,12 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
 // were no entries at all. This is used in many IBA functions that take
 // constant per-channel values.
 #define IBA_FIX_PERCHAN_LEN(av,len,missing,zdef)                        \
-    if (av.size() < len) {                                              \
+    if (std::ssize(av) < len) {                                          \
         int nc = len;                                                   \
         float *vals = OIIO_ALLOCA(float, nc);                           \
         for (int i = 0;  i < nc;  ++i)                                  \
-            vals[i] = i < av.size() ? av[i] : (i ? vals[i-1] : zdef);   \
-        av = cspan<float>(vals, nc);                                    \
+            vals[i] = i < std::ssize(av) ? av[i] : (i ? vals[i-1] : zdef);  \
+        av = cspan<float>(vals, span_size_t(nc));                       \
     }
 
 // Default IBA_FIX_PERCHAN_LEN, with zdef=0.0 and missing = the last value

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -21,30 +21,26 @@
 
 OIIO_NAMESPACE_BEGIN
 
-// By default, our span::size() is a signed value, because we wrote this at
-// a time that the draft of std::span said it should be signed. The final
-// C++20 std::span ended up with an unsigned size, like all the other STL
-// classes. We will eventually conform by switching, but not until we are at
-// OIIO 3.0, allowing source code API-breaking incompatibilities. In the
-// mean time, we allow a back door to experiment with standard conformance
-// by pre-defining OIIO_SPAN_SIZE_IS_UNSIGNED=1.
-#if OIIO_VERSION_GREATER_EQUAL(3,0,0)
+// Our pre-3.0 implementation had span::size() as a signed value, because we
+// wrote it at a time that the draft of std::span said it should be signed.
+// The final C++20 std::span ended up with an unsigned size, like all the
+// other STL classes. It took us until OIIO 3.0 (or the in-progress 2.6.3)
+// before we were able to break compatibility by switching it to match
+// std::span::size() returning a size_t.
+#ifndef OIIO_SPAN_SIZE_IS_UNSIGNED
 #    define OIIO_SPAN_SIZE_IS_UNSIGNED
 #endif
 
-#ifdef OIIO_SPAN_SIZE_IS_UNSIGNED
-using oiio_span_size_type = size_t;
-#else
-using oiio_span_size_type = ptrdiff_t;
-#endif
+using span_size_t = size_t;
+using oiio_span_size_type = OIIO::span_size_t;  // back-compat alias
 
-OIIO_INLINE_CONSTEXPR oiio_span_size_type dynamic_extent = -1;
+OIIO_INLINE_CONSTEXPR span_size_t dynamic_extent = -1;
 
 
 
 /// `span<T>` is a non-owning, non-copying, non-allocating reference to a
-/// contiguous array of T objects known length. A 'span` encapsulates both a
-/// pointer and a length, and thus is a safer way of passing pointers around
+/// contiguous array of T objects of known length. A 'span` encapsulates both
+/// a pointer and a length, and thus is a safer way of passing pointers around
 /// (because the function called knows how long the array is). A function
 /// that might ordinarily take a `T*` and a length could instead just take a
 /// `span<T>`.
@@ -70,17 +66,14 @@ OIIO_INLINE_CONSTEXPR oiio_span_size_type dynamic_extent = -1;
 /// structure (unless you are really sure you know what you're doing).
 ///
 
-template <typename T, oiio_span_size_type Extent = dynamic_extent>
+template <typename T, span_size_t Extent = dynamic_extent>
 class span {
     static_assert (std::is_array<T>::value == false, "can't have span of an array");
 public:
     using element_type = T;
     using value_type = typename std::remove_cv<T>::type;
-    using size_type = oiio_span_size_type;
+    using size_type = span_size_t;
     using difference_type = ptrdiff_t;
-#if OIIO_VERSION < OIIO_MAKE_VERSION(3,0,0)
-    using index_type = size_type;  // DEPRECATED(3.0)
-#endif
     using pointer = element_type*;
     using reference = element_type&;
     using iterator = element_type*;
@@ -93,7 +86,7 @@ public:
     constexpr span () noexcept = default;
 
     /// Copy constructor (copies the span pointer and length, NOT the data).
-    template<class U, oiio_span_size_type N>
+    template<class U, span_size_t N>
     constexpr span (const span<U,N> &copy) noexcept
         : m_data(copy.data()), m_size(copy.size()) { }
     /// Copy constructor (copies the span pointer and length, NOT the data).
@@ -230,27 +223,27 @@ private:
 
 
 /// cspan<T> is a synonym for a non-mutable span<const T>.
-template <typename T, oiio_span_size_type Extent = dynamic_extent>
+template <typename T, span_size_t Extent = dynamic_extent>
 using cspan = span<const T, Extent>;
 
 
 
 /// Compare all elements of two spans for equality
-template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
+template <class T, span_size_t X, class U, span_size_t Y>
 constexpr bool operator== (span<T,X> l, span<U,Y> r) {
 #if OIIO_CPLUSPLUS_VERSION >= 20
     return std::equal (l.begin(), l.end(), r.begin(), r.end());
 #else
     auto lsize = l.size();
     bool same = (lsize == r.size());
-    for (ptrdiff_t i = 0; same && i < lsize; ++i)
+    for (span_size_t i = 0; same && i < lsize; ++i)
         same &= (l[i] == r[i]);
     return same;
 #endif
 }
 
 /// Compare all elements of two spans for inequality
-template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
+template <class T, span_size_t X, class U, span_size_t Y>
 constexpr bool operator!= (span<T,X> l, span<U,Y> r) {
     return !(l == r);
 }
@@ -261,18 +254,15 @@ constexpr bool operator!= (span<T,X> l, span<U,Y> r) {
 /// array with known length and optionally non-default strides through the
 /// data.  A span_strided<T> is mutable (the values in the array may
 /// be modified), whereas a span_strided<const T> is not mutable.
-template <typename T, oiio_span_size_type Extent = dynamic_extent>
+template <typename T, span_size_t Extent = dynamic_extent>
 class span_strided {
     static_assert (std::is_array<T>::value == false,
                    "can't have span_strided of an array");
 public:
     using element_type = T;
     using value_type = typename std::remove_cv<T>::type;
-    using size_type  = oiio_span_size_type;
+    using size_type  = span_size_t;
     using difference_type = ptrdiff_t;
-#if OIIO_VERSION < OIIO_MAKE_VERSION(3,0,0)
-    using index_type = size_type;  // DEPRECATED(3.0)
-#endif
     using stride_type = ptrdiff_t;
     using pointer = element_type*;
     using reference = element_type&;
@@ -356,25 +346,25 @@ private:
 
 
 /// cspan_strided<T> is a synonym for a non-mutable span_strided<const T>.
-template <typename T, oiio_span_size_type Extent = dynamic_extent>
+template <typename T, span_size_t Extent = dynamic_extent>
 using cspan_strided = span_strided<const T, Extent>;
 
 
 
 /// Compare all elements of two spans for equality
-template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
+template <class T, span_size_t X, class U, span_size_t Y>
 constexpr bool operator== (span_strided<T,X> l, span_strided<U,Y> r) {
     auto lsize = l.size();
     if (lsize != r.size())
         return false;
-    for (ptrdiff_t i = 0; i < lsize; ++i)
+    for (span_size_t i = 0; i < lsize; ++i)
         if (l[i] != r[i])
             return false;
     return true;
 }
 
 /// Compare all elements of two spans for inequality
-template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
+template <class T, span_size_t X, class U, span_size_t Y>
 constexpr bool operator!= (span_strided<T,X> l, span_strided<U,Y> r) {
     return !(l == r);
 }
@@ -387,12 +377,12 @@ OIIO_NAMESPACE_END
 // Declare std::size and std::ssize for our span.
 namespace std {
 
-template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+template<class T, OIIO::span_size_t E = OIIO::dynamic_extent>
 constexpr size_t size(const OIIO::span<T, E>& c) {
     return static_cast<size_t>(c.size());
 }
 
-template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+template<class T, OIIO::span_size_t E = OIIO::dynamic_extent>
 constexpr size_t size(const OIIO::span_strided<T, E>& c) {
     return static_cast<size_t>(c.size());
 }
@@ -400,12 +390,12 @@ constexpr size_t size(const OIIO::span_strided<T, E>& c) {
 
 #if OIIO_CPLUSPLUS_VERSION < 20
 // C++20 and beyond already have these declared.
-template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+template<class T, OIIO::span_size_t E = OIIO::dynamic_extent>
 constexpr ptrdiff_t ssize(const OIIO::span<T, E>& c) {
     return static_cast<ptrdiff_t>(c.size());
 }
 
-template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+template<class T, OIIO::span_size_t E = OIIO::dynamic_extent>
 constexpr ptrdiff_t ssize(const OIIO::span_strided<T, E>& c) {
     return static_cast<ptrdiff_t>(c.size());
 }
@@ -423,7 +413,7 @@ constexpr ptrdiff_t ssize(const OIIO::span_strided<T, E>& c) {
 
 /// Custom fmtlib formatters for span/cspan types.
 namespace fmt {
-template<typename T, OIIO::oiio_span_size_type Extent>
+template<typename T, OIIO::span_size_t Extent>
 struct formatter<OIIO::span<T, Extent>>
     : OIIO::pvt::index_formatter<OIIO::span<T, Extent>> {};
 }  // namespace fmt

--- a/src/include/OpenImageIO/span_util.h
+++ b/src/include/OpenImageIO/span_util.h
@@ -71,7 +71,7 @@ make_span(T (&arg)[N])  // span from C array of known length
 
 template<typename T>
 inline constexpr span<T>
-make_span(T* data, oiio_span_size_type size)  // span from ptr + size
+make_span(T* data, span_size_t size)  // span from ptr + size
 {
     return { data, size };
 }
@@ -92,7 +92,7 @@ make_cspan(const T& arg)  // cspan from a single value
 
 template<typename T>
 inline constexpr cspan<T>
-make_cspan(const T* data, oiio_span_size_type size)  // cspan from ptr + size
+make_cspan(const T* data, span_size_t size)  // cspan from ptr + size
 {
     return { data, size };
 }

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -564,11 +564,11 @@ ColorConfig::Impl::test_conversion_yields(const char* from, const char* to,
     if (!proc)
         return false;
     OIIO_DASSERT(test_colors.size() == result_colors.size());
-    int n              = std::ssize(test_colors);
+    auto n             = test_colors.size();
     Imath::C3f* colors = OIIO_ALLOCA(Imath::C3f, n);
     std::copy(test_colors.data(), test_colors.data() + n, colors);
-    proc->apply((float*)colors, n, 1, 3, sizeof(float), 3 * sizeof(float),
-                n * 3 * sizeof(float));
+    proc->apply((float*)colors, int(n), 1, 3, sizeof(float), 3 * sizeof(float),
+                int(n) * 3 * sizeof(float));
     return close_colors({ colors, n }, result_colors);
 }
 

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -568,7 +568,7 @@ DeepData::set_samples(int64_t pixel, int samps)
 void
 DeepData::set_all_samples(cspan<unsigned int> samples)
 {
-    if (samples.size() != m_npixels)
+    if (std::ssize(samples) != m_npixels)
         return;
     OIIO_DASSERT(m_impl);
     if (m_impl->m_allocated) {

--- a/src/libOpenImageIO/exif.h
+++ b/src/libOpenImageIO/exif.h
@@ -57,12 +57,12 @@ dataspan(const TIFFDirEntry& td, cspan<uint8_t> data, int offset_adjustment,
     size_t len = tiff_data_size(td);
     OIIO_DASSERT(len == sizeof(T) * count);
     if (len <= 4)
-        return { (const uint8_t*)&td.tdir_offset, oiio_span_size_type(len) };
+        return { (const uint8_t*)&td.tdir_offset, span_size_t(len) };
     else {
         int offset = td.tdir_offset + offset_adjustment;
         if (offset < 0 || size_t(offset) + len > std::size(data))
             return {};  // out of bounds! return empty span
-        return { data.data() + offset, oiio_span_size_type(len) };
+        return { data.data() + offset, span_size_t(len) };
     }
 }
 

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -38,7 +38,7 @@ channels_(ImageBuf& dst, const ImageBuf& src, cspan<int> channelorder,
                 int cc = channelorder[c];
                 if (cc >= 0 && cc < nchannels)
                     d[c] = s[cc];
-                else if (channelvalues.size() > c)
+                else if (std::ssize(channelvalues) > c)
                     d[c] = channelvalues[c];
             }
         }
@@ -90,7 +90,7 @@ ImageBufAlgo::channels(ImageBuf& dst, const ImageBuf& src, int nchannels,
     bool inorder = true;
     for (int c = 0; c < nchannels; ++c) {
         inorder &= (channelorder[c] == c);
-        if (newchannelnames.size() > c && newchannelnames[c].size()
+        if (std::ssize(newchannelnames) > c && newchannelnames[c].size()
             && c < int(src.spec().channelnames.size()))
             inorder &= (newchannelnames[c] == src.spec().channelnames[c]);
     }
@@ -109,7 +109,7 @@ ImageBufAlgo::channels(ImageBuf& dst, const ImageBuf& src, int nchannels,
     for (int c = 0; c < nchannels; ++c) {
         int csrc = channelorder[c];
         // If the user gave an explicit name for this channel, use it...
-        if (newchannelnames.size() > c && newchannelnames[c].size())
+        if (std::ssize(newchannelnames) > c && newchannelnames[c].size())
             newspec.channelnames[c] = newchannelnames[c];
         // otherwise, if shuffle_channel_names, use the channel name of
         // the src channel we're using (otherwise stick to the default name)
@@ -155,8 +155,8 @@ ImageBufAlgo::channels(ImageBuf& dst, const ImageBuf& src, int nchannels,
                 int csrc = channelorder[c];
                 if (csrc < 0) {
                     // Replacing the channel with a new value
-                    float val = channelvalues.size() > c ? channelvalues[c]
-                                                         : 0.0f;
+                    float val = std::ssize(channelvalues) > c ? channelvalues[c]
+                                                              : 0.0f;
                     for (int s = 0, ns = dstdata.samples(p); s < ns; ++s)
                         dstdata.set_deep_value(p, c, s, val);
                 } else {

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -466,12 +466,13 @@ isConstantColor_(const ImageBuf& src, float threshold, span<float> color,
     }
 
     if (color.size()) {
+        int colsize = int(color.size());
         ImageBuf::ConstIterator<T, float> s(src, roi);
-        for (int c = 0; c < roi.chbegin && c < color.size(); ++c)
+        for (int c = 0; c < roi.chbegin && c < colsize; ++c)
             color[c] = 0.0f;
-        for (int c = roi.chbegin; c < roi.chend && c < color.size(); ++c)
+        for (int c = roi.chbegin; c < roi.chend && c < colsize; ++c)
             color[c] = s[c];
-        for (int c = roi.chend; c < src.nchannels() && c < color.size(); ++c)
+        for (int c = roi.chend; c < src.nchannels() && c < colsize; ++c)
             color[c] = 0.0f;
     }
     return result ? true : false;
@@ -658,7 +659,7 @@ ImageBufAlgo::color_count(const ImageBuf& src, imagesize_t* count, int ncolors,
         roi = get_roi(src.spec());
     roi.chend = std::min(roi.chend, src.nchannels());
 
-    if (color.size() < ncolors * src.nchannels()) {
+    if (std::ssize(color) < ncolors * src.nchannels()) {
         src.errorfmt(
             "ImageBufAlgo::color_count: not enough room in 'color' array");
         return false;

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -1235,7 +1235,7 @@ ImageBufAlgo::color_map(ImageBuf& dst, const ImageBuf& src, int srcchannel,
         dst.errorfmt("invalid source channel selected");
         return false;
     }
-    if (nknots < 2 || knots.size() < (nknots * channels)) {
+    if (nknots < 2 || std::ssize(knots) < (nknots * channels)) {
         dst.errorfmt("not enough knot values supplied");
         return false;
     }

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -254,8 +254,8 @@ test_read_proxy(string_view formatname, string_view extension,
     std::cout << "    Reading Proxy " << formatname << " ... ";
     std::cout.flush();
 
-    auto nvalues = oiio_span_size_type(buf.spec().image_pixels()
-                                       * buf.spec().nchannels);
+    auto nvalues = span_size_t(buf.spec().image_pixels()
+                               * buf.spec().nchannels);
     float eps    = 0.0f;
     // Allow lossy formats to have a little more error
     if (formatname == "heif" || formatname == "jpegxl")
@@ -400,8 +400,8 @@ test_all_formats()
             ok = checked_read(in.get(), filename, pixels);
             if (!ok)
                 continue;
-            auto nvalues = oiio_span_size_type(buf.spec().image_pixels()
-                                               * buf.spec().nchannels);
+            auto nvalues = span_size_t(buf.spec().image_pixels()
+                                       * buf.spec().nchannels);
             ok           = test_pixel_match({ orig_pixels, nvalues },
                                             { (const float*)pixels.data(), nvalues },
                                             eps);

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -532,7 +532,8 @@ ArgParse::Impl::parse_args(int xargc, const char** xargv)
                     if (option->has_callback())
                         option->invoke_callback(1 + n, m_argv + i);
                     if (option->m_action) {
-                        option->m_action(*option, { m_argv + i, n + 1 });
+                        option->m_action(*option,
+                                         { m_argv + i, span_size_t(n + 1) });
                     } else {
                         m_params[option->dest()] = m_argv[i + 1];
                     }

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -1378,14 +1378,14 @@ Filesystem::IOMemReader::pread(void* buf, size_t size, int64_t offset)
     // N.B. No lock necessary
     if (!m_buf.size() || !size)
         return 0;
-    if (size + size_t(offset) > size_t(m_buf.size())) {
-        if (offset < 0 || offset >= m_buf.size()) {
+    if (size + size_t(offset) > std::size(m_buf)) {
+        if (offset < 0 || size_t(offset) >= std::size(m_buf)) {
             error(Strutil::fmt::format(
                 "Invalid pread offset {} for an IOMemReader buffer of size {}",
                 offset, m_buf.size()));
             return 0;
         }
-        size = m_buf.size() - size_t(offset);
+        size = std::size(m_buf) - size_t(offset);
     }
     memcpy(buf, m_buf.data() + offset, size);
     return size;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2180,7 +2180,7 @@ public:
     }
     OpSetColorSpace(Oiiotool& ot, string_view opname, int argc,
                     const char* argv[])
-        : OpSetColorSpace(ot, opname, { argv, argc })
+        : OpSetColorSpace(ot, opname, { argv, span_size_t(argc) })
     {
     }
     bool setup() override
@@ -4901,7 +4901,8 @@ input_file(Oiiotool& ot, cspan<const char*> argv)
     TypeDesc input_dataformat(fileoptions.get_string("type"));
     std::string channel_set = fileoptions["ch"];
 
-    for (int i = 0; i < argv.size(); i++) {  // FIXME: this loop is pointless
+    for (int i = 0; i < std::ssize(argv); i++) {
+        // FIXME: this loop is pointless, since there is ever only one arg
         OTScopedTimer timer(ot, command);
         string_view filename = ot.express(argv[i]);
         auto found           = ot.image_labels.find(filename);

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -260,7 +260,8 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
                            profile_data);
             std::string errormsg;
             bool ok = decode_icc_profile(
-                cspan<uint8_t>((const uint8_t*)profile_data, profile_length),
+                cspan<uint8_t>((const uint8_t*)profile_data,
+                               span_size_t(profile_length)),
                 spec, errormsg);
             if (!ok) {
                 // errorfmt("Could not decode ICC profile: {}\n", errormsg);
@@ -337,7 +338,7 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
     png_uint_32 num_exif = 0;
     png_bytep exif_data  = nullptr;
     if (png_get_eXIf_1(sp, ip, &num_exif, &exif_data)) {
-        decode_exif(cspan<uint8_t>(exif_data, num_exif), spec);
+        decode_exif(cspan<uint8_t>(exif_data, span_size_t(num_exif)), spec);
     }
 #endif
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -808,7 +808,7 @@ PSDInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
             break;
         }
     } else if (m_header.color_mode == ColorMode_CMYK) {
-        oiio_span_size_type cmyklen = channel_count * spec.width;
+        span_size_t cmyklen = channel_count * spec.width;
         switch (bps) {
         case 4: {
             std::unique_ptr<float[]> cmyk(new float[cmyklen]);
@@ -842,11 +842,13 @@ PSDInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
         }
         }
     } else if (m_header.color_mode == ColorMode_Indexed) {
-        if (!indexed_to_rgb({ (unsigned char*)dst, spec.width * spec.nchannels },
+        if (!indexed_to_rgb({ (unsigned char*)dst,
+                              span_size_t(spec.width * spec.nchannels) },
                             channel_buffers[0], spec.width))
             return false;
     } else if (m_header.color_mode == ColorMode_Bitmap) {
-        if (!bitmap_to_rgb({ (unsigned char*)dst, spec.width * spec.nchannels },
+        if (!bitmap_to_rgb({ (unsigned char*)dst,
+                             span_size_t(spec.width * spec.nchannels) },
                            channel_buffers[0], spec.width))
             return false;
     } else {

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -183,7 +183,7 @@ private:
              bool force = true, unsigned short ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? std::ssize(data) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::UINT16, size), data.data());
         }
@@ -192,7 +192,7 @@ private:
              bool force = true, unsigned char ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? std::ssize(data) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::UINT8, size), data.data());
         }
@@ -201,7 +201,7 @@ private:
              bool force = true, float ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? std::ssize(data) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::FLOAT, size), data.data());
         }
@@ -210,7 +210,7 @@ private:
              bool force = true, float ignval = 0)
     {
         float* d = OIIO_ALLOCA(float, data.size());
-        for (auto i = 0; i < data.size(); ++i)
+        for (size_t i = 0; i < std::size(data); ++i)
             d[i] = data[i];
         add(prefix, name, cspan<float>(d, data.size()), force, ignval);
     }


### PR DESCRIPTION
With 3.0 coming soon, it's time to break compatibility by switching OIIO::span::size() to return an unsigned value, matching C++20 std::span.

The history is that when we first added OIIO::span, at that time, the C++ draft proposal for std::span included a signed size() result, but by the time it got finalized into C++20, it was changed to unsigned to match all the other std containers, but it was too late for us to switch without breaking API compatibility rather seriously.
