### PR TITLE
int: Rename env OIIOTOOL_METADATA_HISTORY -> OPENIMAGEIO_METADATA_HISTORY

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -370,10 +370,10 @@ inside the source code.
     take precedence. If neither is set, the default will be 0, which means
     to use as many threads as there are physical cores on the machine.
 
-``OIIOTOOL_METADATA_HISTORY``
+``OPENIMAGEIO_METADATA_HISTORY``
 
-    If set to a nonzero integer value, `oiiotool` will by default write the
-    command line into the ImageHistory and Software metadata fields of any
+    If set to a nonzero integer value, `oiiotool` and `maketx` will by default
+    write the command line into the ImageHistory and Software metadata fields of any
     images it outputs. The default if this is not set is to only write the
     name and version of the software and an indecipherable hash of the command
     line, but not the full human-readable command line. (This was added in

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1982,7 +1982,7 @@ current top image.
     image to potentially reveal any proprietary information that might have
     been present in the command line arguments.
     
-    If the `OIIOTOOL_METADATA_HISTORY` environment variable is set to a
+    If the `OPENIMAGEIO_METADATA_HISTORY` environment variable is set to a
     nonzero integer value, the `--history` option will be enabled by default,
     but can be disabled on the command line with `--no-history`.
 
@@ -1993,7 +1993,7 @@ current top image.
     Prior to OpenImageIO 2.5.11, the full information was always written, but
     could be overridden with `--nosoftwareattrib`. Beginning with 2.5.11, the
     default changed to only write the software name and version (unless the
-    `OIIOTOOL_METADATA_HISTORY` environment variable is set), and require the
+    `OPENIMAGEIO_METADATA_HISTORY` environment variable is set), and require the
     new `--history` option to cause the command line arguments to be written
     as metadata.
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -26,8 +26,8 @@
 
 using namespace OIIO;
 
-#ifndef OIIOTOOL_METADATA_HISTORY_DEFAULT
-#    define OIIOTOOL_METADATA_HISTORY_DEFAULT 0
+#ifndef OPENIMAGEIO_METADATA_HISTORY_DEFAULT
+#    define OPENIMAGEIO_METADATA_HISTORY_DEFAULT 0
 #endif
 
 
@@ -185,12 +185,12 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     bool cdf                   = false;
     float cdfsigma             = 1.0f / 6;
     int cdfbits                = 8;
-#if OIIOTOOL_METADATA_HISTORY_DEFAULT
+#if OPENIMAGEIO_METADATA_HISTORY_DEFAULT
     bool metadata_history = Strutil::from_string<int>(
-        getenv("OIIOTOOL_METADATA_HISTORY", "1"));
+        getenv("OPENIMAGEIO_METADATA_HISTORY", "1"));
 #else
     bool metadata_history = Strutil::from_string<int>(
-        getenv("OIIOTOOL_METADATA_HISTORY"));
+        getenv("OPENIMAGEIO_METADATA_HISTORY"));
 #endif
     std::string incolorspace;
     std::string outcolorspace;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -53,8 +53,8 @@ using pvt::print_info_options;
 #    define OIIO_UNIT_TESTS 1
 #endif
 
-#ifndef OIIOTOOL_METADATA_HISTORY_DEFAULT
-#    define OIIOTOOL_METADATA_HISTORY_DEFAULT 0
+#ifndef OPENIMAGEIO_METADATA_HISTORY_DEFAULT
+#    define OPENIMAGEIO_METADATA_HISTORY_DEFAULT 0
 #endif
 
 
@@ -174,12 +174,12 @@ Oiiotool::clear_options()
     output_dither             = false;
     output_force_tiles        = false;
     metadata_nosoftwareattrib = false;
-#if OIIOTOOL_METADATA_HISTORY_DEFAULT
+#if OPENIMAGEIO_METADATA_HISTORY_DEFAULT
     metadata_history = Strutil::from_string<int>(
-        getenv("OIIOTOOL_METADATA_HISTORY", "1"));
+        getenv("OPENIMAGEIO_METADATA_HISTORY", "1"));
 #else
     metadata_history = Strutil::from_string<int>(
-        getenv("OIIOTOOL_METADATA_HISTORY"));
+        getenv("OPENIMAGEIO_METADATA_HISTORY"));
 #endif
     diff_warnthresh    = 1.0e-6f;
     diff_warnpercent   = 0;


### PR DESCRIPTION
It's not just in oiiotool. This seems clearer and adheres to the env variable naming convention we chose.

Reminder: This controls whether command line history gets written to output image metadata by default by oiiotool and maketx. We historically did it, but recently stopped because of security concerns.
