### PR TITLE
raw: improvements to raw plugin

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2062,7 +2062,23 @@ options are supported:
      - If nonzero, will use libraw's exposure correction. (Default: 0)
    * - ``raw:use_camera_wb``
      - int
-     - If 1, use libraw's camera white balance adjustment. (Default: 1)
+     - If 1, use libraw's camera white balance adjustment. Takes precedence
+       over ``raw:use_auto_wb``, ``raw:greybox``, ``raw:user_mul``. 
+       (Default: 1)
+   * - ``raw:use_auto_wb``
+     - int
+     - If 1, white balance automatically by averaging over the entire image.
+       Only applies if ``raw:use_camera_wb`` is not equal to 0. Takes 
+       precedence over ``raw:greybox``, ``raw:user_mul``.
+       (Default: 0)
+   * - ``raw:greybox``
+     - int[4]
+     - White balance by averaging over the given box. The four values are the 
+       X and Y coordinate of the top-left corner, the width and the height.
+       Only applies if the size is non-zero, and ``raw:use_camera_wb`` is not 
+       equal to 0, ``raw:use_auto_wb`` is not equal to 0. Takes 
+       precedence over ``raw:user_mul``.
+       (Default: 0, 0, 0, 0; meaning no correction.)
    * - ``raw:use_camera_matrix``
      - int
      - Whether to use the embedded color profile, if it's present: 0 =
@@ -2070,6 +2086,10 @@ options are supported:
    * - ``raw:adjust_maximum_thr``
      - float
      - If nonzero, auto-adjusting maximum value. (Default:0.0)
+   * - ``raw:user_black``
+     - int
+     - If not negative, sets the camera minimum value that will be normalized to
+       appear 0. (Default: -1)
    * - ``raw:user_sat``
      - int
      - If nonzero, sets the camera maximum value that will be normalized to
@@ -2086,7 +2106,8 @@ options are supported:
    * - ``raw:user_mul``
      - float[4]
      - Sets user white balance coefficients. Only applies if ``raw:use_camera_wb``
-       is not equal to 0.
+       is not equal to 0, ``raw:use_auto_wb`` is not equal to 0, and the 
+       ``raw:greybox`` box is zero size.
    * - ``raw:ColorSpace``
      - string
      - Which color primaries to use for the returned pixel values: ``raw``,


### PR DESCRIPTION
## Description

The main purpose of this change is to make it possible to use OIIO for reading raw files in rawtoaces instead of calling LibRaw directly. There are the changes:
- add the missing hints needed to implement all combinations of white-balancing methods and matrix methods provided by rawtoaces.
- add the DNG-specific attributes

## Tests

The change adds this functionality:
- new "raw:user_black" hint to override the default black point
- new "raw:use_auto_wb" hint to force LibRaw to white balance by averaging over the whole image.
- new "raw:grey_box" hint to make LibRaw to white balance by averaging over the given rectange.
- new "raw:dng:XXX" attributes added to the output ImageBuf if the input image is a DNG file. The attributes consist of 2 sets of [calibration illuminant; calibration matrix, XYZ to camera RGB matrix]. Note, the current DNG standard supports up to 3 calibration illuminants, but both LibRaw and rawtoaces only use 2 currently.

I have manually tested all permutations of white-balancing modes and matrix methods which are currently supported by raw to aces. The images match up to a rounding error.

The current unit tests pass, but they only seem to use the default conversion settings. We may want to extend those. I'm not clear on how to do that, there are multiple reference images for different versions of LibRaw, not sure if I will have to re-generate all of them. I intend to make more changes to the raw plugin soon, may come back to updating tests during/after that.

There are currently no tests using DNG files, so the new DNG-specific attributes are not covered. The code relying on those in rawtoaces works fine.

I have also updated the documentation to add the new hints, however, I haven't been able to build the documentation.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
