### PR TITLE
api: imagebuf.h add deprecation warnings to deprecated things

### DIFF
--- a/docs/Deprecations-3.0.md
+++ b/docs/Deprecations-3.0.md
@@ -67,18 +67,26 @@ long-deprecated API facets. This document lists the deprecations and removals.
   severefmt, messagefmt, debugfmt, respectively, which all use the std::format
   notation.
 
+## imagebuf.h
+
+* Add deprecation warnings to the varieties of ImageBuf constructor and
+  `reset()` that don't take subimage and miplevel parameters, which have been
+  marked as deprecated since OIIO 2.2. The equivalent is to just pass `0` for
+  both of those parameters.
+* The misspelled `ImageBuf::make_writeable()` has been given deprecation
+  warnings. Since OIIO 2.2, we have used the correct spelling,
+  `make_writable`.
+* The `ImageBuf::error()` method that uses printf-style formatting conventions
+  now has deprecation warnings. Use `ImageBuf::errorfmt()` instead.
+* The `ImageBuf::interppixel_NDC_full()` method, which has been marked as
+  deprecated since OIIO 1.5, now has deprecation warnings. Use
+  `interppixel_NDC()` instead.
+
 ## missingmath.h
 
 * This header has been removed entirely. It has was originally needed for
   pre-C++11 MSVS, but has been unused since OIIO 2.0 (other than transitively
   including fmath.h).
-
-## parallel.h
-
-* Removed several varieties of `parallel_for` functions where the task
-  functions took a thread ID argument in addition to the range, which have
-  been considered deprecated since OIIO 2.3. Please use task functions that do
-  not take a thread ID parameter.
 
 ## paramlist.h
 
@@ -87,6 +95,13 @@ long-deprecated API facets. This document lists the deprecations and removals.
   whether the value was copied. If you need to override the usual copy
   behavior, please use the newer variety of constructors that instead use a
   "strong" type where you pass `ParamValue:Copy(bool)`.
+
+## parallel.h
+
+* Removed several varieties of `parallel_for` functions where the task
+  functions took a thread ID argument in addition to the range, which have
+  been considered deprecated since OIIO 2.3. Please use task functions that do
+  not take a thread ID parameter.
 
 ## strutil.h
 

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -126,7 +126,7 @@ read_input(const std::string& filename, ImageBuf& img, ImageCache* cache,
         && img.miplevel() == miplevel)
         return true;
 
-    img.reset(filename, cache);
+    img.reset(filename, 0, 0, cache);
     if (img.read(subimage, miplevel, false, TypeFloat))
         return true;
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -190,9 +190,6 @@ public:
                       const ImageSpec* config      = nullptr,
                       Filesystem::IOProxy* ioproxy = nullptr);
 
-    // Deprecated synonym for `ImageBuf(name, 0, 0, imagecache, nullptr)`.
-    ImageBuf(string_view name, ImageCache* imagecache);
-
     /// Construct a writable ImageBuf with the given specification
     /// (including resolution, data type, metadata, etc.). The ImageBuf will
     /// allocate and own its own pixel memory and will free that memory
@@ -219,10 +216,14 @@ public:
     explicit ImageBuf(const ImageSpec& spec,
                       InitializePixels zero = InitializePixels::Yes);
 
-    // Deprecated/useless synonym for `ImageBuf(spec,zero)` but also gives
-    // it an internal name.
+    // Synonym for `ImageBuf(spec,zero)` but also gives it an internal name
+    // that will be used if write() is called with an empty filename.
     ImageBuf(string_view name, const ImageSpec& spec,
-             InitializePixels zero = InitializePixels::Yes);
+             InitializePixels zero = InitializePixels::Yes)
+        : ImageBuf(spec, zero)
+    {
+        set_name(name);
+    }
 
     /// Construct a writable ImageBuf that "wraps" existing pixel memory
     /// owned by the calling application. The ImageBuf does not own the
@@ -250,10 +251,6 @@ public:
     ImageBuf(const ImageSpec& spec, void* buffer, stride_t xstride = AutoStride,
              stride_t ystride = AutoStride, stride_t zstride = AutoStride);
 
-    // Deprecated/useless synonym for `ImageBuf(spec,buffer)` but also gives
-    // it an internal name.
-    ImageBuf(string_view name, const ImageSpec& spec, void* buffer);
-
     /// Construct a copy of an ImageBuf.
     ImageBuf(const ImageBuf& src);
 
