### PR TITLE
style: Turn on clang-format for ivmain.cpp

### DIFF
--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -76,6 +76,7 @@ getargs(int argc, char* argv[])
     
     ap.parse(argc, (const char**)argv);
     return ap;
+    // clang-format on
 }
 
 
@@ -107,12 +108,12 @@ main(int argc, char* argv[])
     // LG
     //    Q_INIT_RESOURCE(iv);
     QApplication app(argc, argv);
-    
+
     std::string color_space = ap["image-color-space"].as_string("");
     std::string display     = ap["display"].as_string("");
     std::string view        = ap["view"].as_string("");
     //    std::string look = ap["look"].as_string("");
-    
+
     bool use_ocio       = color_space != "" && display != "" && view != "";
     std::string ocioenv = Sysutil::getenv("OCIO");
     if (ocioenv.empty() || !Filesystem::exists(ocioenv)) {
@@ -123,9 +124,9 @@ main(int argc, char* argv[])
 #endif
     }
 
-    ImageViewer* mainWin = new ImageViewer(use_ocio, color_space, display, 
+    ImageViewer* mainWin = new ImageViewer(use_ocio, color_space, display,
                                            view);
-    
+
     mainWin->show();
 
     // Set up the imagecache with parameters that make sense for iv
@@ -142,19 +143,20 @@ main(int argc, char* argv[])
     mainWin->activateWindow();
 
     ustring uexists("exists");
-    std::vector<std::string> extensionsVector; // Vector to hold all extensions
+    std::vector<std::string> extensionsVector;  // Vector to hold all extensions
     auto all_extensions = OIIO::get_string_attribute("extension_list");
-    for (auto oneformat : OIIO::Strutil::splitsv(all_extensions, ";")) { // Split the extensions by semicolon
+    for (auto oneformat : OIIO::Strutil::splitsv(all_extensions, ";")) {
+        // Split the extensions by semicolon
         auto format_exts = OIIO::Strutil::splitsv(oneformat, ":", 2);
         for (auto ext : OIIO::Strutil::splitsv(format_exts[1], ","))
-            extensionsVector.emplace_back(ext); 
+            extensionsVector.emplace_back(ext);
     }
 
     // Add the images
     for (auto& f : ap["filename"].as_vec<std::string>()) {
         // Check if the file exists
         if (!Filesystem::exists(f)) {
-            std::cerr << "Error: File or directory does not exist: " << f << "\n";
+            print(stderr, "Error: File or directory does not exist: {}\n", f);
             continue;
         }
 
@@ -165,26 +167,33 @@ main(int argc, char* argv[])
 
             std::vector<std::string> validImages;  // Vector to hold valid images
             for (auto& file : files) {
-                std::string extension = Filesystem::extension(file).substr(1);  // Remove the leading dot
-                if (std::find(extensionsVector.begin(), extensionsVector.end(), extension) != extensionsVector.end()) {
+                std::string extension = Filesystem::extension(file).substr(
+                    1);  // Remove the leading dot
+                if (std::find(extensionsVector.begin(), extensionsVector.end(),
+                              extension)
+                    != extensionsVector.end()) {
                     int exists = 0;
-                    bool ok = imagecache->get_image_info(ustring(file), 0, 0, uexists, OIIO::TypeInt, &exists);
+                    bool ok    = imagecache->get_image_info(ustring(file), 0, 0,
+                                                            uexists, OIIO::TypeInt,
+                                                            &exists);
                     if (ok && exists)
                         validImages.push_back(file);
                 }
             }
 
             if (validImages.empty()) {
-                std::cerr << "Error: No valid images found in directory: " << f << "\n";
+                print(stderr, "Error: No valid images found in directory: {}\n",
+                      f);
             } else {
-                std::sort(validImages.begin(), validImages.end()); // Sort the valid images lexicographically
+                // Sort the valid images lexicographically
+                std::sort(validImages.begin(), validImages.end());
                 for (auto& validImage : validImages) {
                     mainWin->add_image(validImage);
                 }
             }
         } else {
             mainWin->add_image(f);
-        } 
+        }
     }
 
     mainWin->current_image(0);
@@ -198,10 +207,8 @@ main(int argc, char* argv[])
 #endif
     {
         size_t mem = Sysutil::memory_used(true);
-        std::cout << "iv total memory used: " << Strutil::memformat(mem)
-                  << "\n";
-        std::cout << "\n";
-        std::cout << imagecache->getstats(1 + verbose) << "\n";
+        print("iv total memory used: {}\n\n", Strutil::memformat(mem));
+        print("{}\n", imagecache->getstats(1 + verbose));
     }
     shutdown();
     return r;


### PR DESCRIPTION
It was disabled to make prettier formatting for getargs, but neglected to turn it back on for the rest of the file.

I also changed a few old `<<` stream output to `print()`.
