### PR TITLE
build: Don't link libOpenImageIO against OpenCV

### DIFF
--- a/docs/Deprecations-3.0.md
+++ b/docs/Deprecations-3.0.md
@@ -86,6 +86,14 @@ about being deprecated will be removed in the final 3.0 release.
   deprecated since OIIO 1.5, now has deprecation warnings. Use
   `interppixel_NDC()` instead.
 
+## imageio.h
+
+* The global OIIO::attribute query "opencv_version" has been removed. The
+  libOpenImageIO library itself no longer has OpenCV as a dependency or links
+  against it. (However, the IBA functions involving OpenCV still exist and are
+  defined in `imagebufalgo_opencv.h` as inline functions, so it is up to the
+  application calling these API functions to find and link against OpenCV.)
+
 ## imagebufalgo.h
 
 * The old versions (deprecated since 2.0) of IBA::compare() and
@@ -111,6 +119,8 @@ about being deprecated will be removed in the final 3.0 release.
   cv::Mat.
 * The pre-KWArgs versions of resize, warp, and fit now have deprecation
   warnings. Use the versions that take KWArgs instead.
+* The OpenCV-related functions `to_OpenCV()`, `from_OpenCV()`, and
+  `capture_image()` have moved to the `imagebufalgo_opencv.h` header.
 
 ## imagebufalgo_util.h
 
@@ -192,4 +202,11 @@ about being deprecated will be removed in the final 3.0 release.
 * This header has been removed completely, since we no longer use the classes
   it defines.
 
+
+## python bindings
+
+* The `ImageBufAlgo.capture_image()` function has been removed from the
+  Python bindings. Python scripts that wish to capture images from live
+  cameras should use OpenCV or other capture APIs of choice and then
+  pass the results to OIIO to construct an ImageBuf.
 

--- a/src/cmake/fancy_add_executable.cmake
+++ b/src/cmake/fancy_add_executable.cmake
@@ -20,6 +20,7 @@
 #   fancy_add_executable ([ NAME targetname ... ]
 #                         [ SRC source1 ... ]
 #                         [ INCLUDE_DIRS include_dir1 ... ]
+#                         [ SYSTEM_INCLUDE_DIRS include_dir1 ... ]
 #                         [ DEFINITIONS FOO=bar ... ])
 #                         [ COMPILE_OPTIONS -Wno-foo ... ]
 #                         [ LINK_LIBRARIES external_lib1 ... ]

--- a/src/cmake/modules/FindOpenCV.cmake
+++ b/src/cmake/modules/FindOpenCV.cmake
@@ -15,12 +15,9 @@
 
 find_path (OpenCV_INCLUDE_DIR
            NAMES opencv4/opencv2/opencv.hpp opencv2/opencv.hpp
-           PATHS
-               /opt/local/include
-               /usr/local/opt/opencv4
-               /usr/local/opt/opencv3
+           PATHS /opt/local/include /usr/local/opt/opencv4
            PATH_SUFFIXES opencv4
-           )
+          )
 
 set (_ocv_include_root "${OpenCV_INCLUDE_DIR}")
 if (OpenCV_INCLUDE_DIR AND EXISTS "${OpenCV_INCLUDE_DIR}/opencv4/opencv2/core/version.hpp")

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -63,7 +63,7 @@ endmacro()
 # pybind11
 
 macro (setup_python_module)
-    cmake_parse_arguments (lib "" "TARGET;MODULE" "SOURCES;LIBS" ${ARGN})
+    cmake_parse_arguments (lib "" "TARGET;MODULE" "SOURCES;LIBS;INCLUDES;SYSTEM_INCLUDE_DIRS" ${ARGN})
     # Arguments: <prefix> <options> <one_value_keywords> <multi_value_keywords> args...
 
     set (target_name ${lib_TARGET})
@@ -79,6 +79,10 @@ macro (setup_python_module)
 #    add_library (${target_name} MODULE ${lib_SOURCES})
 #
     # Declare the libraries it should link against
+    target_include_directories (${target_name}
+                                PRIVATE ${lib_INCLUDES})
+    target_include_directories (${target_name}
+                                SYSTEM PRIVATE ${lib_SYSTEM_INCLUDE_DIRS})
     target_link_libraries (${target_name}
                            PRIVATE ${lib_LIBS})
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3698,18 +3698,6 @@ Import / export
 
 
 
-.. py:method:: ImageBuf ImageBufAlgo::capture_image (cameranum, convert = OpenImageIO.UNKNOWN)
-
-    Capture a still image from a designated camera.
-
-    Example:
-
-    .. code-block:: python
-
-        WebcamImage = ImageBufAlgo.capture_image (0, OpenImageIO.UINT8)
-        WebcamImage.write ("webcam.jpg")
-
-
 
 Functions specific to deep images
 ---------------------------------

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -23,14 +23,6 @@
 
 #include <limits>
 
-#if !defined(__OPENCV_CORE_TYPES_H__) && !defined(OPENCV_CORE_TYPES_H)
-struct IplImage;  // Forward declaration; used by Intel Image lib & OpenCV
-namespace cv {
-    class Mat;
-}
-#endif
-
-
 
 OIIO_NAMESPACE_BEGIN
 
