### PR TITLE
Fix typo where apostrophe was used for possessive of 'it'

### DIFF
--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -145,7 +145,7 @@ IffInput::open(const std::string& name, ImageSpec& spec)
     // limited to images.
     //
     // The openimageio IFF implementation deals specifically with Maya IFF
-    // images with it's data blocks structured as follows:
+    // images with its data blocks structured as follows:
     //
     // Header:
     // FOR4 <size> CIMG

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -134,7 +134,7 @@ IffOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     // limited to images.
     //
     // The openimageio IFF implementation deals specifically with Maya IFF
-    // images with it's data blocks structured as follows:
+    // images with its data blocks structured as follows:
     //
     // Header:
     // FOR4 <size> CIMG

--- a/src/iff.imageio/noproxy-iffinput.cpp
+++ b/src/iff.imageio/noproxy-iffinput.cpp
@@ -43,7 +43,7 @@ IffInput::open(const std::string& name, ImageSpec& spec)
     // limited to images.
     //
     // The openimageio IFF implementation deals specifically with Maya IFF
-    // images with it's data blocks structured as follows:
+    // images with its data blocks structured as follows:
     //
     // Header:
     // FOR4 <size> CIMG

--- a/src/iff.imageio/noproxy-iffoutput.cpp
+++ b/src/iff.imageio/noproxy-iffoutput.cpp
@@ -43,7 +43,7 @@ IffOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     // limited to images.
     //
     // The openimageio IFF implementation deals specifically with Maya IFF
-    // images with it's data blocks structured as follows:
+    // images with its data blocks structured as follows:
     //
     // Header:
     // FOR4 <size> CIMG


### PR DESCRIPTION
## Description

Nominally, fix four places where "it's" was used when "its" was appropriate. Realistically, force the EasyCLA dialog so that I can get an individual CLA in place, my employment with ARRI having terminated on 15 July of this year.

## Tests

Did not add a test; this was a removal of a typo in a comment, repeated across four files.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
