### PR TITLE
deps: Raise libPNG minimum to 1.6.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,6 +38,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * **Python >= 3.7** (tested through 3.12)
      * **pybind11 >= 2.7** (tested through 2.12)
      * NumPy
+ * If you want support for PNG files:
+     * **libPNG >= 1.6.0** (tested though 1.6.43)
  * If you want support for camera "RAW" formats:
      * **LibRaw >= 0.20** (tested though 0.21.2)
  * If you want support for a wide variety of video formats:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -118,7 +118,7 @@ endif ()
 # Dependencies for optional formats and features. If these are not found,
 # we will continue building, but the related functionality will be disabled.
 
-checked_find_package (PNG)
+checked_find_package (PNG VERSION_MIN 1.6.0)
 
 checked_find_package (BZip2)   # Used by ffmpeg and freetype
 if (NOT BZIP2_FOUND)

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -244,12 +244,8 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
     }
 
     if (png_get_valid(sp, ip, PNG_INFO_iCCP)) {
-        png_charp profile_name = NULL;
-#if OIIO_LIBPNG_VERSION > 10500 /* PNG function signatures changed */
-        png_bytep profile_data = NULL;
-#else
-        png_charp profile_data = NULL;
-#endif
+        png_charp profile_name     = nullptr;
+        png_bytep profile_data     = nullptr;
         png_uint_32 profile_length = 0;
         int compression_type;
         png_get_iCCP(sp, ip, &profile_name, &compression_type, &profile_data,
@@ -628,21 +624,14 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
     // Write ICC profile, if we have anything
     const ParamValue* icc_profile_parameter = spec.find_attribute(
         ICC_PROFILE_ATTR);
-    if (icc_profile_parameter != NULL) {
+    if (icc_profile_parameter != nullptr) {
         unsigned int length = icc_profile_parameter->type().size();
         if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
             return "Could not set PNG iCCP chunk";
-#if OIIO_LIBPNG_VERSION > 10500 /* PNG function signatures changed */
         unsigned char* icc_profile
             = (unsigned char*)icc_profile_parameter->data();
         if (icc_profile && length)
             png_set_iCCP(sp, ip, "Embedded Profile", 0, icc_profile, length);
-#else
-        char* icc_profile = (char*)icc_profile_parameter->data();
-        if (icc_profile && length)
-            png_set_iCCP(sp, ip, (png_charp) "Embedded Profile", 0, icc_profile,
-                         length);
-#endif
     }
 
     if (false && !spec.find_attribute("DateTime")) {


### PR DESCRIPTION
Raised from 1.5.13 (maybe? we never carefully checked) to 1.6.0 minimum, which was released in 2013 (so absolutely nobody should be bothered by this).
