### PR TITLE
api: use shared_ptr for ImageCache and TextureSystem

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -356,8 +356,8 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
     // subimage appending, we gather them all first.
     std::vector<ImageSpec> subimagespecs;
     if (out->supports("multiimage") && !out->supports("appendsubimage")) {
-        ImageCache* imagecache = ImageCache::create();
-        int nsubimages         = 0;
+        auto imagecache = ImageCache::create();
+        int nsubimages  = 0;
         ustring ufilename(in_filename);
         imagecache->get_image_info(ufilename, 0, 0, ustring("subimages"),
                                    TypeInt, &nsubimages);
@@ -370,7 +370,6 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
                 adjust_spec(in.get(), out.get(), inspec, subimagespecs[i]);
             }
         }
-        ImageCache::destroy(imagecache);
     }
 
     bool ok                      = true;

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -419,7 +419,6 @@ main(int argc, char* argv[])
     }
 
     imagecache->invalidate_all(true);
-    imagecache.reset();  // Be sure to free cache before the shutdown below
     shutdown();
     return ret;
 }

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -119,8 +119,9 @@ getargs(int argc, char* argv[])
 
 
 static bool
-read_input(const std::string& filename, ImageBuf& img, ImageCache* cache,
-           int subimage = 0, int miplevel = 0)
+read_input(const std::string& filename, ImageBuf& img,
+           std::shared_ptr<ImageCache> cache, int subimage = 0,
+           int miplevel = 0)
 {
     if (img.subimage() >= 0 && img.subimage() == subimage
         && img.miplevel() == miplevel)
@@ -232,7 +233,7 @@ main(int argc, char* argv[])
 
     // Create a private ImageCache so we can customize its cache size
     // and instruct it store everything internally as floats.
-    ImageCache* imagecache = ImageCache::create(true);
+    std::shared_ptr<ImageCache> imagecache = ImageCache::create(true);
     imagecache->attribute("forcefloat", 1);
     if (sizeof(void*) == 4)  // 32 bit or 64?
         imagecache->attribute("max_memory_MB", 512.0);
@@ -418,7 +419,7 @@ main(int argc, char* argv[])
     }
 
     imagecache->invalidate_all(true);
-    ImageCache::destroy(imagecache);
+    imagecache.reset();
     shutdown();
     return ret;
 }

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -419,7 +419,7 @@ main(int argc, char* argv[])
     }
 
     imagecache->invalidate_all(true);
-    imagecache.reset();
+    imagecache.reset();  // Be sure to free cache before the shutdown below
     shutdown();
     return ret;
 }

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -77,7 +77,7 @@ enum class InitializePixels { No = 0, Yes = 1 };
 /// translate into a different data format than appears in the file).
 ///
 /// ImageBuf data coming from disk files may optionally be backed by
-/// ImageCache, by explicitly passing an `ImageCache*` to the ImageBuf
+/// ImageCache, by explicitly passing an ImageCache to the ImageBuf
 /// constructor or `reset()` method (pass `ImageCache::create()` to get a
 /// pointer to the default global ImageCache), or by having previously set the
 /// global OIIO attribute `"imagebuf:use_imagecache"` to a nonzero value. When
@@ -186,9 +186,9 @@ public:
     ///         ensure that it remains valid for the lifetime of the ImageBuf.
     ///
     explicit ImageBuf(string_view name, int subimage = 0, int miplevel = 0,
-                      ImageCache* imagecache       = nullptr,
-                      const ImageSpec* config      = nullptr,
-                      Filesystem::IOProxy* ioproxy = nullptr);
+                      std::shared_ptr<ImageCache> imagecache = {},
+                      const ImageSpec* config                = nullptr,
+                      Filesystem::IOProxy* ioproxy           = nullptr);
 
     /// Construct a writable ImageBuf with the given specification
     /// (including resolution, data type, metadata, etc.). The ImageBuf will
@@ -270,9 +270,9 @@ public:
     /// as if newly constructed with the same arguments, as a read-only
     /// representation of an existing image file.
     void reset(string_view name, int subimage = 0, int miplevel = 0,
-               ImageCache* imagecache       = nullptr,
-               const ImageSpec* config      = nullptr,
-               Filesystem::IOProxy* ioproxy = nullptr);
+               std::shared_ptr<ImageCache> imagecache = {},
+               const ImageSpec* config                = nullptr,
+               Filesystem::IOProxy* ioproxy           = nullptr);
 
     /// Destroy any previous contents of the ImageBuf and re-initialize it
     /// as if newly constructed with the same arguments, as a read/write