@@ -2343,36 +2335,6 @@ bool OIIO_API make_texture (MakeTextureMode mode,
                             const ImageSpec &config,
                             std::ostream *outstream = nullptr);
 /// @}
-
-
-/// Convert an OpenCV cv::Mat into an ImageBuf, copying the pixels (optionally
-/// converting to the pixel data type specified by `convert`, if not UNKNOWN,
-/// which means to preserve the original data type if possible).  Return true
-/// if ok, false if it was not able to make the conversion from Mat to
-/// ImageBuf. Any error messages can be retrieved by calling `geterror()` on
-/// the returned ImageBuf. If OpenImageIO was compiled without OpenCV support,
-/// this function will return false.
-OIIO_API ImageBuf
-from_OpenCV (const cv::Mat& mat, TypeDesc convert = TypeUnknown,
-             ROI roi={}, int nthreads=0);
-
-/// Construct an OpenCV cv::Mat containing the contents of ImageBuf src, and
-/// return true. If it is not possible, or if OpenImageIO was compiled without
-/// OpenCV support, then return false. Any error messages can be retrieved by
-/// calling OIIO::geterror(). Note that OpenCV only supports up to 4 channels,
-/// so >4 channel images will be truncated in the conversion.
-OIIO_API bool to_OpenCV (cv::Mat& dst, const ImageBuf& src,
-                         ROI roi={}, int nthreads=0);
-
-
-/// Capture a still image from a designated camera.  If able to do so,
-/// store the image in dst and return true.  If there is no such device,
-/// or support for camera capture is not available (such as if OpenCV
-/// support was not enabled at compile time), return false and do not
-/// alter dst.
-ImageBuf OIIO_API capture_image (int cameranum = 0,
-                                 TypeDesc convert=TypeUnknown);
-
 
 
 /// Return the "deep" equivalent of the "flat" input `src`. Turning a flat

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3134,12 +3134,6 @@ inline bool attribute (string_view name, string_view val) {
 ///   OpenImageiO, or "0.0.0" if no OpenColorIO support has been enabled.
 ///   (Added in OpenImageIO 2.4.6)
 ///
-/// - `int opencv_version`
-///
-///   Returns the encoded version (such as 40701 for 4.7.1) of the OpenCV that
-///   is used by OpenImageIO, or 0 if no OpenCV support has been enabled.
-///   (Added in OpenImageIO 2.5.2)
-///
 /// - `string hw:simd`
 /// - `string build:simd` (read-only)
 ///

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -43,7 +43,6 @@ extern int oiio_log_times;
 extern int openexr_core;
 extern int limit_channels;
 extern int limit_imagesize_MB;
-extern int opencv_version;
 extern int imagebuf_print_uncaught_errors;
 extern int imagebuf_use_imagecache;
 extern atomic_ll IB_local_mem_current;

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -55,7 +55,7 @@ set (libOpenImageIO_srcs
                           imagebufalgo_minmaxchan.cpp
                           imagebufalgo_orient.cpp
                           imagebufalgo_xform.cpp
-                          imagebufalgo_yee.cpp imagebufalgo_opencv.cpp
+                          imagebufalgo_yee.cpp
                           deepdata.cpp exif.cpp exif-canon.cpp
                           formatspec.cpp
                           icc.cpp imagebuf.cpp
@@ -120,7 +120,6 @@ endif ()
 target_compile_definitions(OpenImageIO
               PRIVATE
                   OIIO_FREETYPE_VERSION="${FREETYPE_VERSION_STRING}"
-                  OIIO_OpenCV_VERSION="${OpenCV_VERSION}"
                   OIIO_PYTHON_VERSION="${Python3_VERSION}"
                   OIIO_QT_VERSION="${Qt6_VERSION}${Qt5_VERSION}"
                   OIIO_TBB_VERSION="${TBB_VERSION}"
@@ -138,7 +137,6 @@ target_include_directories (OpenImageIO
                             PRIVATE
                                 ${ROBINMAP_INCLUDES}
                             )
-target_include_directories (OpenImageIO SYSTEM PUBLIC ${OpenCV_INCLUDES})
 
 if (NOT BUILD_SHARED_LIBS)
     target_compile_definitions (OpenImageIO PUBLIC OIIO_STATIC_DEFINE=1)
@@ -155,7 +153,6 @@ target_link_libraries (OpenImageIO
             ${OPENIMAGEIO_IMATH_TARGETS}
         PRIVATE
             ${OPENIMAGEIO_OPENEXR_TARGETS}
-            ${OpenCV_LIBRARIES}
             ${format_plugin_libs} # Add all the target link libraries from the plugins
             OpenColorIO::OpenColorIO
             $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIOHeaders>
@@ -253,6 +250,9 @@ if (OIIO_BUILD_TESTS AND BUILD_TESTING)
     add_test (unit_imagecache ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagecache_test)
 
     fancy_add_executable (NAME imagebufalgo_test SRC imagebufalgo_test.cpp
+                          SYSTEM_INCLUDE_DIRS
+                                ${ROBINMAP_INCLUDES}
+                                ${OpenCV_INCLUDES}            
                           LINK_LIBRARIES OpenImageIO
                                          ${OpenCV_LIBRARIES}
                                          ${OPENIMAGEIO_IMATH_TARGETS}

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -10,14 +10,6 @@
 
 #include <OpenImageIO/platform.h>
 
-#if USE_OPENCV
-// Suppress gcc 11 / C++20 errors about opencv 4 headers
-#    if OIIO_GNUC_VERSION >= 110000 && OIIO_CPLUSPLUS_VERSION >= 20
-#        pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
-#    endif
-#    include <opencv2/opencv.hpp>
-#endif
-
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/benchmark.h>
 #include <OpenImageIO/color.h>
@@ -28,6 +20,10 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/unittest.h>
+
+#if USE_OPENCV
+#    include <OpenImageIO/imagebufalgo_opencv.h>
+#endif
 
 using namespace OIIO;
 

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -665,10 +665,6 @@ getattribute(string_view name, TypeDesc type, void* val)
                                             (v >> 16) & 0xff, (v >> 8) & 0xff);
         return true;
     }
-    if (name == "opencv_version" && type == TypeInt) {
-        *(int*)val = OIIO::pvt::opencv_version;
-        return true;
-    }
     if (name == "IB_local_mem_current" && type == TypeInt64) {
         *(long long*)val = IB_local_mem_current;
         return true;

--- a/src/oiiotool/CMakeLists.txt
+++ b/src/oiiotool/CMakeLists.txt
@@ -4,8 +4,9 @@
 
 fancy_add_executable (SYSTEM_INCLUDE_DIRS
                         ${ROBINMAP_INCLUDES}
+                        ${OpenCV_INCLUDES}
                       LINK_LIBRARIES
                         OpenImageIO
                         $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
-                        $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
+                        ${OpenCV_LIBRARIES}
                      )

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -8,8 +8,9 @@ file (GLOB python_srcs *.cpp)
 setup_python_module (TARGET    PyOpenImageIO
                      MODULE    OpenImageIO
                      SOURCES   ${python_srcs}
-                     LIBS      OpenImageIO ${OPENIMAGEIO_IMATH_TARGETS}
-                     )
+                     LIBS      OpenImageIO
+                               ${OPENIMAGEIO_IMATH_TARGETS}
+                    )
 
 # Unity builds: If in unity group mode, make the python bindings one group. If
 # in unity batch mode, use the smaller batch size because these tend to be

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -2327,25 +2327,6 @@ IBA_histogram(const ImageBuf& src, int channel = 0, int bins = 256,
 
 
 bool
-IBA_capture_image(ImageBuf& dst, int cameranum,
-                  TypeDesc::BASETYPE convert = TypeDesc::UNKNOWN)
-{
-    py::gil_scoped_release gil;
-    dst = ImageBufAlgo::capture_image(cameranum, convert);
-    return !dst.has_error();
-}
-
-ImageBuf
-IBA_capture_image_ret(int cameranum,
-                      TypeDesc::BASETYPE convert = TypeDesc::UNKNOWN)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::capture_image(cameranum, convert);
-}
-
-
-
-bool
 IBA_make_texture_ib(ImageBufAlgo::MakeTextureMode mode, const ImageBuf& buf,
                     const std::string& outputfilename, const ImageSpec& config)
 {
@@ -3012,11 +2993,6 @@ declare_imagebufalgo(py::module& m)
                     "src"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
         .def_static("fillholes_pushpull", &IBA_fillholes_pushpull_ret, "src"_a,
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
-
-        .def_static("capture_image", &IBA_capture_image, "dst"_a,
-                    "cameranum"_a = 0, "convert"_a = TypeDesc::UNKNOWN)
-        .def_static("capture_image", &IBA_capture_image_ret, "cameranum"_a = 0,
-                    "convert"_a = TypeDesc::UNKNOWN)
 
         .def_static("over", &IBA_over, "dst"_a, "A"_a, "B"_a,
                     "roi"_a = ROI::All(), "nthreads"_a = 0)


### PR DESCRIPTION
Fully linking OpenCV against libOpenImageIO is burdensome for people downstream, especially those who want a static version of libOpenImageIO.

There were only three IBA functions that use OpenCV: to_OpenCV(), from_OpenCV(), and capture_image(), and all three are fairly short. Move them to a separate header, imagebufalgo_opencv.h, make them fully INLINE (so they don't actually produce object code in libOpenImageIO, which therefore does not need to link against OpenCV).

Applications wanting these three functions should include this header and will be responsible themselves for ensuring that the include paths and linkage of their application makes provisions for finding and using OpenCV. All other applications don't need to deal with OpenCV dependency at all.

Our own oiiotool (for --capture) and our python bindings still link against OpenCV to support this functionality (again, still as an optional dependency, enabled only if OpenCV is found at build time). But downstream apps using libOpenImageIO and who do not themselves need our OpenCV functioality now no longer need to link against OpenCV.

We have removed capture_image() from the Python bindings -- Python scripts that need to capture live camera images can use OpenCV or any other capture API of their choice without going through OIIO.
