### PR TITLE
build(deps): Raise libheif minimum to 1.11

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,10 +59,9 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for GIF images:
      * **giflib >= 5.0** (tested through 5.2)
  * If you want support for HEIF/HEIC or AVIF images:
-     * libheif >= 1.3 (1.7 required for AVIF support, 1.16 required for
-       correct orientation support, tested through 1.17.6)
+     * **libheif >= 1.11** (1.16 required for correct orientation support,
+       tested through 1.18.2)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.
-     * Avoid libheif 1.10 on Mac, it is very broken. Libheif 1.11+ is fine.
  * If you want support for DICOM medical image files:
      * DCMTK >= 3.6.1 (tested through 3.6.8)
  * If you want support for WebP images:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -156,13 +156,9 @@ checked_find_package (FFmpeg VERSION_MIN 4.0)
 checked_find_package (GIF VERSION_MIN 5.0)
 
 # For HEIF/HEIC/AVIF formats
-checked_find_package (Libheif VERSION_MIN 1.3
+checked_find_package (Libheif VERSION_MIN 1.11
                       RECOMMEND_MIN 1.16
                       RECOMMEND_MIN_REASON "for orientation support")
-if (APPLE AND LIBHEIF_VERSION VERSION_GREATER_EQUAL 1.10 AND LIBHEIF_VERSION VERSION_LESS 1.11)
-    message (WARNING "Libheif 1.10 on Apple is known to be broken, disabling libheif support")
-    set (Libheif_FOUND 0)
-endif ()
 
 checked_find_package (LibRaw
                       VERSION_MIN 0.20.0

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -38,9 +38,7 @@ public:
     {
         return feature == "exif";
     }
-#if LIBHEIF_HAVE_VERSION(1, 4, 0)
     bool valid_file(const std::string& filename) const override;
-#endif
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -98,17 +96,12 @@ heif_input_imageio_create()
     return new HeifInput;
 }
 
-OIIO_EXPORT const char* heif_input_extensions[] = { "heic",  "heif",
-                                                    "heics", "hif",
-#if LIBHEIF_HAVE_VERSION(1, 7, 0)
-                                                    "avif",
-#endif
-                                                    nullptr };
+OIIO_EXPORT const char* heif_input_extensions[] = { "heic", "heif", "heics",
+                                                    "hif",  "avif", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 
 
-#if LIBHEIF_HAVE_VERSION(1, 4, 0)
 bool
 HeifInput::valid_file(const std::string& filename) const
 {
@@ -120,7 +113,6 @@ HeifInput::valid_file(const std::string& filename) const
     return filetype_check != heif_filetype_no
            && filetype_check != heif_filetype_yes_unsupported;
 }
-#endif
 
 
 

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -81,12 +81,8 @@ heif_output_imageio_create()
     return new HeifOutput;
 }
 
-OIIO_EXPORT const char* heif_output_extensions[] = { "heif",  "heic",
-                                                     "heics", "hif",
-#if LIBHEIF_HAVE_VERSION(1, 7, 0)
-                                                     "avif",
-#endif
-                                                     nullptr };
+OIIO_EXPORT const char* heif_output_extensions[] = { "heif", "heic", "heics",
+                                                     "hif",  "avif", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 
@@ -116,14 +112,12 @@ HeifOutput::open(const std::string& name, const ImageSpec& newspec,
                            newspec.height, 8 * m_spec.nchannels /*bit depth*/);
 
         m_encoder = heif::Encoder(heif_compression_HEVC);
-#if LIBHEIF_HAVE_VERSION(1, 7, 0)
         auto compqual  = m_spec.decode_compression_metadata("", 75);
         auto extension = Filesystem::extension(m_filename);
         if (compqual.first == "avif"
             || (extension == ".avif" && compqual.first == "")) {
             m_encoder = heif::Encoder(heif_compression_AV1);
         }
-#endif
     } catch (const heif::Error& err) {
         std::string e = err.get_message();
         errorfmt("{}", e.empty() ? "unknown exception" : e.c_str());

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -111,7 +111,7 @@ HeifOutput::open(const std::string& name, const ImageSpec& newspec,
         m_himage.add_plane(heif_channel_interleaved, newspec.width,
                            newspec.height, 8 * m_spec.nchannels /*bit depth*/);
 
-        m_encoder = heif::Encoder(heif_compression_HEVC);
+        m_encoder      = heif::Encoder(heif_compression_HEVC);
         auto compqual  = m_spec.decode_compression_metadata("", 75);
         auto extension = Filesystem::extension(m_filename);
         if (compqual.first == "avif"


### PR DESCRIPTION
This version dates from early 2021 (so still supporting back 3.5 years).

The reason for the bump is to simplify a bit on our part and avoid older versions known to be broken or lacking certain features.

This is for master/2.6/3.0 only, will not be backported to 2.5, since we never raise minimum dependencies in already-released branches.