@@ -268,9 +265,6 @@ public:
     /// constructor (holding no image, with storage
     /// `IBStorage::UNINITIALIZED`).
     void reset() { clear(); }
-
-    // Deprecated/useless synonym for `reset(name, 0, 0, imagecache, nullptr)`
-    void reset(string_view name, ImageCache* imagecache);
 
     /// Destroy any previous contents of the ImageBuf and re-initialize it
     /// as if newly constructed with the same arguments, as a read-only
@@ -294,10 +288,13 @@ public:
     void reset(const ImageSpec& spec,
                InitializePixels zero = InitializePixels::Yes);
 
-    // Deprecated/useless synonym for `reset(spec, zero)` and also give it an
-    // internal name.
+    /// Synonym for `reset(spec, zero)` and also give it an internal name.
     void reset(string_view name, const ImageSpec& spec,
-               InitializePixels zero = InitializePixels::Yes);
+               InitializePixels zero = InitializePixels::Yes)
+    {
+        reset(spec, zero);
+        set_name(name);
+    }
 
     /// Destroy any previous contents of the ImageBuf and re-initialize it
     /// as if newly constructed with the same arguments, to "wrap" existing
@@ -322,10 +319,6 @@ public:
     ///             Return `true` if it works (including if no read was
     ///             necessary), `false` if something went horribly wrong.
     bool make_writable(bool keep_cache_type = false);
-
-    // DEPRECATED(2.2): This is an alternate, and less common, spelling.
-    // Let's standardize on "writable". We will eventually remove this.
-    bool make_writeable(bool keep_cache_type = false);
 
     /// @}
 
@@ -712,13 +705,6 @@ public:
     void interppixel_NDC(float s, float t, float* pixel,
                          WrapMode wrap = WrapBlack) const;
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    // DEPRECATED (1.5) synonym for interppixel_NDC.
-    OIIO_DEPRECATED("use interppixel_NDC (1.5)")
-    void interppixel_NDC_full(float s, float t, float* pixel,
-                              WrapMode wrap = WrapBlack) const;
-#endif
-
     /// Bicubic interpolation at pixel coordinates (x,y).
     void interppixel_bicubic(float x, float y, float* pixel,
                              WrapMode wrap = WrapBlack) const;
@@ -866,6 +852,10 @@ public:
 
     /// Return the name of the buffer as a ustring.
     ustring uname(void) const;
+
+    /// Set the name of the ImageBuf, will be used later as default
+    /// filename if write() is called with an empty filename.
+    void set_name(string_view name);
 
     /// Return the name of the image file format of the file this ImageBuf
     /// refers to (for example `"openexr"`).  Returns an empty string for an
@@ -1063,17 +1053,6 @@ public:
         error(Strutil::fmt::format(fmt, args...));
     }
 
-    /// Error reporting for ImageBuf: call this with Strutil::format
-    /// formatting conventions.  It is not necessary to have the error
-    /// message contain a trailing newline. Beware, this is in transition,
-    /// is currently printf-like but will someday change to python-like!
-    template<typename... Args>
-    OIIO_FORMAT_DEPRECATED void error(const char* fmt,
-                                      const Args&... args) const
-    {
-        error(Strutil::format(fmt, args...));
-    }
-
     /// Returns `true` if the ImageBuf has had an error and has an error
     /// message ready to retrieve via `geterror()`.
     bool has_error(void) const;
@@ -1165,6 +1144,54 @@ public:
     /// name, this will return `WrapDefault`.
     static WrapMode WrapMode_from_string(string_view name);
 
