### PR TITLE
feat(oiiotool): Expression eval improvements: BOTTOM, IMG[expression], check label/var names

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -123,12 +123,17 @@ contents of an expression may be any of:
   If there is no metadata whose name matches, the expression will not have any
   substitution made and an error will be issued.
   
-  The *imagename* may be one of: `TOP` (the top or current image), `IMG[i]`
-  describing the i-th image on the stack (thus `TOP` is a synonym for
-  `IMG[0]`, the next image on the stack is `IMG[1]`, etc.), or `IMG[name]`
-  to denote an image named by filename or by label name. Remember that the
-  positions on the stack (including `TOP`) refer to *at that moment*, with
-  successive commands changing the contents of the top image.
+  The *imagename* may be one of:
+
+  * `TOP` : the top or current image;
+  * `IMG[index]` : if `index` evaluates to an integer `i`, the i-th image on
+    the stack (thus `TOP` is a synonym for `IMG[0]`, the next image on the
+    stack is `IMG[1]`, etc.);
+  * `IMG[name]` : an image named by filename or by label name.
+
+  Remember that the positions on the stack (including `TOP`) refer to *at that
+  moment*, with successive commands changing the contents of the top image. If
+  the
   
   The *metadata* may be any of:
   

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -982,6 +982,10 @@ output each one to a different file, with names `sub0001.tif`,
     sign), it will be saved as `int`; if it also contains a decimal point, it
     will be saved as a `float`; otherwise, it will be saved as a `string`.
 
+    The name of the variable must be in the form of an "identifier" (a
+    sequence of alphanumeric characters and underscores, starting with a
+    letter or underscore).
+
     This command was added in OIIO 2.4.0.
 
     Examples::
@@ -2241,6 +2245,10 @@ current top image.
     Thereafter, the label name may be used to refer to that saved image, in
     the usual manner that an ordinary input image would be specified by
     filename.
+
+    The name of the label must be in the form of an "identifier" (a sequence
+    of alphanumeric characters and underscores, starting with a letter or
+    underscore).
 
 
 :program:`oiiotool` commands that make entirely new images

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -126,9 +126,10 @@ contents of an expression may be any of:
   The *imagename* may be one of:
 
   * `TOP` : the top or current image;
+  * `BOTTOM` : the image at the bottom of the stack;
   * `IMG[index]` : if `index` evaluates to an integer `i`, the i-th image on
     the stack (thus `TOP` is a synonym for `IMG[0]`, the next image on the
-    stack is `IMG[1]`, etc.);
+    stack is `IMG[1]`, ..., and `BOTTOM` is a synonmym for `IMG[NIMAGES-1]`);
   * `IMG[name]` : an image named by filename or by label name.
 
   Remember that the positions on the stack (including `TOP`) refer to *at that

