### PR TITLE
fix: copy/paste error in the ImageBuf iterator copy constructor

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -3129,7 +3129,7 @@ ImageBuf::IteratorBase::operator=(const IteratorBase& i)
     m_rng_zend   = i.m_rng_zend;
     m_x          = i.m_x;
     m_y          = i.m_y;
-    m_y          = i.m_y;
+    m_z          = i.m_z;
     return *this;
 }
 


### PR DESCRIPTION

## Description

Fixes a simple copy/paste error in a copy constructor where the y coordinate gets initialised twice instead of y and z.

## Tests

This is a trivial change, I don't think it needs any additional testing.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