+
+#if !defined(OIIO_DOXYGEN) && !defined(OIIO_INTERNAL)
+    // Deprecated things -- might be removed at any time
+
+    OIIO_DEPRECATED("Use `ImageBuf(name, 0, 0, imagecache, nullptr)` (2.2)")
+    ImageBuf(string_view name, ImageCache* imagecache)
+        : ImageBuf(name, 0, 0, imagecache)
+    {
+    }
+
+    OIIO_DEPRECATED(
+        "The name parameter is not used, use `ImageBuf(spec,buffer)` (2.2)")
+    ImageBuf(string_view name, const ImageSpec& spec, void* buffer)
+        : ImageBuf(spec, buffer)
+    {
+    }
+
+    OIIO_DEPRECATED("Use `reset(name, 0, 0, imagecache)` (2.2)")
+    void reset(string_view name, ImageCache* imagecache)
+    {
+        reset(name, 0, 0, imagecache);
+    }
+
+    OIIO_DEPRECATED("Use make_writable (2.2)")
+    bool make_writeable(bool keep_cache_type = false)
+    {
+        return make_writable(keep_cache_type);
+    }
+
+    OIIO_DEPRECATED("use interppixel_NDC (1.5)")
+    void interppixel_NDC_full(float s, float t, float* pixel,
+                              WrapMode wrap = WrapBlack) const
+    {
+        const ImageSpec& spec(this->spec());
+        interppixel(static_cast<float>(spec.full_x)
+                        + s * static_cast<float>(spec.full_width),
+                    static_cast<float>(spec.full_y)
+                        + t * static_cast<float>(spec.full_height),
+                    pixel, wrap);
+    }
+
+    template<typename... Args>
+    OIIO_DEPRECATED("Use errorfmt")
+    void error(const char* fmt, const Args&... args) const
+    {
+        error(Strutil::old::format(fmt, args...));
+    }
+#endif
 
     friend class IteratorBase;
 
@@ -1613,11 +1640,6 @@ protected:
                        int& tilexbegin, int& tileybegin, int& tilezbegin,
                        int& tilexend, bool& haderr, bool exists,
                        WrapMode wrap) const;
