### PR TITLE
build(deps): Fix FindLibheif.cmake failed on gentoo

### DIFF
--- a/src/cmake/modules/FindLibheif.cmake
+++ b/src/cmake/modules/FindLibheif.cmake
@@ -30,7 +30,19 @@ find_library (LIBHEIF_LIBRARY heif
               DOC "The directory where libheif libraries reside")
 
 if (LIBHEIF_INCLUDE_DIR)
-    file(STRINGS "${LIBHEIF_INCLUDE_DIR}/libheif/heif_version.h" TMP REGEX "^#define LIBHEIF_VERSION[ \t].*$")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        # msvc
+        set(PREPROCESS_COMMAND ${CMAKE_CXX_COMPILER} /E "${LIBHEIF_INCLUDE_DIR}/libheif/heif_version.h")
+    else ()
+        # clang, gcc or icc
+        set(PREPROCESS_COMMAND ${CMAKE_CXX_COMPILER} -E -dD -P "${LIBHEIF_INCLUDE_DIR}/libheif/heif_version.h")
+    endif ()
+    execute_process(
+        COMMAND ${PREPROCESS_COMMAND}
+        OUTPUT_VARIABLE PREPROCESS_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REGEX MATCH "#define LIBHEIF_VERSION[ \t]+[^\n]+" TMP "${PREPROCESS_OUTPUT}")
     string(REGEX MATCHALL "[0-9.]+" LIBHEIF_VERSION ${TMP})
 endif ()
 


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->

- Fixed the issue where FindLibheif.cmake failed to obtain the libheif version on gentoo.

``media-libs/libheif`` in ``::gentoo`` has an extra layer of warpper, which causes the regular expression to fail. Here I used compiler preprocessing to solve the problem. Regardless of whether there is a warpper or a space is added before the macro definition, it can be processed correctly.

Bug: https://bugs.gentoo.org/936472
Closes: https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4356


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