@@ -1005,9 +1005,9 @@ public:
     /// image being in RAM somewhere?
     bool cachedpixels() const;
 
-    /// A pointer to the underlying ImageCache, or nullptr if this ImageBuf
-    /// is not backed by an ImageCache.
-    ImageCache* imagecache() const;
+    /// A shared pointer to the underlying ImageCache, or empty if this
+    /// ImageBuf is not backed by an ImageCache.
+    std::shared_ptr<ImageCache> imagecache() const;
 
     /// Return the address where pixel `(x,y,z)`, channel `ch`, is stored in
     /// the image buffer.  Use with extreme caution!  Will return `nullptr`
@@ -1151,7 +1151,7 @@ public:
     // Deprecated things -- might be removed at any time
 
     OIIO_DEPRECATED("Use `ImageBuf(name, 0, 0, imagecache, nullptr)` (2.2)")
-    ImageBuf(string_view name, ImageCache* imagecache)
+    ImageBuf(string_view name, std::shared_ptr<ImageCache> imagecache)
         : ImageBuf(name, 0, 0, imagecache)
     {
     }
@@ -1164,7 +1164,7 @@ public:
     }
 
     OIIO_DEPRECATED("Use `reset(name, 0, 0, imagecache)` (2.2)")
-    void reset(string_view name, ImageCache* imagecache)
+    void reset(string_view name, std::shared_ptr<ImageCache> imagecache)
     {
         reset(name, 0, 0, imagecache);
     }

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -24,6 +24,9 @@
 // Does invalidate() support the optional `force` flag?
 #define OIIO_IMAGECACHE_INVALIDATE_FORCE 1
 
+// Does ImageCache::create() return a shared pointer?
+#define OIIO_IMAGECACHE_CREATE_SHARED 1
+
 
 
 OIIO_NAMESPACE_BEGIN
@@ -56,8 +59,7 @@ public:
     /// or destroy the concrete implementation, so two static methods of
     /// ImageCache are provided:
 
-    /// Create a ImageCache and return a raw pointer to it.  This should
-    /// only be freed by passing it to `ImageCache::destroy()`!
+    /// Create a ImageCache and return a shared pointer to it.
     ///
     /// @param  shared
     ///     If `true`, the pointer returned will be a shared ImageCache (so
@@ -66,22 +68,20 @@ public:
     ///     completely unique ImageCache will be created and returned.
     ///
     /// @returns
-    ///     A raw pointer to an ImageCache, which can only be freed with
+    ///     A shared pointer to an ImageCache, which can only be freed with
     ///     `ImageCache::destroy()`.
     ///
     /// @see    ImageCache::destroy
-    static ImageCache* create(bool shared = true);
+    static std::shared_ptr<ImageCache> create(bool shared = true);
 
-    /// Destroy an allocated ImageCache, including freeing all system
-    /// resources that it holds.
-    ///
-    /// It is safe to destroy even a shared ImageCache, as the implementation
-    /// of `destroy()` will recognize a shared one and only truly release
-    /// its resources if it has been requested to be destroyed as many times as
-    /// shared ImageCache's were created.
+    /// Release the shared_ptr to an ImageCache, including freeing all
+    /// system resources that it holds if no one else is still using it. This
+    /// is not strictly necessary to call, simply destroying the shared_ptr
+    /// will do the same thing, but this call is for backward compatibility
+    /// and is helpful if you want to use the teardown option.
     ///
     /// @param  cache
-    ///     Raw pointer to the ImageCache to destroy.
+    ///     Shared pointer to the ImageCache to destroy.
     ///
     /// @param  teardown
     ///     For a shared ImageCache, if the `teardown` parameter is
@@ -89,7 +89,7 @@ public:
     ///     nobody else is still holding a reference (otherwise, it will
     ///     leave it intact). This parameter has no effect if `cache` was
     ///     not the single globally shared ImageCache.
