### PR TITLE
build: CI sanitizer test improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,13 @@ jobs:
           - desc: sanitizers
             nametag: sanitizer
             runner: ubuntu-latest
-            container: aswf/ci-osl:2022-clang13
-            vfxyear: 2022
+            container: aswf/ci-osl:2024-clang17
+            vfxyear: 2024
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
             opencolorio_ver: v2.3.2
-            python_ver: 3.9
+            python_ver: "3.11"
             setenvs: export SANITIZE=address,undefined
                             OIIO_CMAKE_FLAGS="-DSANITIZE=address,undefined -DUSE_PYTHON=0"
                             CMAKE_BUILD_TYPE=Debug

--- a/Makefile
+++ b/Makefile
@@ -180,10 +180,6 @@ ifeq (${CODECOV},1)
   MY_CMAKE_FLAGS += -DCODECOV:BOOL=${CODECOV}
 endif
 
-ifneq (${SANITIZE},)
-  MY_CMAKE_FLAGS += -DSANITIZE=${SANITIZE}
-endif
-
 ifneq (${CLANG_TIDY},)
   MY_CMAKE_FLAGS += -DCLANG_TIDY:BOOL=1
 endif
@@ -360,7 +356,7 @@ help:
 	@echo "      USE_CCACHE=0             Disable ccache (even if available)"
 	@echo "      UNITY=BATCH              Do a 'Unity' build (BATCH or GROUP or nothing)"
 	@echo "      CODECOV=1                Enable code coverage tests"
-	@echo "      SANITIZE=name1,...       Enable sanitizers (address, leak, thread)"
+	@echo "      SANITIZE=name1,...       Enable sanitizers (address, leak, thread, undefined)"
 	@echo "      CLANG_TIDY=1             Run clang-tidy on all source (can be modified"
 	@echo "                                  by CLANG_TIDY_ARGS=... and CLANG_TIDY_FIX=1"
 	@echo "      CLANG_FORMAT_INCLUDES=... CLANG_FORMAT_EXCLUDES=..."

--- a/src/build-scripts/ubsan-suppressions.txt
+++ b/src/build-scripts/ubsan-suppressions.txt
@@ -1,0 +1,2 @@
+vptr:function.h
+vptr:openvdb::v11_0

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -423,7 +423,7 @@ endif ()
 ###########################################################################
 # Sanitizer options
 #
-set (SANITIZE "" CACHE STRING "Build code using sanitizer (address, thread)")
+set_cache (SANITIZE "" "Build code using sanitizer (address, thread, undefined)")
 if (SANITIZE AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
     message (STATUS "Compiling for sanitizer=${SANITIZE}")
     string (REPLACE "," ";" SANITIZE_FEATURE_LIST ${SANITIZE})


### PR DESCRIPTION
CI sanitizers in master have been failing lately. A different PR addresses the root cause, but this patch contains some improvements I made along the way while investigating it:

* CMake: Change the SANIIZE build variables to use set_cache, thus allowing easier override by env variable.

* Bumped the CI sanitizer test to use the 2024 container and latest compilers.

* Suppress UB warnings in STL function.h, where it's claiming undefined behavior in the std::function guts called by ArgParse internals. Only seen failing on my Mac, wasn't actually failing in the GHA CI. I'm pretty sure it's a false positive.

* Also, only on my Mac building against OpenVDB 11, it found some UB in OpenVDB, which I'm suppressing (I think it's also false positive).
