### PR TITLE
feat(jpeg): output hint "jpeg:iptc"

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1077,6 +1077,10 @@ control aspects of the writing itself:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by writing to a memory buffer.
+   * - ``jpeg:iptc``
+     - int (1)
+     - If zero, will suppress writing the IPTC metadata block to the
+       JPEG file.
    * - ``jpeg:progressive``
      - int
      - If nonzero, will write a progressive JPEG file.

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -189,8 +189,9 @@ OIIO_API bool decode_iptc_iim (const void *iptc, int length, ImageSpec &spec);
 /// for multiple format plugins to support embedding IPTC metadata
 /// without having to duplicate functionality within each plugin.  Note
 /// that IIM is actually considered obsolete and is replaced by an XML
-/// scheme called XMP.
-OIIO_API void encode_iptc_iim (const ImageSpec &spec, std::vector<char> &iptc);
+/// scheme called XMP. Return true if it was successful and any items
+/// were encoded.
+OIIO_API bool encode_iptc_iim (const ImageSpec &spec, std::vector<char> &iptc);
 
 /// Add metadata to spec based on XMP data in an XML block.  Return true
 /// if all is ok, false if the xml was somehow malformed.  This is a

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -249,8 +249,8 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
 
     // Write IPTC IIM metadata tags, if we have anything
     std::vector<char> iptc;
-    encode_iptc_iim(m_spec, iptc);
-    if (iptc.size()) {
+    if (m_spec.get_int_attribute("jpeg:iptc", 1)
+        && encode_iptc_iim(m_spec, iptc)) {
         static char photoshop[] = "Photoshop 3.0";
         std::vector<char> head(photoshop, photoshop + strlen(photoshop) + 1);
         static char _8BIM[] = "8BIM";

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -179,7 +179,7 @@ encode_iptc_iim_one_tag(int tag, string_view data, std::vector<char>& iptc)
 
 
 
-void
+bool
 encode_iptc_iim(const ImageSpec& spec, std::vector<char>& iptc)
 {
     iptc.clear();
@@ -206,6 +206,7 @@ encode_iptc_iim(const ImageSpec& spec, std::vector<char>& iptc)
                 encode_iptc_iim_one_tag(iimtag[i].tag, p->get_string(0), iptc);
         }
     }
+    return iptc.size() != 0;
 }
 
 


### PR DESCRIPTION
JPEG output configuration hint "jpeg:iptc" (default: 1), if set to 0, will suppress IPTC block output to the file.

In the process, we changed the return type of utility function encode_iptc_iim() to return true if anything was successfully encoded, false otherwise.
