### PR TITLE
api: move OIIO::pvt::error and log_time into the exposed OIIO namespace

### DIFF
--- a/src/iff.imageio/noproxy-iff_pvt.h
+++ b/src/iff.imageio/noproxy-iff_pvt.h
@@ -145,7 +145,7 @@ public:
         try {
             close();
         } catch (const std::exception& e) {
-            OIIO::pvt::errorfmt("{}", e.what());
+            OIIO::errorfmt("{}", e.what());
         }
     }
     const char* format_name(void) const override { return "iff"; }
@@ -228,7 +228,7 @@ public:
         try {
             close();
         } catch (const std::exception& e) {
-            OIIO::pvt::errorfmt("{}", e.what());
+            OIIO::errorfmt("{}", e.what());
         }
     }
     const char* format_name(void) const override { return "iff"; }

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -41,6 +41,7 @@ OIIO_NAMESPACE_BEGIN
 
 class DeepData;
 class ImageBuf;
+class Timer;
 
 
 /// Type we use for stride lengths between pixels, scanlines, or image
@@ -3363,7 +3364,22 @@ void debugfmt (const char* fmt, Args&&... args)
     Strutil::debug(fmt, std::forward<Args>(args)...);
 }
 
+namespace pvt {
+// For internal use - use errorfmt() below for a nicer interface.
+OIIO_API void append_error(string_view message);
+}
 
+/// error logging (mostly for OIIO internals) with `std::format` conventions.
+template<typename... Args>
+inline void errorfmt(const char* fmt, Args&&... args)
+{
+    pvt::append_error(string_view(Strutil::fmt::format(fmt, args...)));
+}
+
+/// Internal function to log time recorded by an OIIO::timer(). It will only
+/// trigger a read of the time if the "log_times" attribute is set or the
+/// OPENIMAGEIO_LOG_TIMES env variable is set.
+OIIO_API void log_time(string_view key, const Timer& timer, int count = 1);
 
 // to force correct linkage on some systems
 OIIO_API void _ImageIO_force_link ();

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -152,7 +152,9 @@ using old::format;
 #endif
 
 
-// format_to comes from fmt library
+// More things we wrap from fmt library
+using ::fmt::format_args;
+using ::fmt::make_format_args;
 using ::fmt::format_to;
 using ::fmt::format_to_n;
 

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -60,18 +60,6 @@ font_list();
 
 
 
-// For internal use - use error() below for a nicer interface.
-void
-append_error(string_view message);
-
-/// Use errorfmt() privately only. Formatting notation is like std::format.
-template<typename... Args>
-inline void
-errorfmt(const char* fmt, const Args&... args)
-{
-    append_error(Strutil::fmt::format(fmt, args...));
-}
-
 // Make sure all plugins are inventoried. For internal use only.
 void
 catalog_all_plugins(std::string searchpath);
@@ -122,12 +110,6 @@ parallel_convert_from_float(const float* src, void* dst, size_t nvals,
 /// incorrect files and it was fixed.
 OIIO_API bool
 check_texture_metadata_sanity(ImageSpec& spec);
-
-/// Internal function to log time recorded by an OIIO::timer(). It will only
-/// trigger a read of the time if the "log_times" attribute is set or the
-/// OPENIMAGEIO_LOG_TIMES env variable is set.
-OIIO_API void
-log_time(string_view key, const Timer& timer, int count = 1);
 
 /// Get the timing report from log_time entries.
 OIIO_API std::string

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -169,16 +169,14 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
     } else if (spec.format == TypeDesc(TypeDesc::DOUBLE)) {
         dstFormat = CV_MAKETYPE(CV_64F, chans);
     } else {
-        OIIO::pvt::errorfmt(
-            "to_OpenCV() doesn't know how to make a cv::Mat of {}",
-            spec.format);
+        OIIO::errorfmt("to_OpenCV() doesn't know how to make a cv::Mat of {}",
+                       spec.format);
         return false;
     }
     dst.create(roi.height(), roi.width(), dstFormat);
     if (dst.empty()) {
-        OIIO::pvt::errorfmt(
-            "to_OpenCV() was unable to create cv::Mat of {}x{} {}", roi.width(),
-            roi.height(), dstSpecFormat);
+        OIIO::errorfmt("to_OpenCV() was unable to create cv::Mat of {}x{} {}",
+                       roi.width(), roi.height(), dstSpecFormat);
         return false;
     }
 
