### PR TITLE
Finish removing Imath include

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -46,11 +46,6 @@
 
 #include <OpenImageIO/detail/fmt.h>
 
-// Without SSE, we need to fall back on Imath for matrix44 invert
-#if !OIIO_SIMD_SSE
-#   include <OpenImageIO/Imath.h>
-#endif
-
 
 //////////////////////////////////////////////////////////////////////////
 // Sort out which SIMD capabilities we have and set definitions


### PR DESCRIPTION
https://github.com/lgritz/OpenImageIO/commit/4cb956b0a0a123376e468a5b5e6e188178ec077e lost this removal when resolving a merge conflict. This properly removes it.

Signed-off-by: Thiago Ize

## Description
https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4076 implemented matrix44::inverse() so that we could stop including Imath.h. It removed the Imath.h include in the master/dev-2.6 branch but the dev-2.5 branch kept the include, likely because of an improperly resolved merge conflict. This PR removes the include like in master.

## Tests

No tests are needed. As long as it compiles, this should be good. I verified this builds on arm64.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