-    static void destroy(ImageCache* cache, bool teardown = false);
+    static void destroy(std::shared_ptr<ImageCache>& cache, bool teardown = false);
 
     /// @}
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -791,7 +791,7 @@ ImageViewer::readSettings(bool ui_is_set_up)
 
     OIIO::attribute("imagebuf:use_imagecache", 1);
 
-    ImageCache* imagecache = ImageCache::create(true);
+    auto imagecache = ImageCache::create(true);
     imagecache->attribute("automip", autoMipmap->isChecked());
     imagecache->attribute("max_memory_MB", (float)maxMemoryIC->value());
 }

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -124,7 +124,7 @@ main(int argc, char* argv[])
     mainWin->show();
 
     // Set up the imagecache with parameters that make sense for iv
-    ImageCache* imagecache = ImageCache::create(true);
+    auto imagecache = ImageCache::create(true);
     imagecache->attribute("autotile", 256);
     imagecache->attribute("deduplicate", (int)0);
     if (ap["no-autopremult"].get<int>())

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -89,7 +89,7 @@ set_roi_full(ImageSpec& spec, const ROI& newroi)
 class ImageBufImpl {
 public:
     ImageBufImpl(string_view filename, int subimage, int miplevel,
-                 ImageCache* imagecache = nullptr,
+                 std::shared_ptr<ImageCache> imagecache = {},
                  const ImageSpec* spec = nullptr, void* buffer = nullptr,
                  const ImageSpec* config      = nullptr,
                  Filesystem::IOProxy* ioproxy = nullptr,
@@ -100,7 +100,7 @@ public:
 
     void clear();
     void reset(string_view name, int subimage, int miplevel,
-               ImageCache* imagecache, const ImageSpec* config,
+               std::shared_ptr<ImageCache> imagecache, const ImageSpec* config,
                Filesystem::IOProxy* ioproxy);
     // Reset the buf to blank, given the spec. If nativespec is also
     // supplied, use it for the "native" spec, otherwise make the nativespec
@@ -252,7 +252,7 @@ public:
     // Invalidate the file in our imagecache and the shared one
     void invalidate(ustring filename, bool force)
     {
-        ImageCache* shared_imagecache = ImageCache::create(true);
+        auto shared_imagecache = ImageCache::create(true);
         OIIO_DASSERT(shared_imagecache);
         if (m_imagecache)
             m_imagecache->invalidate(filename, force);  // *our* IC
@@ -298,11 +298,11 @@ private:
     stride_t m_zstride;
     stride_t m_channel_stride;
     bool m_contiguous;
-    ImageCache* m_imagecache = nullptr;  ///< ImageCache to use
-    TypeDesc m_cachedpixeltype;          ///< Data type stored in the cache
-    DeepData m_deepdata;                 ///< Deep data
-    size_t m_allocated_size;             ///< How much memory we've allocated
-    std::vector<char> m_blackpixel;      ///< Pixel-sized zero bytes
+    std::shared_ptr<ImageCache> m_imagecache;  ///< ImageCache to use
+    TypeDesc m_cachedpixeltype;            ///< Data type stored in the cache
+    DeepData m_deepdata;                   ///< Deep data
+    size_t m_allocated_size;               ///< How much memory we've allocated
+    std::vector<char> m_blackpixel;        ///< Pixel-sized zero bytes
     std::vector<TypeDesc> m_write_format;  /// Pixel data format to use for write()
     int m_write_tile_width;
     int m_write_tile_height;
@@ -348,8 +348,9 @@ ImageBuf::impl_deleter(ImageBufImpl* todel)
 
 
 ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
-                           ImageCache* imagecache, const ImageSpec* spec,
-                           void* buffer, const ImageSpec* config,
+                           std::shared_ptr<ImageCache> imagecache,
+                           const ImageSpec* spec, void* buffer,
+                           const ImageSpec* config,
                            Filesystem::IOProxy* ioproxy, stride_t xstride,
                            stride_t ystride, stride_t zstride)
     : m_storage(ImageBuf::UNINITIALIZED)
@@ -503,8 +504,8 @@ ImageBuf::ImageBuf()
 
 
 ImageBuf::ImageBuf(string_view filename, int subimage, int miplevel,
-                   ImageCache* imagecache, const ImageSpec* config,
-                   Filesystem::IOProxy* ioproxy)
+                   std::shared_ptr<ImageCache> imagecache,
+                   const ImageSpec* config, Filesystem::IOProxy* ioproxy)
     : m_impl(new ImageBufImpl(filename, subimage, miplevel, imagecache,
                               nullptr /*spec*/, nullptr /*buffer*/, config,
                               ioproxy),
@@ -710,7 +711,7 @@ ImageBufImpl::clear()
     m_zstride        = 0;
     m_channel_stride = 0;
     m_contiguous     = false;
-    m_imagecache     = nullptr;
+    m_imagecache.reset();
     m_deepdata.free();
     m_blackpixel.clear();
     m_write_format.clear();
@@ -735,8 +736,8 @@ ImageBuf::clear()
 
 void
 ImageBufImpl::reset(string_view filename, int subimage, int miplevel,
-                    ImageCache* imagecache, const ImageSpec* config,
-                    Filesystem::IOProxy* ioproxy)
+                    std::shared_ptr<ImageCache> imagecache,
+                    const ImageSpec* config, Filesystem::IOProxy* ioproxy)
 {
     clear();
     m_name = ustring(filename);
@@ -768,7 +769,7 @@ ImageBufImpl::reset(string_view filename, int subimage, int miplevel,
 
 void
 ImageBuf::reset(string_view filename, int subimage, int miplevel,
-                ImageCache* imagecache, const ImageSpec* config,
+                std::shared_ptr<ImageCache> imagecache, const ImageSpec* config,
                 Filesystem::IOProxy* ioproxy)
 {
     m_impl->reset(filename, subimage, miplevel, imagecache, config, ioproxy);
@@ -899,7 +900,7 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
 
     // If we weren't given an imagecache but "imagebuf:use_imagecache"
     // attribute was set, use a shared IC.
-    if (m_imagecache == nullptr && pvt::imagebuf_use_imagecache)
+    if (!m_imagecache && pvt::imagebuf_use_imagecache)
         m_imagecache = ImageCache::create(true);
 
     if (m_imagecache) {
@@ -1849,7 +1850,7 @@ ImageBuf::cachedpixels() const
 
 
 
-ImageCache*
+std::shared_ptr<ImageCache>
 ImageBuf::imagecache() const
 {
     return m_impl->m_imagecache;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -402,7 +402,8 @@ ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
     } else if (filename.length() > 0) {
         // filename being nonempty means this ImageBuf refers to a file.
         OIIO_DASSERT(buffer == nullptr);
-        reset(filename, subimage, miplevel, imagecache, config, ioproxy);
+        reset(filename, subimage, miplevel, std::move(imagecache), config,
+              ioproxy);
     } else {
         OIIO_DASSERT(buffer == nullptr);
     }
@@ -506,9 +507,9 @@ ImageBuf::ImageBuf()
 ImageBuf::ImageBuf(string_view filename, int subimage, int miplevel,
                    std::shared_ptr<ImageCache> imagecache,
                    const ImageSpec* config, Filesystem::IOProxy* ioproxy)
-    : m_impl(new ImageBufImpl(filename, subimage, miplevel, imagecache,
-                              nullptr /*spec*/, nullptr /*buffer*/, config,
-                              ioproxy),
+    : m_impl(new ImageBufImpl(filename, subimage, miplevel,
+                              std::move(imagecache), nullptr /*spec*/,
+                              nullptr /*buffer*/, config, ioproxy),
              &impl_deleter)
 {
 }
@@ -748,7 +749,7 @@ ImageBufImpl::reset(string_view filename, int subimage, int miplevel,
     }
     m_current_subimage = subimage;
     m_current_miplevel = miplevel;
-    m_imagecache       = imagecache;
+    m_imagecache       = std::move(imagecache);
     if (config)
         m_configspec.reset(new ImageSpec(*config));
     m_rioproxy = ioproxy;
@@ -772,7 +773,8 @@ ImageBuf::reset(string_view filename, int subimage, int miplevel,
                 std::shared_ptr<ImageCache> imagecache, const ImageSpec* config,
                 Filesystem::IOProxy* ioproxy)
 {
-    m_impl->reset(filename, subimage, miplevel, imagecache, config, ioproxy);
+    m_impl->reset(filename, subimage, miplevel, std::move(imagecache), config,
+                  ioproxy);
 }
 
 

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -306,7 +306,7 @@ test_open_with_config()
 {
     // N.B. This function must run after ImageBuf_test_appbuffer, which
     // writes "A.tif".
-    ImageCache* ic = ImageCache::create(false);
+    auto ic = ImageCache::create(false);
     ImageSpec config;
     config.attribute("oiio:DebugOpenConfig!", 1);
     ImageBuf A("A_imagebuf_test.tif", 0, 0, ic, &config);
@@ -315,7 +315,6 @@ test_open_with_config()
     // Clear A because it would be unwise to let the ImageBuf outlive the
     // custom ImageCache we passed it to use.
     A.clear();
-    ic->destroy(ic);
 }
 
 

--- a/src/libOpenImageIO/imagecache_test.cpp
+++ b/src/libOpenImageIO/imagecache_test.cpp
@@ -53,7 +53,7 @@ static void
 test_get_pixels_errors()
 {
     Strutil::print("\nTesting get_pixels error handling\n");
-    ImageCache* ic = ImageCache::create();
+    std::shared_ptr<ImageCache> ic = ImageCache::create();
     float fpixels[4 * 4 * 3];
     const int fpixelsize = 3 * sizeof(float);
 
@@ -121,7 +121,7 @@ test_get_pixels_cachechannels(int chbegin = 0, int chend = 4,
     std::cout << "\nTesting IC get_pixels of chans [" << chbegin << "," << chend
               << ") with cache range [" << cache_chbegin << "," << cache_chend
               << "):\n";
-    ImageCache* imagecache = ImageCache::create(false /*not shared*/);
+    auto imagecache = ImageCache::create(false);
 
     // Create a 10 channel file
     ustring filename("tenchannels.tif");
@@ -151,8 +151,6 @@ test_get_pixels_cachechannels(int chbegin = 0, int chend = 4,
     }
     for (int c = 2 * nc; c < 2 * nchans; ++c)
         OIIO_CHECK_EQUAL(p[c], -1.0f);
-
-    ImageCache::destroy(imagecache);
 }
 
 
@@ -172,7 +170,7 @@ NullInputCreator()
 void
 test_app_buffer()
 {
-    ImageCache* imagecache = ImageCache::create(false /*not shared*/);
+    auto imagecache = ImageCache::create(false /*not shared*/);
 
     // Add a file entry with a "null" ImageInput proxy configured to look
     // like a 2x2 RGB float image.
@@ -226,8 +224,6 @@ test_app_buffer()
     OIIO_CHECK_EQUAL(testpixel[0], pixels[1][1][0]);
     OIIO_CHECK_EQUAL(testpixel[1], pixels[1][1][1]);
     OIIO_CHECK_EQUAL(testpixel[2], pixels[1][1][2]);
-
-    ImageCache::destroy(imagecache);
 }
 
 
@@ -236,8 +232,8 @@ void
 test_custom_threadinfo()
 {
     Strutil::print("\nTesting creating/destroying custom IC and thread info\n");
-    ImageCache* imagecache = ImageCache::create(true);
-    auto threadinfo        = imagecache->create_thread_info();
+    auto imagecache = ImageCache::create(true);
+    auto threadinfo = imagecache->create_thread_info();
     OIIO_CHECK_ASSERT(threadinfo != nullptr);
     imagecache->destroy_thread_info(threadinfo);
     imagecache->close_all();
@@ -249,7 +245,7 @@ void
 test_tileptr()
 {
     Strutil::print("\nTesting tile ptr things\n");
-    ImageCache* imagecache = ImageCache::create();
+    auto imagecache        = ImageCache::create();
     auto hand              = imagecache->get_image_handle(checkertex);
     ImageCache::Tile* tile = imagecache->get_tile(hand, nullptr, 0, 0, 4, 4, 0);
     OIIO_CHECK_ASSERT(tile != nullptr);
@@ -277,7 +273,7 @@ static void
 test_imagespec()
 {
     Strutil::print("\nTesting imagespec retrieval\n");
-    ImageCache* ic = ImageCache::create();
+    auto ic = ImageCache::create();
 
     {  // basic get_imagespec()
         ImageSpec spec;
@@ -350,7 +346,7 @@ main(int /*argc*/, char* /*argv*/[])
     test_custom_threadinfo();
     test_imagespec();
 
-    ImageCache* ic = ImageCache::create();
+    auto ic = ImageCache::create();
     Strutil::print("\n\n{}\n", ic->getstats(5));
     ic->reset_stats();
 

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -34,7 +34,7 @@ static std::string output_filename;
 static std::string output_format;
 static std::vector<char> buffer;
 static ImageSpec bufspec, outspec;
-static ImageCache* imagecache         = NULL;
+static std::shared_ptr<ImageCache> imagecache;
 static imagesize_t total_image_pixels = 0;
 static float cache_size               = 0;
 
@@ -611,6 +611,5 @@ main(int argc, char** argv)
     if (verbose)
         std::cout << "\n" << imagecache->getstats(2) << "\n";
 
-    ImageCache::destroy(imagecache);
     return unit_test_failures;
 }

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -37,7 +37,7 @@ class TextureSystemImpl final : public TextureSystem {
 public:
     typedef ImageCacheFile TextureFile;
 
-    TextureSystemImpl(ImageCache* imagecache);
+    TextureSystemImpl(std::shared_ptr<ImageCache> imagecache);
     ~TextureSystemImpl() override;
 
     bool attribute(string_view name, TypeDesc type, const void* val) override;
@@ -283,7 +283,10 @@ public:
 
     /// Return an opaque, non-owning pointer to the underlying ImageCache
     /// (if there is one).
-    ImageCache* imagecache() const override { return m_imagecache; }
+    std::shared_ptr<ImageCache> imagecache() const override
+    {
+        return m_imagecache_sp;
+    }
 
 private:
     typedef ImageCacheTileRef TileRef;
@@ -495,6 +498,7 @@ private:
     void visualize_ellipse(const std::string& name, float dsdx, float dtdx,
                            float dsdy, float dtdy, float sblur, float tblur);
 
+    std::shared_ptr<ImageCache> m_imagecache_sp;
     ImageCacheImpl* m_imagecache = nullptr;
     uint64_t m_id;                    // A unique ID for this TextureSystem
     Imath::M44f m_Mw2c;               ///< world-to-"common" matrix

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -502,7 +502,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
 
     if (ignore_unassoc) {
         configspec.attribute("maketx:ignore_unassoc", (int)ignore_unassoc);
-        ImageCache* ic = ImageCache::create();  // get the shared one
+        auto ic = ImageCache::create();  // get the shared one
         ic->attribute("unassociatedalpha", (int)ignore_unassoc);
     }
 
@@ -532,7 +532,7 @@ main(int argc, char* argv[])
     OIIO::attribute("threads", nthreads);
 
     // N.B. This will apply to the default IC that any ImageBuf's get.
-    ImageCache* ic = ImageCache::create();   // get the shared one
+    auto ic = ImageCache::create();          // get the shared one
     ic->attribute("forcefloat", 1);          // Force float upon read
     ic->attribute("max_memory_MB", 1024.0);  // 1 GB cache
 

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -182,7 +182,7 @@ ImageRec::ImageRec(ImageBufRef img, bool copy_pixels)
 
 
 ImageRec::ImageRec(const std::string& name, const ImageSpec& spec,
-                   ImageCache* imagecache)
+                   std::shared_ptr<ImageCache> imagecache)
     : m_name(name)
     , m_elaborated(true)
     , m_pixels_modified(true)

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -140,7 +140,7 @@ public:
     ImageRecRef curimg;                    // current image
     std::vector<ImageRecRef> image_stack;  // stack of previous images
     std::map<std::string, ImageRecRef> image_labels;  // labeled images
-    ImageCache* imagecache = nullptr;                 // back ptr to ImageCache
+    std::shared_ptr<ImageCache> imagecache;           // back ptr to ImageCache
     ColorConfig colorconfig;                          // OCIO color config
     Timer total_runtime;
     // total_readtime is the amount of time for direct reads, and does not
@@ -434,7 +434,7 @@ private:
 /// and potentially MIPmap levels for each subimage.
 class ImageRec {
 public:
-    ImageRec(const std::string& name, ImageCache* imagecache)
+    ImageRec(const std::string& name, std::shared_ptr<ImageCache> imagecache)
         : m_name(name)
         , m_imagecache(imagecache)
     {
@@ -471,7 +471,7 @@ public:
 
     // Initialize an ImageRec with the given spec.
     ImageRec(const std::string& name, const ImageSpec& spec,
-             ImageCache* imagecache);
+             std::shared_ptr<ImageCache> imagecache);
 
     ImageRec(const ImageRec& copy) = delete;  // Disallow copy ctr
 
@@ -618,7 +618,7 @@ private:
     std::vector<SubimageRec> m_subimages;
     std::time_t m_time;  //< Modification time of the input file
     TypeDesc m_input_dataformat;
-    ImageCache* m_imagecache = nullptr;
+    std::shared_ptr<ImageCache> m_imagecache;
     mutable std::string m_err;
     std::unique_ptr<ImageSpec> m_configspec;
 

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -9,10 +9,7 @@ namespace PyOpenImageIO {
 // Make a special wrapper to help with the weirdo way we use create/destroy.
 class ImageCacheWrap {
 public:
-    struct ICDeleter {
-        void operator()(ImageCache* p) const { ImageCache::destroy(p); }
-    };
-    std::unique_ptr<ImageCache, ICDeleter> m_cache;
+    std::shared_ptr<ImageCache> m_cache;
 
     ImageCacheWrap(bool shared = true)
         : m_cache(ImageCache::create(shared))
@@ -23,7 +20,7 @@ public:
     ~ImageCacheWrap() {}  // will call the deleter on the IC
     static void destroy(ImageCacheWrap* x, bool teardown = false)
     {
-        ImageCache::destroy(x->m_cache.release(), teardown);
+        ImageCache::destroy(x->m_cache, teardown);
     }
     py::object get_pixels(const std::string& filename, int subimage,
                           int miplevel, int xbegin, int xend, int ybegin,

--- a/src/python/py_texturesys.cpp
+++ b/src/python/py_texturesys.cpp
@@ -44,14 +44,11 @@ public:
 // Make a special wrapper to help with the weirdo way we use create/destroy.
 class TextureSystemWrap {
 public:
-    struct TSDeleter {
-        void operator()(TextureSystem* p) const { TextureSystem::destroy(p); }
-    };
-    std::unique_ptr<TextureSystem, TSDeleter> m_texsys;
+    std::shared_ptr<TextureSystem> m_texsys;
 
 
     TextureSystemWrap(bool shared = true)
-        : m_texsys(TextureSystem::create(shared, nullptr))
+        : m_texsys(TextureSystem::create(shared))
     {
     }
     TextureSystemWrap(const TextureSystemWrap&) = delete;
@@ -59,7 +56,7 @@ public:
     ~TextureSystemWrap() {}  // will call the deleter on the m_texsys
     static void destroy(TextureSystemWrap* x)
     {
-        TextureSystem::destroy(x->m_texsys.release());
+        TextureSystem::destroy(x->m_texsys);
     }
 };
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -56,7 +56,7 @@ static bool test_construction   = false;
 static bool test_gettexels      = false;
 static bool test_getimagespec   = false;
 static bool filtertest          = false;
-static TextureSystem* texsys    = NULL;
+static std::shared_ptr<TextureSystem> texsys;
 static std::string searchpath;
 static bool batch         = false;
 static bool nowarp        = false;
@@ -1649,7 +1649,7 @@ test_icwrite(int testicwrite)
 
     // The global "shared" ImageCache will be the same one the
     // TextureSystem uses.
-    ImageCache* ic = ImageCache::create();
+    std::shared_ptr<ImageCache> ic = ImageCache::create();
 
     // Set up the fake file and add it
     int tw = 64, th = 64;  // tile width and height


### PR DESCRIPTION
Change IC::create() and TS::create() to return shared_ptr instead of a raw pointer. This cleans up a lot of lingering lifetime management issue of these classes. The switch to 3.0 is an opportunity to make breaking changes to these APIs.

For the sake of downstream users, we define preprocessor symbols
OIIO_IMAGECACHE_CREATE_SHARED and OIIO_TEXTURESYSTEM_CREATE_SHARED to signal that the new APIs are present. Some very minor changes may be needed at the call site.
