### PR TITLE
fix for setenv() on Windows

### DIFF
--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -75,6 +75,7 @@ getargs(int argc, char* argv[])
       .action(ArgParse::store());
     
     ap.parse(argc, (const char**)argv);
+    // clang-format on
     return ap;
 }
 
@@ -113,13 +114,13 @@ main(int argc, char* argv[])
     std::string view        = ap["view"].as_string("");
     //    std::string look = ap["look"].as_string("");
     
-    bool use_ocio = color_space != "" && display != "" && view != "";
+    bool use_ocio       = color_space != "" && display != "" && view != "";
     std::string ocioenv = Sysutil::getenv("OCIO");
     if (ocioenv.empty() || !Filesystem::exists(ocioenv)) {
 #ifdef _MSC_VER
-    _putenv_s("OCIO", "ocio://default");
+        _putenv_s("OCIO", "ocio://default");
 #else
-    setenv("OCIO", "ocio://default", 1);
+        setenv("OCIO", "ocio://default", 1);
 #endif
     }
 

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -115,8 +115,13 @@ main(int argc, char* argv[])
     
     bool use_ocio = color_space != "" && display != "" && view != "";
     std::string ocioenv = Sysutil::getenv("OCIO");
-    if (ocioenv.empty() || !Filesystem::exists(ocioenv))
-        setenv("OCIO", "ocio://default", 1);
+    if (ocioenv.empty() || !Filesystem::exists(ocioenv)) {
+#ifdef _MSC_VER
+    _putenv_s("OCIO", "ocio://default");
+#else
+    setenv("OCIO", "ocio://default", 1);
+#endif
+    }
 
     ImageViewer* mainWin = new ImageViewer(use_ocio, color_space, display, 
                                            view);

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -75,7 +75,6 @@ getargs(int argc, char* argv[])
       .action(ArgParse::store());
     
     ap.parse(argc, (const char**)argv);
-    // clang-format on
     return ap;
 }
 


### PR DESCRIPTION
## Description
Microsoft's runtime library doesn't support the standard setenv() function. _putenv_s() should be used instead.

Without fix iv do not compiling:
`E:\GH\OpenImageIO\src\iv\ivmain.cpp(119,9): error C3861: 'setenv': identifier not found [E:\GH\OpenImageIO\build\src\iv\iv.vcxproj]`

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