--- a/src/oiiotool/expressions.cpp
+++ b/src/oiiotool/expressions.cpp
@@ -155,28 +155,61 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
         if (Strutil::parse_prefix(s, "TOP")) {
             img = curimg;
         } else if (Strutil::parse_prefix(s, "IMG[")) {
-            int index = -1;
-            if (Strutil::parse_int(s, index) && Strutil::parse_char(s, ']')
-                && index >= 0 && index <= (int)image_stack.size()) {
-                if (index == 0)
-                    img = curimg;
-                else
-                    img = image_stack[image_stack.size() - index];
-            } else {
-                string_view name = Strutil::parse_until(s, "]");
-                auto found       = image_labels.find(name);
-                if (found != image_labels.end())
-                    img = found->second;
-                else
-                    img = ImageRecRef(new ImageRec(name, imagecache));
-                Strutil::parse_char(s, ']');
+            std::string until_bracket = Strutil::parse_until(s, "]");
+            if (until_bracket.empty() || !Strutil::parse_char(s, ']')) {
+                express_error(expr, until_bracket,
+                              "malformed IMG[] specification");
+                result = orig;
+                return false;
+            }
+            auto labelfound = image_labels.find(until_bracket);
+            if (labelfound != image_labels.end()) {
+                // Found an image label
+                img = labelfound->second;
+            } else if (Strutil::string_is_int(until_bracket)) {
+                // It's an integer... don't process more quite yet
+            } else if (Filesystem::exists(until_bracket)) {
+                // It's the name of an image file
+                img = ImageRecRef(new ImageRec(until_bracket, imagecache));
+            }
+            if (!img) {
+                // Not a label, int, or file. Evaluate it as an expression.
+                // Evaluate it as an expression and hope it's an integer or
+                // the name of an image?
+                until_bracket = express_impl(until_bracket);
+                if (Strutil::string_is_int(until_bracket)) {
+                    // Between brackets (including an expanded variable) is an
+                    // integer -- it's an index into the image stack (error if out
+                    // of range).
+                    int index = Strutil::stoi(until_bracket);
+                    if (index >= 0 && index <= (int)image_stack.size()) {
+                        img = (index == 0)
+                                  ? curimg
+                                  : image_stack[image_stack.size() - index];
+                    } else {
+                        express_error(expr, until_bracket,
+                                      "out-of-range IMG[] index");
+                        result = orig;
+                        return false;
+                    }
+                } else if (Filesystem::exists(until_bracket)) {
+                    // It's the name of an image file
+                    img = ImageRecRef(new ImageRec(until_bracket, imagecache));
+                }
+            }
+            if (!img || img->has_error()) {
+                express_error(expr, until_bracket, "not a valid image");
+                result = orig;
+                return false;
             }
         }
-        if (!img.get()) {
+        if (!img || img->has_error()) {
             express_error(expr, s, "not a valid image");
             result = orig;
             return false;
         }
+        OIIO_ASSERT(img);
+        img->read();
         bool using_bracket = false;
         if (Strutil::parse_char(s, '[')) {
             using_bracket = true;

--- a/src/oiiotool/expressions.cpp
+++ b/src/oiiotool/expressions.cpp
@@ -149,11 +149,14 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
             return false;
 
     } else if (Strutil::starts_with(s, "TOP")
+               || Strutil::starts_with(s, "BOTTOM")
                || Strutil::starts_with(s, "IMG[")) {
         // metadata substitution
         ImageRecRef img;
         if (Strutil::parse_prefix(s, "TOP")) {
             img = curimg;
+        } else if (Strutil::parse_prefix(s, "BOTTOM")) {
+            img = (image_stack.size() <= 1) ? curimg : image_stack[0];
         } else if (Strutil::parse_prefix(s, "IMG[")) {
             std::string until_bracket = Strutil::parse_until(s, "]");
             if (until_bracket.empty() || !Strutil::parse_char(s, ']')) {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -699,8 +699,13 @@ unset_autopremult(Oiiotool& ot, cspan<const char*> argv)
 static void
 action_label(Oiiotool& ot, cspan<const char*> argv)
 {
-    string_view labelname      = ot.express(argv[1]);
-    ot.image_labels[labelname] = ot.curimg;
+    string_view command = ot.express(argv[0]);
+    string_view name    = ot.express(argv[1]);
+    if (!Strutil::string_is_identifier(name)) {
+        ot.errorfmt(command, "Invalid label name \"{}\"", name);
+        return;
+    }
+    ot.image_labels[name] = ot.curimg;
 }
 
 
@@ -1397,7 +1402,13 @@ set_user_variable(Oiiotool& ot, cspan<const char*> argv)
     string_view command = ot.express(argv[0]);
     string_view name    = ot.express(argv[1]);
     string_view value   = ot.express(argv[2]);
-    auto options        = ot.extract_options(command);
+
+    if (!Strutil::string_is_identifier(name)) {
+        ot.errorfmt(command, "Invalid variable name \"{}\"", name);
+        return 0;
+    }
+
+    auto options = ot.extract_options(command);
     TypeDesc type(options["type"].as_string());
 
     set_attribute_helper(ot.uservars, name, value, type);

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -58,6 +58,10 @@ Testing --set of implied types:
   i = 42, f = 3.5, s = hello world
 Testing --set of various explicit types:
   i = 42, f = 3.5, s = hello world, tc = 01:02:03:04, rat = 1/2
+This should make an error:
+oiiotool ERROR: -set : Invalid variable name "3"
+Full command line was:
+> oiiotool -echo "This should make an error:" -set 3 5
 Expr getattribute(limits:channels) = 1024
 Testing if with true cond (expect output):
   inside if clause, i=42

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -260,6 +260,7 @@ Constant: No
 Monochrome: No
 
 Stack holds [0] = ../common/tahoe-small.tif, [1] = ../common/tahoe-tiny.tif
+Stack holds [1] = ../common/tahoe-tiny.tif
 filename=../common/tahoe-tiny.tif file_extension=.tif file_noextension=../common/tahoe-tiny
 MINCOLOR=0,0,0 MAXCOLOR=0.745098,1,1 AVGCOLOR=0.101942,0.216695,0.425293
 Testing NIMAGES:

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -259,8 +259,9 @@ Stats FiniteCount: 12288 12288 12288
 Constant: No
 Monochrome: No
 
-Stack holds [0] = ../common/tahoe-small.tif, [1] = ../common/tahoe-tiny.tif
-Stack holds [1] = ../common/tahoe-tiny.tif
+Stack holds [0] = ../common/grid.tif, [1] = ../common/tahoe-small.tif, [2] = ../common/tahoe-tiny.tif
+TOP = ../common/grid.tif, BOTTOM = ../common/tahoe-tiny.tif
+Stack holds [1] = ../common/tahoe-small.tif
 filename=../common/tahoe-tiny.tif file_extension=.tif file_noextension=../common/tahoe-tiny
 MINCOLOR=0,0,0 MAXCOLOR=0.745098,1,1 AVGCOLOR=0.101942,0.216695,0.425293
 Testing NIMAGES:

--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -134,11 +134,13 @@ command += oiiotool ("../common/tahoe-tiny.tif"
                      + " --echo \"\\nMeta native: {TOP.METANATIVE}\""
                      + " --echo \"\\nStats:\\n{TOP.STATS}\\n\"")
 
-# Test IMG[]
-command += oiiotool ("../common/tahoe-tiny.tif ../common/tahoe-small.tif " +
-                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}\" " +
+# Test IMG[], TOP, BOTTOM
+command += oiiotool ("../common/tahoe-tiny.tif ../common/tahoe-small.tif ../common/grid.tif " +
+                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}, [2] = {IMG[2].filename}\" " +
+                     "--echo \"TOP = {TOP.filename}, BOTTOM = {BOTTOM.filename}\" " +
                      "--set i 1 " +
-                     "--echo \"Stack holds [{i}] = {IMG[i].filename}\" ")
+                     "--echo \"Stack holds [{i}] = {IMG[i].filename}\" "
+                     )
 
 # Test some special attribute evaluation names
 command += oiiotool ("../common/tahoe-tiny.tif " +

--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -88,6 +88,8 @@ command += oiiotool ('-echo "Testing --set of various explicit types:" ' +
                      '-set:type=timecode tc 01:02:03:04 ' +
                      '-set:type=rational rat 1/2 ' +
                      '-echo "  i = {i}, f = {f}, s = {s}, tc = {tc}, rat = {rat}"')
+command += oiiotool ('-echo "This should make an error:" ' +
+                     '-set 3 5')
 
 # Test getattribute in an expression
 command += oiiotool ('-echo "Expr getattribute(\"limits:channels\") = {getattribute(\"limits:channels\")}"')
@@ -134,7 +136,9 @@ command += oiiotool ("../common/tahoe-tiny.tif"
 
 # Test IMG[]
 command += oiiotool ("../common/tahoe-tiny.tif ../common/tahoe-small.tif " +
-                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}\"")
+                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}\" " +
+                     "--set i 1 " +
+                     "--echo \"Stack holds [{i}] = {IMG[i].filename}\" ")
 
 # Test some special attribute evaluation names
 command += oiiotool ("../common/tahoe-tiny.tif " +

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -4,6 +4,10 @@
        0  < 0,0,0
     6400  > 1,0.9,1
    59136  within range
+This should make an error:
+oiiotool ERROR: --label : Invalid label name "2hot2handle"
+Full command line was:
+> oiiotool -echo "This should make an error:" --create 1x1 3 --label 2hot2handle -o out.tif
 --printstats:
  128 x   96, 3 channel, float tiff
     Stats Min: 0 0 0 (of 255)

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+redirect += " 2>&1"
+failureok = True
+
 # Create some test images we need
 command += oiiotool ("--create 320x240 3 -d uint8 -o black.tif")
 command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 128x128 3 -d half -o grey128.exr")
@@ -180,6 +183,8 @@ command += oiiotool (
             " --pattern constant:color=0.5,0.0,0.0 128x128 3 --label B " +
             " --pop --pop --pop " +
             " R G --add -d half -o labeladd.exr")
+command += oiiotool ('-echo "This should make an error:" ' +
+                     '--create 1x1 3 --label 2hot2handle -o out.tif')
 
 # test subimages
 command += oiiotool ("--pattern constant:color=0.5,0.0,0.0 64x64 3 " +


### PR DESCRIPTION
Improvements to expression evaluation of oiiotool command line arguments surrounded by `{braces}`.

* Just like `TOP` refers to the top image on the stack, now `BOTTOM` refers to the bottom image.
* Referring to images with `IMG[id]` previously worked if `id` was a literal integer or an image label or an image filepath. But now it can be any expression that evaluates to any of those things. So, for example, you could say `{IMG[i].filename}` to get the filename of the i-th image down the stack (where `i` is a variable), or `{IMG[NIMAGES-2].width}` to get the x resolution of the 2nd-from-bottom image on the stack.
* The `--label` and `--set` commands check that the name you use for an image label or user variable follow the "C identifier" lexical rules: must be alphanumeric + underscore, but not start with number. It was previously possibly to do completely chaotic things like `--set 1 2`.