-
-    // DEPRECATED(2.4)
-    const void* retile(int x, int y, int z, pvt::ImageCacheTile*& tile,
-                       int& tilexbegin, int& tileybegin, int& tilezbegin,
-                       int& tilexend, bool exists, WrapMode wrap) const;
 
     const void* blackpixel() const;
 

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -75,9 +75,9 @@ IvImage::read_iv(int subimage, int miplevel, bool force, TypeDesc format,
                                        progress_callback_data);
 
     if (m_image_valid && secondary_data && spec().format == TypeDesc::UINT8) {
-        m_corrected_image.reset("", ImageSpec(spec().width, spec().height,
-                                              std::min(spec().nchannels, 4),
-                                              spec().format));
+        m_corrected_image.reset(ImageSpec(spec().width, spec().height,
+                                          std::min(spec().nchannels, 4),
+                                          spec().format));
     } else {
         m_corrected_image.clear();
     }

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -514,26 +514,8 @@ ImageBuf::ImageBuf(string_view filename, int subimage, int miplevel,
 
 
 
-ImageBuf::ImageBuf(string_view filename, ImageCache* imagecache)
-    : m_impl(new ImageBufImpl(filename, 0, 0, imagecache), &impl_deleter)
-{
-}
-
-
-
 ImageBuf::ImageBuf(const ImageSpec& spec, InitializePixels zero)
     : m_impl(new ImageBufImpl("", 0, 0, NULL, &spec), &impl_deleter)
-{
-    m_impl->alloc(spec);
-    if (zero == InitializePixels::Yes && !deep())
-        ImageBufAlgo::zero(*this);
-}
-
-
-
-ImageBuf::ImageBuf(string_view filename, const ImageSpec& spec,
-                   InitializePixels zero)
-    : m_impl(new ImageBufImpl(filename, 0, 0, NULL, &spec), &impl_deleter)
 {
     m_impl->alloc(spec);
     if (zero == InitializePixels::Yes && !deep())
@@ -546,14 +528,6 @@ ImageBuf::ImageBuf(const ImageSpec& spec, void* buffer, stride_t xstride,
                    stride_t ystride, stride_t zstride)
     : m_impl(new ImageBufImpl("", 0, 0, NULL, &spec, buffer, nullptr, nullptr,
                               xstride, ystride, zstride),
-             &impl_deleter)
-{
-}
-
-
-
-ImageBuf::ImageBuf(string_view filename, const ImageSpec& spec, void* buffer)
-    : m_impl(new ImageBufImpl(filename, 0, 0, NULL, &spec, buffer),
              &impl_deleter)
 {
 }
@@ -803,14 +777,6 @@ ImageBuf::reset(string_view filename, int subimage, int miplevel,
 
 
 void
-ImageBuf::reset(string_view filename, ImageCache* imagecache)
-{
-    m_impl->reset(filename, 0, 0, imagecache, nullptr, nullptr);
-}
-
-
-
-void
 ImageBufImpl::reset(string_view filename, const ImageSpec& spec,
                     const ImageSpec* nativespec, void* buffer, stride_t xstride,
                     stride_t ystride, stride_t zstride)
@@ -846,17 +812,6 @@ ImageBufImpl::reset(string_view filename, const ImageSpec& spec,
     }
     if (nativespec)
         m_nativespec = *nativespec;
-}
-
-
-
-void
-ImageBuf::reset(string_view filename, const ImageSpec& spec,
-                InitializePixels zero)
-{
-    m_impl->reset(filename, spec);
-    if (initialized() && zero == InitializePixels::Yes && !deep())
-        ImageBufAlgo::zero(*this);
 }
 
 
@@ -1589,14 +1544,6 @@ ImageBuf::make_writable(bool keep_cache_type)
 
 
 
-bool
-ImageBuf::make_writeable(bool keep_cache_type)
-{
-    return make_writable(keep_cache_type);
-}
-
-
-
 void
 ImageBufImpl::copy_metadata(const ImageBufImpl& src)
 {
@@ -1754,6 +1701,15 @@ ImageBuf::uname(void) const
 {
     return m_impl->m_name;
 }
+
+
+
+void
+ImageBuf::set_name(string_view name)
+{
+    m_impl->m_name = name;
+}
+
 
 
 string_view
@@ -2066,7 +2022,7 @@ ImageBuf::copy(const ImageBuf& src, TypeDesc format)
         ImageSpec newspec(src.spec());
         newspec.set_format(format);
         newspec.channelformats.clear();
-        reset(src.name(), newspec);
+        reset(newspec);
     }
     return this->copy_pixels(src);
 }
@@ -2190,20 +2146,6 @@ ImageBuf::interppixel(float x, float y, float* pixel, WrapMode wrap) const
 
 void
 ImageBuf::interppixel_NDC(float x, float y, float* pixel, WrapMode wrap) const
-{
-    const ImageSpec& spec(m_impl->spec());
-    interppixel(static_cast<float>(spec.full_x)
-                    + x * static_cast<float>(spec.full_width),
-                static_cast<float>(spec.full_y)
-                    + y * static_cast<float>(spec.full_height),
-                pixel, wrap);
-}
-
-
-
-void
-ImageBuf::interppixel_NDC_full(float x, float y, float* pixel,
-                               WrapMode wrap) const
 {
     const ImageSpec& spec(m_impl->spec());
     interppixel(static_cast<float>(spec.full_x)
@@ -2999,18 +2941,6 @@ ImageBuf::retile(int x, int y, int z, ImageCache::Tile*& tile, int& tilexbegin,
                  int& tileybegin, int& tilezbegin, int& tilexend,
                  bool& haderror, bool exists, WrapMode wrap) const
 {
-    return m_impl->retile(x, y, z, tile, tilexbegin, tileybegin, tilezbegin,
-                          tilexend, haderror, exists, wrap);
-}
-
-
-// DEPRECATED(2.4)
-const void*
-ImageBuf::retile(int x, int y, int z, ImageCache::Tile*& tile, int& tilexbegin,
-                 int& tileybegin, int& tilezbegin, int& tilexend, bool exists,
-                 WrapMode wrap) const
-{
-    bool haderror;
     return m_impl->retile(x, y, z, tile, tilexbegin, tileybegin, tilezbegin,
                           tilexend, haderror, exists, wrap);
 }

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1326,7 +1326,7 @@ ImageBufAlgo::fft(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
     std::swap(specT.full_width, specT.full_height);
 
     // Resize dst
-    dst.reset(dst.name(), spec);
+    dst.reset(spec);
 
     // Copy src to a 2-channel (for "complex") float buffer
     ImageBuf A(spec);
@@ -1416,7 +1416,7 @@ ImageBufAlgo::ifft(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
     spec.nchannels = 1;
     spec.channelnames.clear();
     spec.channelnames.emplace_back("R");
-    dst.reset(dst.name(), spec);
+    dst.reset(spec);
     ROI Broi   = get_roi(B.spec());
     Broi.chend = 1;
     ImageBufAlgo::transpose(dst, B, Broi, nthreads);

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -1117,7 +1117,7 @@ ImageBufAlgo::histogram_draw(ImageBuf& R,
     if (R.spec().format != TypeFloat || R.nchannels() != 1
         || R.spec().width != bins) {
         ImageSpec newspec = ImageSpec(bins, height, 1, TypeDesc::FLOAT);
-        R.reset("dummy", newspec);
+        R.reset(newspec);
     }
 
     // Fill output image R with white color.

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -142,7 +142,7 @@ time_read_imagebuf()
 {
     imagecache->invalidate_all(true);
     for (ustring filename : input_filename) {
-        ImageBuf ib(filename.string(), imagecache);
+        ImageBuf ib(filename, 0, 0, imagecache);
         ib.read(0, 0, true, conversion);
     }
 }
@@ -280,7 +280,7 @@ time_write_tiles_row_at_a_time()
 static void
 time_write_imagebuf()
 {
-    ImageBuf ib(output_filename, bufspec, &buffer[0]);  // wrap the buffer
+    ImageBuf ib(bufspec, &buffer[0]);  // wrap the buffer
     auto out = ImageOutput::create(output_filename);
     OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
@@ -440,7 +440,7 @@ test_pixel_iteration(const std::string& explanation,
     // Force the whole image to be read at once
     imagecache->attribute("autotile", autotile);
     imagecache->attribute("autoscanline", 1);
-    ImageBuf ib(input_filename[0].string(), imagecache);
+    ImageBuf ib(input_filename[0], 0, 0, imagecache);
     ib.read(0, 0, preload, TypeFloat);
     double t    = time_trial(std::bind(func, std::ref(ib), iters), ntrials);
     double rate = double(ib.spec().image_pixels()) / (t / iters);

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1034,8 +1034,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         src.reset(new ImageBuf(*input));
     } else {
         // Image buffer supplied that has pixels -- wrap it
-        src.reset(new ImageBuf(input->name(), input->spec(),
-                               (void*)input->localpixels()));
+        src.reset(new ImageBuf(input->spec(), (void*)input->localpixels()));
     }
     OIIO_DASSERT(src.get());
 
@@ -1324,8 +1323,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             newspec.full_width  = newspec.width;
             newspec.full_height = newspec.height;
             newspec.full_depth  = newspec.depth;
-            std::string name    = std::string(src->name()) + ".constant_color";
-            src->reset(name, newspec);
+            src->reset(newspec);
             ImageBufAlgo::fill(*src, &constantColor[0]);
             if (verbose) {
                 outstream << "  Constant color image detected. ";

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -94,7 +94,7 @@ ImageRec::ImageRec(ImageRec& img, int subimage_to_copy, int miplevel_to_copy,
             } else {
                 // The other image is not modified, and we don't need to be
                 // writable, either.
-                ib      = new ImageBuf(img.name(), srcib.imagecache());
+                ib      = new ImageBuf(img.name(), 0, 0, srcib.imagecache());
                 bool ok = ib->read(srcsub, srcmip, false /*force*/,
                                    img.m_input_dataformat /*convert*/);
                 OIIO_ASSERT(ok);

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -338,14 +338,6 @@ declare_imagebuf(py::module& m)
                 return self.make_writable(keep_cache_type);
             },
             "keep_cache_type"_a = false)
-        // DEPRECATED(2.2): nonstandard spelling
-        .def(
-            "make_writeable",
-            [](ImageBuf& self, bool keep_cache_type) {
-                py::gil_scoped_release gil;
-                return self.make_writable(keep_cache_type);
-            },
-            "keep_cache_type"_a = false)
         .def("set_write_format", &ImageBuf_set_write_format)
         // FIXME -- write(ImageOut&)
         .def("set_write_tiles", &ImageBuf::set_write_tiles, "width"_a = 0,


### PR DESCRIPTION
* Add deprecation warnings to the varieties of ImageBuf constructor and `reset()` that don't take subimage and miplevel parameters. The equivalent is to just pass `0` for both of those parameters. The warned constructors have been marked as deprecated since OIIO 2.2.
* The misspelled `ImageBuf::make_writeable()` has been given deprecation warnings. Since OIIO 2.2, the correct spelling is `make_writable`.
* The `ImageBuf::error()` method that uses printf-style formatting now has deprecation warnings. Use `ImageBuf::errorfmt()` instead.
* The `ImageBuf::interppixel_NDC_full()` method, which has been marked as deprecated since OIIO 1.5, now has deprecation warnings. Use `interppixel_NDC()` instead.

Undeprecate the name+spec varieties of constructors. They were documented as deprecated but warnings were never added. In doing this set of changes, I realized that they were used for something useful after all -- it makes it easy to remember the name of a new buffer you're making not from a file, so you can later `write()` it without needing to know the filename at that time.  I also added a new `set_name()` method to do it directly for times when you don't want to rely on the constructor or want to change the name.

By the way, I'm being careful also to convert all the warned or marked deprecated functions to inline, if at all possible, so that in the future removing them will not be an ABI break.