@@ -189,7 +187,7 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
                   dst.ptr(), pixelsize, linestep, AutoStride);
     bool converted = ImageBufAlgo::copy(cvib, src);
     if (!converted) {
-        OIIO::pvt::errorfmt(
+        OIIO::errorfmt(
             "to_OpenCV() was unable to convert source {} to cv::Mat of {}",
             spec.format, dstSpecFormat);
         return false;
@@ -204,7 +202,7 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
 
     return true;
 #else
-    OIIO::pvt::errorfmt(
+    OIIO::errorfmt(
         "to_OpenCV() not supported -- no OpenCV support at compile time");
     return false;
 #endif

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -164,7 +164,7 @@ ImageInput::open(const std::string& filename, const ImageSpec* config,
         // error, delete the ImageInput we allocated, and return NULL.
         std::string err = in->geterror();
         if (err.size())
-            OIIO::pvt::errorfmt("{}", err);
+            OIIO::errorfmt("{}", err);
         in.reset();
     }
 

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -364,7 +364,7 @@ debug(string_view message)
 
 
 void
-pvt::log_time(string_view key, const Timer& timer, int count)
+log_time(string_view key, const Timer& timer, int count)
 {
     timing_log(key, timer, count);
 }

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -526,7 +526,7 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
 {
     std::unique_ptr<ImageOutput> out;
     if (filename.empty()) {  // Can't even guess if no filename given
-        OIIO::pvt::errorfmt("ImageOutput::create() called with no filename");
+        OIIO::errorfmt("ImageOutput::create() called with no filename");
         return out;
     }
 
@@ -563,9 +563,9 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
                 const char* msg
                     = "ImageOutput::create() could not find any ImageOutput plugins!  Perhaps you need to set OIIO_LIBRARY_PATH.\n";
                 Strutil::print(stderr, "{}", msg);
-                OIIO::pvt::errorfmt("{}", msg);
+                OIIO::errorfmt("{}", msg);
             } else
-                OIIO::pvt::errorfmt(
+                OIIO::errorfmt(
                     "OpenImageIO could not find a format writer for \"{}\". "
                     "Is it a file format that OpenImageIO doesn't know about?\n",
                     filename);
@@ -582,7 +582,7 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
     }
     if (out && ioproxy) {
         if (!out->supports("ioproxy")) {
-            OIIO::pvt::errorfmt(
+            OIIO::errorfmt(
                 "ImageOutput::create called with IOProxy, but format {} does not support IOProxy",
                 out->format_name());
             out.reset();
@@ -609,7 +609,7 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
     // Only check REST arguments if the file does not exist
     if (!Filesystem::exists(filename)) {
         if (!Strutil::get_rest_arguments(filename, filename_stripped, args)) {
-            OIIO::pvt::errorfmt(
+            OIIO::errorfmt(
                 "ImageInput::create() called with malformed filename");
             return in;
         }
@@ -619,7 +619,7 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
         filename_stripped = filename;
 
     if (filename_stripped.empty()) {  // Can't even guess if no filename given
-        OIIO::pvt::errorfmt("ImageInput::create() called with no filename");
+        OIIO::errorfmt("ImageInput::create() called with no filename");
         return in;
     }
 
@@ -770,18 +770,18 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
                 = "ImageInput::create() could not find any ImageInput plugins!\n"
                   "    Perhaps you need to set OIIO_LIBRARY_PATH.\n";
             Strutil::print(stderr, "{}", msg);
-            OIIO::pvt::errorfmt("{}", msg);
+            OIIO::errorfmt("{}", msg);
         } else if (!specific_error.empty()) {
             // Pass along any specific error message we got from our
             // best guess of the format.
-            OIIO::pvt::errorfmt("{}", specific_error);
+            OIIO::errorfmt("{}", specific_error);
         } else if (Filesystem::exists(filename))
-            pvt::errorfmt(
+            OIIO::errorfmt(
                 "OpenImageIO could not find a format reader for \"{}\". "
                 "Is it a file format that OpenImageIO doesn't know about?\n",
                 filename);
         else
-            OIIO::pvt::errorfmt(
+            OIIO::errorfmt(
                 "Image \"{}\" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.\n",
                 filename);
         OIIO_DASSERT(!in);

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -615,7 +615,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
              std::ostream& outstream, double& stat_writetime,
              double& stat_miptime, size_t& peak_mem)
 {
-    using OIIO::pvt::errorfmt;
+    using OIIO::errorfmt;
     using OIIO::Strutil::sync::print;  // Be sure to use synchronized one
     bool envlatlmode       = (mode == ImageBufAlgo::MakeTxEnvLatl);
     bool orig_was_overscan = (img->spec().x || img->spec().y || img->spec().z
@@ -981,7 +981,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
                   std::string filename, std::string outputfilename,
                   const ImageSpec& _configspec, std::ostream* outstream_ptr)
 {
-    using OIIO::pvt::errorfmt;
+    using OIIO::errorfmt;
     using OIIO::Strutil::sync::print;  // Be sure to use synchronized one
     OIIO_ASSERT(mode >= 0 && mode < ImageBufAlgo::_MakeTxLast);
     double stat_readtime         = 0;


### PR DESCRIPTION
This is needed for the related OpenCV-related PR