### PR TITLE
refactor: de-virtualize IC and TS

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -25,10 +25,7 @@ OIIO_NAMESPACE_BEGIN
 class ImageBuf;
 class ImageBufImpl;  // Opaque type for the unique_ptr.
 class ImageCache;
-
-namespace pvt {
 class ImageCacheTile;
-};  // namespace pvt
 
 
 
@@ -1369,7 +1366,7 @@ public:
         int m_rng_xbegin, m_rng_xend, m_rng_ybegin, m_rng_yend, m_rng_zbegin,
             m_rng_zend;
         int m_x, m_y, m_z;
-        pvt::ImageCacheTile* m_tile = nullptr;
+        ImageCacheTile* m_tile = nullptr;
         int m_tilexbegin, m_tileybegin, m_tilezbegin;
         int m_tilexend;
         int m_nchannels;
@@ -1638,7 +1635,7 @@ protected:
     // tile for the given pixel, and return the ptr to the actual pixel
     // within the tile. If any read errors occur, set haderror=true (but
     // if there are no errors, do not modify haderror).
-    const void* retile(int x, int y, int z, pvt::ImageCacheTile*& tile,
+    const void* retile(int x, int y, int z, ImageCacheTile*& tile,
                        int& tilexbegin, int& tileybegin, int& tilezbegin,
                        int& tilexend, bool& haderr, bool exists,
                        WrapMode wrap) const;

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -45,11 +45,11 @@ OIIO_NAMESPACE_BEGIN
 // Forward declarations
 
 class ImageCache;
+class TextureSystemImpl;
 
 
 namespace pvt {
 
-class TextureSystemImpl;
 
 // Used internally by TextureSystem.  Unfortunately, this is the only
 // clean place to store it.  Sorry, users, this isn't really for you.
@@ -295,7 +295,7 @@ private:
     // Options set INTERNALLY by libtexture after the options are passed
     // by the user.  Users should not attempt to alter these!
     int envlayout;  // Layout for environment wrap
-    friend class pvt::TextureSystemImpl;
+    friend class TextureSystemImpl;
 };
 
 
@@ -347,8 +347,11 @@ private:
     // by the user.  Users should not attempt to alter these!
     int envlayout = 0;               // Layout for environment wrap
 
-    friend class pvt::TextureSystemImpl;
+    friend class TextureSystemImpl;
 };
+
+
+// clang-format on
 
 
 
@@ -391,8 +394,8 @@ public:
     ///     when the last shared_ptr to it is destroyed.
     ///
     /// @see    TextureSystem::destroy
-    static std::shared_ptr<TextureSystem> create(bool shared=true,
-                                 std::shared_ptr<ImageCache> imagecache = {});
+    static std::shared_ptr<TextureSystem>
+    create(bool shared = true, std::shared_ptr<ImageCache> imagecache = {});
 
     /// Release the shared_ptr to a TextureSystem, including freeing all
     /// system resources that it holds if no one else is still using it. This
@@ -566,15 +569,30 @@ public:
     ///                 (including it being an unrecognized attribute or not
     ///                 of the correct type).
     ///
-    virtual bool attribute (string_view name, TypeDesc type, const void *val) = 0;
+    bool attribute(string_view name, TypeDesc type, const void* val);
 
     /// Specialized `attribute()` for setting a single `int` value.
-    virtual bool attribute (string_view name, int val) = 0;
+    bool attribute(string_view name, int val)
+    {
+        return attribute(name, TypeInt, &val);
+    }
     /// Specialized `attribute()` for setting a single `float` value.
-    virtual bool attribute (string_view name, float val) = 0;
-    virtual bool attribute (string_view name, double val) = 0;
+    bool attribute(string_view name, float val)
+    {
+        return attribute(name, TypeFloat, &val);
+    }
+    bool attribute(string_view name, double val)
+    {
+        float f = (float)val;
+        return attribute(name, TypeFloat, &f);
+    }
     /// Specialized `attribute()` for setting a single string value.
-    virtual bool attribute (string_view name, string_view val) = 0;
+    bool attribute(string_view name, string_view val)
+    {
+        std::string valstr(val);
+        const char* s = valstr.c_str();
+        return attribute(name, TypeDesc::STRING, &s);
+    }
 
     /// Get the named attribute of the texture system, store it in `*val`.
     /// All of the attributes that may be set with the `attribute() call`
@@ -610,26 +628,48 @@ public:
     ///                 attribute was retrieved, or `false` upon failure
     ///                 (including it being an unrecognized attribute or not
     ///                 of the correct type).
-    virtual bool getattribute (string_view name,
-                               TypeDesc type, void *val) const = 0;
+    bool getattribute(string_view name, TypeDesc type, void* val) const;
 
     /// Specialized `attribute()` for retrieving a single `int` value.
-    virtual bool getattribute(string_view name, int& val) const = 0;
+    bool getattribute(string_view name, int& val) const
+    {
+        return getattribute(name, TypeInt, &val);
+    }
     /// Specialized `attribute()` for retrieving a single `float` value.
-    virtual bool getattribute(string_view name, float& val) const = 0;
-    virtual bool getattribute(string_view name, double& val) const = 0;
+    bool getattribute(string_view name, float& val) const
+    {
+        return getattribute(name, TypeFloat, &val);
+    }
+    bool getattribute(string_view name, double& val) const
+    {
+        float f;
+        bool ok = getattribute(name, TypeFloat, &f);
+        if (ok)
+            val = f;
+        return ok;
+    }
     /// Specialized `attribute()` for retrieving a single `string` value
     /// as a `char*`.
-    virtual bool getattribute(string_view name, char** val) const = 0;
+    bool getattribute(string_view name, char** val) const
+    {
+        return getattribute(name, TypeString, val);
+    }
     /// Specialized `attribute()` for retrieving a single `string` value
     /// as a `std::string`.
-    virtual bool getattribute(string_view name, std::string& val) const = 0;
+    bool getattribute(string_view name, std::string& val) const
+    {
+        const char* s;
+        bool ok = getattribute(name, TypeString, &s);
+        if (ok)
+            val = s;
+        return ok;
+    }
 
     /// If the named attribute is known, return its data type. If no such
     /// attribute exists, return `TypeUnknown`.
     ///
     /// This was added in version 2.5.
-    virtual TypeDesc getattributetype (string_view name) const = 0;
+    TypeDesc getattributetype(string_view name) const;
 
     /// @}
 
@@ -680,14 +720,14 @@ public:
     /// thread_info is not nullptr, it won't create a new one or retrieve a
     /// TSP, but it will do other necessary housekeeping on the Perthread
     /// information.
-    virtual Perthread* get_perthread_info(Perthread* thread_info = nullptr) = 0;
+    Perthread* get_perthread_info(Perthread* thread_info = nullptr);
 
     /// Create a new Perthread. It is the caller's responsibility to
     /// eventually destroy it using `destroy_thread_info()`.
-    virtual Perthread* create_thread_info() = 0;
+    Perthread* create_thread_info();
 
     /// Destroy a Perthread that was allocated by `create_thread_info()`.
-    virtual void destroy_thread_info(Perthread* threadinfo) = 0;
+    void destroy_thread_info(Perthread* threadinfo);
 
     /// Define an opaque data type that allows us to have a handle to a
     /// texture (already having its name resolved) but without exposing
@@ -700,13 +740,14 @@ public:
     /// (currently: the colorspace). The opaque pointer `thread_info` is
     /// thread-specific information returned by `get_perthread_info()`. Return
     /// nullptr if something has gone horribly wrong.
-    virtual TextureHandle* get_texture_handle(ustring filename,
-                                      Perthread* thread_info = nullptr,
-                                      const TextureOpt* options = nullptr) = 0;
+    TextureHandle* get_texture_handle(ustring filename,
+                                      Perthread* thread_info    = nullptr,
+                                      const TextureOpt* options = nullptr);
     /// Get a TextureHandle using a UTF-16 encoded wstring filename.
     TextureHandle* get_texture_handle(const std::wstring& filename,
-                                      Perthread* thread_info = nullptr,
-                                      const TextureOpt* options = nullptr) {
+                                      Perthread* thread_info    = nullptr,
+                                      const TextureOpt* options = nullptr)
+    {
         return get_texture_handle(ustring(Strutil::utf16_to_utf8(filename)),
                                   thread_info, options);
     }
@@ -714,21 +755,19 @@ public:
     /// Return true if the texture handle (previously returned by
     /// `get_image_handle()`) is a valid texture that can be subsequently
     /// read.
-    virtual bool good(TextureHandle* texture_handle) = 0;
+    bool good(TextureHandle* texture_handle);
 
     /// Given a handle, return the UTF-8 encoded filename for that texture.
     ///
     /// This method was added in OpenImageIO 2.3.
-    virtual ustring filename_from_handle(TextureHandle* handle) = 0;
+    ustring filename_from_handle(TextureHandle* handle);
 
     /// Retrieve an id for a color transformation by name. This ID can be used
     /// as the value for TextureOpt::colortransformid. The returned value will
     /// be -1 if either color space is unknown, and 0 for a null
     /// transformation.
-    virtual int get_colortransform_id(ustring fromspace,
-                                      ustring tospace) const = 0;
-    virtual int get_colortransform_id(ustringhash fromspace,
-                                      ustringhash tospace) const = 0;
+    int get_colortransform_id(ustring fromspace, ustring tospace) const;
+    int get_colortransform_id(ustringhash fromspace, ustringhash tospace) const;
     /// @}
 
     /// @{
@@ -812,20 +851,17 @@ public:
     ///             found or could not be opened by any available ImageIO
     ///             plugin.
     ///
-    virtual bool texture (ustring filename, TextureOpt &options,
-                          float s, float t, float dsdx, float dtdx,
-                          float dsdy, float dtdy,
-                          int nchannels, float *result,
-                          float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    bool texture(ustring filename, TextureOpt& options, float s, float t,
+                 float dsdx, float dtdx, float dsdy, float dtdy, int nchannels,
+                 float* result, float* dresultds = nullptr,
+                 float* dresultdt = nullptr);
 
     /// Slightly faster version of texture() lookup if the app already has a
     /// texture handle and per-thread info.
-    virtual bool texture (TextureHandle *texture_handle,
-                          Perthread *thread_info, TextureOpt &options,
-                          float s, float t, float dsdx, float dtdx,
-                          float dsdy, float dtdy,
-                          int nchannels, float *result,
-                          float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    bool texture(TextureHandle* texture_handle, Perthread* thread_info,
+                 TextureOpt& options, float s, float t, float dsdx, float dtdx,
+                 float dsdy, float dtdy, int nchannels, float* result,
+                 float* dresultds = nullptr, float* dresultdt = nullptr);
 
 
     /// Perform a filtered 3D volumetric texture lookup on a position
@@ -907,40 +943,19 @@ public:
     ///             found or could not be opened by any available ImageIO
     ///             plugin.
     ///
-    virtual bool texture3d (ustring filename, TextureOpt &options,
-                            V3fParam P, V3fParam dPdx,
-                            V3fParam dPdy, V3fParam dPdz,
-                            int nchannels, float *result,
-                            float *dresultds=nullptr, float *dresultdt=nullptr,
-                            float *dresultdr=nullptr) = 0;
+    bool texture3d(ustring filename, TextureOpt& options, V3fParam P,
+                   V3fParam dPdx, V3fParam dPdy, V3fParam dPdz, int nchannels,
+                   float* result, float* dresultds = nullptr,
+                   float* dresultdt = nullptr, float* dresultdr = nullptr);
 
     /// Slightly faster version of texture3d() lookup if the app already has
     /// a texture handle and per-thread info.
-    virtual bool texture3d (TextureHandle *texture_handle,
-                            Perthread *thread_info, TextureOpt &options,
-                            V3fParam P, V3fParam dPdx,
-                            V3fParam dPdy, V3fParam dPdz,
-                            int nchannels, float *result,
-                            float *dresultds=nullptr, float *dresultdt=nullptr,
-                            float *dresultdr=nullptr) = 0;
+    bool texture3d(TextureHandle* texture_handle, Perthread* thread_info,
+                   TextureOpt& options, V3fParam P, V3fParam dPdx,
+                   V3fParam dPdy, V3fParam dPdz, int nchannels, float* result,
+                   float* dresultds = nullptr, float* dresultdt = nullptr,
+                   float* dresultdr = nullptr);
 
-
-    // Retrieve a shadow lookup for a single position P.
-    //
-    // Return true if the file is found and could be opened by an
-    // available ImageIO plugin, otherwise return false.
-    virtual bool shadow (ustring filename, TextureOpt &options,
-                         V3fParam P, V3fParam dPdx,
-                         V3fParam dPdy, float *result,
-                         float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
-
-    // Slightly faster version of texture3d() lookup if the app already
-    // has a texture handle and per-thread info.
-    virtual bool shadow (TextureHandle *texture_handle, Perthread *thread_info,
-                         TextureOpt &options,
-                         V3fParam P, V3fParam dPdx,
-                         V3fParam dPdy, float *result,
-                         float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
 
     /// Perform a filtered directional environment map lookup in the
     /// direction of vector `R`, from the texture identified by `filename`,
@@ -998,18 +1013,16 @@ public:
     ///             `true` upon success, or `false` if the file was not
     ///             found or could not be opened by any available ImageIO
     ///             plugin.
-    virtual bool environment (ustring filename, TextureOpt &options,
-                              V3fParam R, V3fParam dRdx,
-                              V3fParam dRdy, int nchannels, float *result,
-                              float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    bool environment(ustring filename, TextureOpt& options, V3fParam R,
+                     V3fParam dRdx, V3fParam dRdy, int nchannels, float* result,
+                     float* dresultds = nullptr, float* dresultdt = nullptr);
 
     /// Slightly faster version of environment() if the app already has a
     /// texture handle and per-thread info.
-    virtual bool environment (TextureHandle *texture_handle,
-                              Perthread *thread_info, TextureOpt &options,
-                              V3fParam R, V3fParam dRdx,
-                              V3fParam dRdy, int nchannels, float *result,
-                              float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    bool environment(TextureHandle* texture_handle, Perthread* thread_info,
+                     TextureOpt& options, V3fParam R, V3fParam dRdx,
+                     V3fParam dRdy, int nchannels, float* result,
+                     float* dresultds = nullptr, float* dresultdt = nullptr);
 
     /// @}
 
@@ -1063,23 +1076,19 @@ public:
     ///             found or could not be opened by any available ImageIO
     ///             plugin.
     ///
-    virtual bool texture (ustring filename, TextureOptBatch &options,
-                          Tex::RunMask mask, const float *s, const float *t,
-                          const float *dsdx, const float *dtdx,
-                          const float *dsdy, const float *dtdy,
-                          int nchannels, float *result,
-                          float *dresultds=nullptr,
-                          float *dresultdt=nullptr) = 0;
+    bool texture(ustring filename, TextureOptBatch& options, Tex::RunMask mask,
+                 const float* s, const float* t, const float* dsdx,
+                 const float* dtdx, const float* dsdy, const float* dtdy,
+                 int nchannels, float* result, float* dresultds = nullptr,
+                 float* dresultdt = nullptr);
     /// Slightly faster version of texture() lookup if the app already has a
     /// texture handle and per-thread info.
-    virtual bool texture (TextureHandle *texture_handle,
-                          Perthread *thread_info, TextureOptBatch &options,
-                          Tex::RunMask mask, const float *s, const float *t,
-                          const float *dsdx, const float *dtdx,
-                          const float *dsdy, const float *dtdy,
-                          int nchannels, float *result,
-                          float *dresultds=nullptr,
-                          float *dresultdt=nullptr) = 0;
+    bool texture(TextureHandle* texture_handle, Perthread* thread_info,
+                 TextureOptBatch& options, Tex::RunMask mask, const float* s,
+                 const float* t, const float* dsdx, const float* dtdx,
+                 const float* dsdy, const float* dtdy, int nchannels,
+                 float* result, float* dresultds = nullptr,
+                 float* dresultdt = nullptr);
 
     /// Perform filtered 3D volumetric texture lookups on a batch of
     /// positions from the same texture, all at once. The "point-like"
@@ -1129,23 +1138,18 @@ public:
     ///             found or could not be opened by any available ImageIO
     ///             plugin.
     ///
-    virtual bool texture3d (ustring filename,
-                            TextureOptBatch &options, Tex::RunMask mask,
-                            const float *P, const float *dPdx,
-                            const float *dPdy, const float *dPdz,
-                            int nchannels, float *result,
-                            float *dresultds=nullptr, float *dresultdt=nullptr,
-                            float *dresultdr=nullptr) = 0;
+    bool texture3d(ustring filename, TextureOptBatch& options,
+                   Tex::RunMask mask, const float* P, const float* dPdx,
+                   const float* dPdy, const float* dPdz, int nchannels,
+                   float* result, float* dresultds = nullptr,
+                   float* dresultdt = nullptr, float* dresultdr = nullptr);
     /// Slightly faster version of texture3d() lookup if the app already
     /// has a texture handle and per-thread info.
-    virtual bool texture3d (TextureHandle *texture_handle,
-                            Perthread *thread_info,
-                            TextureOptBatch &options, Tex::RunMask mask,
-                            const float *P, const float *dPdx,
-                            const float *dPdy, const float *dPdz,
-                            int nchannels, float *result,
-                            float *dresultds=nullptr, float *dresultdt=nullptr,
-                            float *dresultdr=nullptr) = 0;
+    bool texture3d(TextureHandle* texture_handle, Perthread* thread_info,
+                   TextureOptBatch& options, Tex::RunMask mask, const float* P,
+                   const float* dPdx, const float* dPdy, const float* dPdz,
+                   int nchannels, float* result, float* dresultds = nullptr,
+                   float* dresultdt = nullptr, float* dresultdr = nullptr);
 
     /// Perform filtered directional environment map lookups on a batch of
     /// directions from the same texture, all at once. The "point-like"
@@ -1195,28 +1199,17 @@ public:
     ///             found or could not be opened by any available ImageIO
     ///             plugin.
     ///
-    virtual bool environment (ustring filename,
-                              TextureOptBatch &options, Tex::RunMask mask,
-                              const float *R, const float *dRdx, const float *dRdy,
-                              int nchannels, float *result,
-                              float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    bool environment(ustring filename, TextureOptBatch& options,
+                     Tex::RunMask mask, const float* R, const float* dRdx,
+                     const float* dRdy, int nchannels, float* result,
+                     float* dresultds = nullptr, float* dresultdt = nullptr);
     /// Slightly faster version of environment() if the app already has a
     /// texture handle and per-thread info.
-    virtual bool environment (TextureHandle *texture_handle, Perthread *thread_info,
-                              TextureOptBatch &options, Tex::RunMask mask,
-                              const float *R, const float *dRdx, const float *dRdy,
-                              int nchannels, float *result,
-                              float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
-
-    // Batched shadow lookups
-    virtual bool shadow (ustring filename,
-                         TextureOptBatch &options, Tex::RunMask mask,
-                         const float *P, const float *dPdx, const float *dPdy,
-                         float *result, float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
-    virtual bool shadow (TextureHandle *texture_handle, Perthread *thread_info,
-                         TextureOptBatch &options, Tex::RunMask mask,
-                         const float *P, const float *dPdx, const float *dPdy,
-                         float *result, float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    bool environment(TextureHandle* texture_handle, Perthread* thread_info,
+                     TextureOptBatch& options, Tex::RunMask mask,
+                     const float* R, const float* dRdx, const float* dRdy,
+                     int nchannels, float* result, float* dresultds = nullptr,
+                     float* dresultdt = nullptr);
 
     /// @}
 
@@ -1227,7 +1220,7 @@ public:
 
     /// Given possibly-relative 'filename' (UTF-8 encoded), resolve it using
     /// the search path rules and return the full resolved filename.
-    virtual std::string resolve_filename (const std::string &filename) const=0;
+    std::string resolve_filename(const std::string& filename) const;
 
     /// Get information or metadata about the named texture and store it in
     /// `*data`.
@@ -1412,15 +1405,15 @@ public:
     ///             Except for the `"exists"` query, a file that does not
     ///             exist or could not be read properly as an image also
     ///             constitutes a query failure that will return `false`.
-    virtual bool get_texture_info (ustring filename, int subimage,
-                          ustring dataname, TypeDesc datatype, void *data) = 0;
+    bool get_texture_info(ustring filename, int subimage, ustring dataname,
+                          TypeDesc datatype, void* data);
 
     /// A more efficient variety of `get_texture_info()` for cases where you
     /// can use a `TextureHandle*` to specify the image and optionally have
     /// a `Perthread*` for the calling thread.
-    virtual bool get_texture_info (TextureHandle *texture_handle,
-                          Perthread *thread_info, int subimage,
-                          ustring dataname, TypeDesc datatype, void *data) = 0;
+    bool get_texture_info(TextureHandle* texture_handle, Perthread* thread_info,
+                          int subimage, ustring dataname, TypeDesc datatype,
+                          void* data);
 
     /// Copy the ImageSpec associated with the named texture (the first
     /// subimage by default, or as set by `subimage`).
@@ -1438,14 +1431,12 @@ public:
     ///             as being unable to find, open, or read the file, or if
     ///             it does not contain the designated subimage or MIP
     ///             level).
-    virtual bool get_imagespec (ustring filename, int subimage,
-                                ImageSpec &spec) = 0;
+    bool get_imagespec(ustring filename, int subimage, ImageSpec& spec);
     /// A more efficient variety of `get_imagespec()` for cases where you
     /// can use a `TextureHandle*` to specify the image and optionally have
     /// a `Perthread*` for the calling thread.
-    virtual bool get_imagespec (TextureHandle *texture_handle,
-                                Perthread *thread_info, int subimage,
-                                ImageSpec &spec) = 0;
+    bool get_imagespec(TextureHandle* texture_handle, Perthread* thread_info,
+                       int subimage, ImageSpec& spec);
 
     /// Return a pointer to an ImageSpec associated with the named texture
     /// if the file is found and is an image format that can be read,
@@ -1468,13 +1459,13 @@ public:
     ///             A pointer to the spec, if the image is found and able to
     ///             be opened and read by an available image format plugin,
     ///             and the designated subimage exists.
-    virtual const ImageSpec *imagespec (ustring filename, int subimage=0) = 0;
+    const ImageSpec* imagespec(ustring filename, int subimage = 0);
     /// A more efficient variety of `imagespec()` for cases where you can
     /// use a `TextureHandle*` to specify the image and optionally have a
     /// `Perthread*` for the calling thread.
-    virtual const ImageSpec *imagespec (TextureHandle *texture_handle,
-                                        Perthread *thread_info = nullptr,
-                                        int subimage=0) = 0;
+    const ImageSpec* imagespec(TextureHandle* texture_handle,
+                               Perthread* thread_info = nullptr,
+                               int subimage           = 0);
 
     /// For a texture specified by name, retrieve the rectangle of raw
     /// unfiltered texels from the subimage specified in `options` and at
@@ -1517,20 +1508,17 @@ public:
     ///
     /// @returns
     ///             `true` for success, `false` for failure.
-    virtual bool get_texels (ustring filename, TextureOpt &options,
-                             int miplevel, int xbegin, int xend,
-                             int ybegin, int yend, int zbegin, int zend,
-                             int chbegin, int chend,
-                             TypeDesc format, void *result) = 0;
+    bool get_texels(ustring filename, TextureOpt& options, int miplevel,
+                    int xbegin, int xend, int ybegin, int yend, int zbegin,
+                    int zend, int chbegin, int chend, TypeDesc format,
+                    void* result);
     /// A more efficient variety of `get_texels()` for cases where you can
     /// use a `TextureHandle*` to specify the image and optionally have a
     /// `Perthread*` for the calling thread.
-    virtual bool get_texels (TextureHandle *texture_handle,
-                             Perthread *thread_info, TextureOpt &options,
-                             int miplevel, int xbegin, int xend,
-                             int ybegin, int yend, int zbegin, int zend,
-                             int chbegin, int chend,
-                             TypeDesc format, void *result) = 0;
+    bool get_texels(TextureHandle* texture_handle, Perthread* thread_info,
+                    TextureOpt& options, int miplevel, int xbegin, int xend,
+                    int ybegin, int yend, int zbegin, int zend, int chbegin,
+                    int chend, TypeDesc format, void* result);
 
     /// @}
 
@@ -1541,12 +1529,12 @@ public:
     /// Is the UTF-8 encoded filename a UDIM pattern?
     ///
     /// This method was added in OpenImageIO 2.3.
-    virtual bool is_udim(ustring filename) = 0;
+    bool is_udim(ustring filename);
 
     /// Does the handle refer to a file that's a UDIM pattern?
     ///
     /// This method was added in OpenImageIO 2.3.
-    virtual bool is_udim(TextureHandle* udimfile) = 0;
+    bool is_udim(TextureHandle* udimfile);
 
     /// For a UDIM filename pattern (UTF-8 encoded) and texture coordinates,
     /// return the TextureHandle pointer for the concrete tile file it refers
@@ -1554,17 +1542,15 @@ public:
     /// allowed to be sparse).
     ///
     /// This method was added in OpenImageIO 2.3.
-    virtual TextureHandle* resolve_udim(ustring udimpattern,
-                                        float s, float t) = 0;
+    TextureHandle* resolve_udim(ustring udimpattern, float s, float t);
 
     /// A more efficient variety of `resolve_udim()` for cases where you
     /// have the `TextureHandle*` that corresponds to the "virtual" UDIM
     /// file and optionally have a `Perthread*` for the calling thread.
     ///
     /// This method was added in OpenImageIO 2.3.
-    virtual TextureHandle* resolve_udim(TextureHandle* udimfile,
-                                        Perthread* thread_info,
-                                        float s, float t) = 0;
+    TextureHandle* resolve_udim(TextureHandle* udimfile, Perthread* thread_info,
+                                float s, float t);
 
     /// Produce a full inventory of the set of concrete files comprising the
     /// UDIM set specified by UTF-8 encoded `udimpattern`.  The apparent
@@ -1577,19 +1563,17 @@ public:
     /// `utile + vtile * nvtiles`.
     ///
     /// This method was added in OpenImageIO 2.3.
-    virtual void inventory_udim(ustring udimpattern,
-                                std::vector<ustring>& filenames,
-                                int& nutiles, int& nvtiles) = 0;
+    void inventory_udim(ustring udimpattern, std::vector<ustring>& filenames,
+                        int& nutiles, int& nvtiles);
 
     /// A more efficient variety of `inventory_udim()` for cases where you
     /// have the `TextureHandle*` that corresponds to the "virtual" UDIM
     /// file and optionally have a `Perthread*` for the calling thread.
     ///
     /// This method was added in OpenImageIO 2.3.
-    virtual void inventory_udim(TextureHandle* udimfile,
-                                Perthread* thread_info,
-                                std::vector<ustring>& filenames,
-                                int& nutiles, int& nvtiles) = 0;
+    void inventory_udim(TextureHandle* udimfile, Perthread* thread_info,
+                        std::vector<ustring>& filenames, int& nutiles,
+                        int& nvtiles);
     /// @}
 
     /// @{
@@ -1600,11 +1584,11 @@ public:
     /// encoded), including loaded texture tiles from that texture, and close
     /// any open file handle associated with the file. This calls
     /// `ImageCache::invalidate(filename,force)` on the underlying ImageCache.
-    virtual void invalidate (ustring filename, bool force = true) = 0;
+    void invalidate(ustring filename, bool force = true);
 
     /// Invalidate all cached data for all textures.  This calls
     /// `ImageCache::invalidate_all(force)` on the underlying ImageCache.
-    virtual void invalidate_all (bool force=false) = 0;
+    void invalidate_all(bool force = false);
 
     /// Close any open file handles associated with a UTF-8 encoded filename,
     /// but do not invalidate any image spec information or pixels associated
@@ -1612,10 +1596,10 @@ public:
     /// handle resources, or to make it safe for other processes to modify
     /// textures on disk.  This calls `ImageCache::close(force)` on the
     /// underlying ImageCache.
-    virtual void close (ustring filename) = 0;
+    void close(ustring filename);
 
     /// `close()` all files known to the cache.
-    virtual void close_all () = 0;
+    void close_all();
 
     /// @}
 
@@ -1623,13 +1607,13 @@ public:
     /// @name Errors and statistics
 
     /// Is there a pending error message waiting to be retrieved?
-    virtual bool has_error() const = 0;
+    bool has_error() const;
 
     /// Return the text of all pending error messages issued against this
     /// TextureSystem, and clear the pending error message unless `clear` is
     /// false. If no error message is pending, it will return an empty
     /// string.
-    virtual std::string geterror(bool clear = true) const = 0;
+    std::string geterror(bool clear = true) const;
 
     /// Returns a big string containing useful statistics about the
     /// TextureSystem operations, suitable for saving to a file or
@@ -1639,34 +1623,36 @@ public:
     /// the returned string will also contain all the statistics of the
     /// underlying ImageCache, but if false will only contain
     /// texture-specific statistics.
-    virtual std::string getstats (int level=1, bool icstats=true) const = 0;
+    std::string getstats(int level = 1, bool icstats = true) const;
 
     /// Reset most statistics to be as they were with a fresh TextureSystem.
     /// Caveat emptor: this does not flush the cache itself, so the resulting
     /// statistics from the next set of texture requests will not match the
     /// number of tile reads, etc., that would have resulted from a new
     /// TextureSystem.
-    virtual void reset_stats () = 0;
+    void reset_stats();
 
     /// @}
 
     /// Return an opaque, non-owning pointer to the underlying ImageCache
     /// (if there is one).
-    virtual std::shared_ptr<ImageCache> imagecache() const = 0;
-
-    virtual ~TextureSystem () { }
+    std::shared_ptr<ImageCache> imagecache() const;
 
     // For testing -- do not use
     static void unit_test_hash();
 
-protected:
+    TextureSystem(std::shared_ptr<ImageCache> imagecache);
+    ~TextureSystem();
+
+private:
+    // PIMPL idiom
+    using Impl = TextureSystemImpl;
+    // class Impl;
+    static void impl_deleter(Impl*);
+    std::unique_ptr<Impl, decltype(&impl_deleter)> m_impl;
+
     // User code should never directly construct or destruct a TextureSystem.
     // Always use TextureSystem::create() and TextureSystem::destroy().
-    TextureSystem (void) { }
-private:
-    // Make delete private and unimplemented in order to prevent apps
-    // from calling it.  Instead, they should call TextureSystem::destroy().
-    void operator delete(void* /*todel*/) {}
 };
 
 

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -203,6 +203,54 @@ OIIO_NAMESPACE_BEGIN
 using namespace pvt;
 using namespace simd;
 
+
+bool
+TextureSystem::environment(ustring filename, TextureOpt& options, V3fParam R,
+                           V3fParam dRdx, V3fParam dRdy, int nchannels,
+                           float* result, float* dresultds, float* dresultdt)
+{
+    return m_impl->environment(filename, options, R, dRdx, dRdy, nchannels,
+                               result, dresultds, dresultdt);
+}
+
+
+bool
+TextureSystem::environment(TextureHandle* texture_handle,
+                           Perthread* thread_info, TextureOpt& options,
+                           V3fParam R, V3fParam dRdx, V3fParam dRdy,
+                           int nchannels, float* result, float* dresultds,
+                           float* dresultdt)
+{
+    return m_impl->environment(texture_handle, thread_info, options, R, dRdx,
+                               dRdy, nchannels, result, dresultds, dresultdt);
+}
+
+
+bool
+TextureSystem::environment(ustring filename, TextureOptBatch& options,
+                           Tex::RunMask mask, const float* R, const float* dRdx,
+                           const float* dRdy, int nchannels, float* result,
+                           float* dresultds, float* dresultdt)
+{
+    return m_impl->environment(filename, options, mask, R, dRdx, dRdy,
+                               nchannels, result, dresultds, dresultdt);
+}
+
+
+bool
+TextureSystem::environment(TextureHandle* texture_handle,
+                           Perthread* thread_info, TextureOptBatch& options,
+                           Tex::RunMask mask, const float* R, const float* dRdx,
+                           const float* dRdy, int nchannels, float* result,
+                           float* dresultds, float* dresultdt)
+{
+    return m_impl->environment(texture_handle, thread_info, options, mask, R,
+                               dRdx, dRdy, nchannels, result, dresultds,
+                               dresultdt);
+}
+
+
+
 namespace pvt {
 
 
@@ -224,6 +272,8 @@ vector_to_latlong(const Imath::V3f& R, bool y_is_up, float& s, float& t)
     if (isnan(t))
         t = 0.0f;
 }
+
+}  // namespace pvt
 
 
 
@@ -593,7 +643,5 @@ TextureSystemImpl::environment(ustring filename, TextureOptBatch& options,
                        dRdy, nchannels, result, dresultds, dresultdt);
 }
 
-
-}  // end namespace pvt
 
 OIIO_NAMESPACE_END

--- a/src/libtexture/imagecache_memory_pvt.h
+++ b/src/libtexture/imagecache_memory_pvt.h
@@ -51,12 +51,7 @@ template<>
 inline size_t
 heapsize<ImageCacheFile>(const ImageCacheFile& file)
 {
-    size_t size = heapsize(file.m_subimages);
-    size += heapsize(file.m_configspec);
-    size += heapsize(file.m_input);
-    size += heapsize(file.m_mipreadcount);
-    size += heapsize(file.m_udim_lookup);
-    return size;
+    return file.heapsize();
 }
 
 // heapsize specialization for ImageCacheTile
@@ -72,9 +67,7 @@ template<>
 inline size_t
 heapsize<ImageCachePerThreadInfo>(const ImageCachePerThreadInfo& info)
 {
-    /// TODO: this should take into account the two last tiles, if their refcount is zero.
-    constexpr size_t sizeofPair = sizeof(ustring) + sizeof(ImageCacheFile*);
-    return info.m_thread_files.size() * sizeofPair;
+    return info.heapsize();
 }
 
 // heapsize specialization for ImageCacheImpl
@@ -82,26 +75,7 @@ template<>
 inline size_t
 heapsize<ImageCacheImpl>(const ImageCacheImpl& ic)
 {
-    size_t size = 0;
-    // strings
-    size += heapsize(ic.m_searchpath) + heapsize(ic.m_plugin_searchpath)
-            + heapsize(ic.m_searchdirs);
-    // thread info
-    size += heapsize(ic.m_all_perthread_info);
-    // tile cache
-    for (TileCache::iterator t = ic.m_tilecache.begin(),
-                             e = ic.m_tilecache.end();
-         t != e; ++t)
-        size += footprint(t->first) + footprint(t->second);
-    // files
-    for (FilenameMap::iterator t = ic.m_files.begin(), e = ic.m_files.end();
-         t != e; ++t)
-        size += footprint(t->first) + footprint(t->second);
-    // finger prints; we only account for references, this map does not own the files.
-    constexpr size_t sizeofFingerprintPair = sizeof(ustring)
-                                             + sizeof(ImageCacheFileRef);
-    size += ic.m_fingerprints.size() * sizeofFingerprintPair;
-    return size;
+    return ic.heapsize();
 }
 
 }  // namespace pvt

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -47,7 +47,54 @@ float2float(float val)
 
 }  // end anonymous namespace
 
-namespace pvt {  // namespace pvt
+bool
+TextureSystem::texture3d(ustring filename, TextureOpt& options, V3fParam P,
+                         V3fParam dPdx, V3fParam dPdy, V3fParam dPdz,
+                         int nchannels, float* result, float* dresultds,
+                         float* dresultdt, float* dresultdr)
+{
+    return m_impl->texture3d(filename, options, P, dPdx, dPdy, dPdz, nchannels,
+                             result, dresultds, dresultdt, dresultdr);
+}
+
+
+bool
+TextureSystem::texture3d(TextureHandle* texture_handle, Perthread* thread_info,
+                         TextureOpt& options, V3fParam P, V3fParam dPdx,
+                         V3fParam dPdy, V3fParam dPdz, int nchannels,
+                         float* result, float* dresultds, float* dresultdt,
+                         float* dresultdr)
+{
+    return m_impl->texture3d(texture_handle, thread_info, options, P, dPdx,
+                             dPdy, dPdz, nchannels, result, dresultds,
+                             dresultdt, dresultdr);
+}
+
+
+bool
+TextureSystem::texture3d(ustring filename, TextureOptBatch& options,
+                         Tex::RunMask mask, const float* P, const float* dPdx,
+                         const float* dPdy, const float* dPdz, int nchannels,
+                         float* result, float* dresultds, float* dresultdt,
+                         float* dresultdr)
+{
+    return m_impl->texture3d(filename, options, mask, P, dPdx, dPdy, dPdz,
+                             nchannels, result, dresultds, dresultdt,
+                             dresultdr);
+}
+
+
+bool
+TextureSystem::texture3d(TextureHandle* texture_handle, Perthread* thread_info,
+                         TextureOptBatch& options, Tex::RunMask mask,
+                         const float* P, const float* dPdx, const float* dPdy,
+                         const float* dPdz, int nchannels, float* result,
+                         float* dresultds, float* dresultdt, float* dresultdr)
+{
+    return m_impl->texture3d(texture_handle, thread_info, options, mask, P,
+                             dPdx, dPdy, dPdz, nchannels, result, dresultds,
+                             dresultdt, dresultdr);
+}
 
 
 
@@ -713,7 +760,5 @@ TextureSystemImpl::texture3d(ustring filename, TextureOptBatch& options,
                      dPdz, nchannels, result, dresultds, dresultdt, dresultdr);
 }
 
-
-}  // end namespace pvt
 
 OIIO_NAMESPACE_END

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -16,107 +16,103 @@
 OIIO_NAMESPACE_BEGIN
 
 class ImageCache;
+class TextureSystemImpl;
 class Filter1D;
 
-namespace pvt {
-
-class TextureSystemImpl;
-
 #ifndef OPENIMAGEIO_IMAGECACHE_PVT_H
-class ImageCacheImpl;
 class ImageCacheFile;
 class ImageCacheTile;
 class ImageCacheTileRef;
+class ImageCacheTileID;
+class ImageCacheImpl;
 #endif
 
 
 
 /// Working implementation of the abstract TextureSystem class.
-///
-class TextureSystemImpl final : public TextureSystem {
+class TextureSystemImpl {
 public:
-    typedef ImageCacheFile TextureFile;
+    using TextureHandle = TextureSystem::TextureHandle;
+    using Perthread     = TextureSystem::Perthread;
+    using TextureFile   = ImageCacheFile;
 
-    TextureSystemImpl(std::shared_ptr<ImageCache> imagecache);
-    ~TextureSystemImpl() override;
+    TextureSystemImpl(std::shared_ptr<ImageCache> imagecache = {});
+    ~TextureSystemImpl();
 
-    bool attribute(string_view name, TypeDesc type, const void* val) override;
-    bool attribute(string_view name, int val) override
+    bool attribute(string_view name, TypeDesc type, const void* val);
+    bool attribute(string_view name, int val)
     {
-        return attribute(name, TypeDesc::INT, &val);
+        return attribute(name, TypeInt, &val);
     }
-    bool attribute(string_view name, float val) override
+    bool attribute(string_view name, float val)
     {
-        return attribute(name, TypeDesc::FLOAT, &val);
+        return attribute(name, TypeFloat, &val);
     }
-    bool attribute(string_view name, double val) override
+    bool attribute(string_view name, double val)
     {
         float f = (float)val;
-        return attribute(name, TypeDesc::FLOAT, &f);
+        return attribute(name, TypeFloat, &f);
     }
-    bool attribute(string_view name, string_view val) override
+    bool attribute(string_view name, string_view val)
     {
         std::string valstr(val);
         const char* s = valstr.c_str();
-        return attribute(name, TypeDesc::STRING, &s);
+        return attribute(name, TypeString, &s);
     }
 
-    TypeDesc getattributetype(string_view name) const override;
+    TypeDesc getattributetype(string_view name) const;
 
-    bool getattribute(string_view name, TypeDesc type,
-                      void* val) const override;
-    bool getattribute(string_view name, int& val) const override
+    bool getattribute(string_view name, TypeDesc type, void* val) const;
+    bool getattribute(string_view name, int& val) const
     {
-        return getattribute(name, TypeDesc::INT, &val);
+        return getattribute(name, TypeInt, &val);
     }
-    bool getattribute(string_view name, float& val) const override
+    bool getattribute(string_view name, float& val) const
     {
-        return getattribute(name, TypeDesc::FLOAT, &val);
+        return getattribute(name, TypeFloat, &val);
     }
-    bool getattribute(string_view name, double& val) const override
+    bool getattribute(string_view name, double& val) const
     {
         float f;
-        bool ok = getattribute(name, TypeDesc::FLOAT, &f);
+        bool ok = getattribute(name, TypeFloat, &f);
         if (ok)
             val = f;
         return ok;
     }
-    bool getattribute(string_view name, char** val) const override
+    bool getattribute(string_view name, char** val) const
     {
-        return getattribute(name, TypeDesc::STRING, val);
+        return getattribute(name, TypeString, val);
     }
-    bool getattribute(string_view name, std::string& val) const override
+    bool getattribute(string_view name, std::string& val) const
     {
         const char* s;
-        bool ok = getattribute(name, TypeDesc::STRING, &s);
+        bool ok = getattribute(name, TypeString, &s);
         if (ok)
             val = s;
         return ok;
     }
 
-
     // Retrieve options
     void get_commontoworld(Imath::M44f& result) const { result = m_Mc2w; }
 
-    Perthread* get_perthread_info(Perthread* thread_info = NULL) override
+    Perthread* get_perthread_info(Perthread* thread_info = NULL)
     {
         return (Perthread*)m_imagecache->get_perthread_info(
             (ImageCachePerThreadInfo*)thread_info);
     }
-    Perthread* create_thread_info() override
+    Perthread* create_thread_info()
     {
         OIIO_ASSERT(m_imagecache);
         return (Perthread*)m_imagecache->create_thread_info();
     }
-    void destroy_thread_info(Perthread* threadinfo) override
+    void destroy_thread_info(Perthread* threadinfo)
     {
         OIIO_ASSERT(m_imagecache);
         m_imagecache->destroy_thread_info((ImageCachePerThreadInfo*)threadinfo);
     }
 
-    TextureHandle*
-    get_texture_handle(ustring filename, Perthread* thread,
-                       const TextureOpt* options = nullptr) override
+    TextureHandle* get_texture_handle(ustring filename, Perthread* thread,
+                                      const TextureOpt* options = nullptr)
     {
         PerThreadInfo* thread_info = thread
                                          ? ((PerThreadInfo*)thread)
@@ -124,173 +120,134 @@ public:
         return (TextureHandle*)find_texturefile(filename, thread_info, options);
     }
 
-    bool good(TextureHandle* texture_handle) override
+    bool good(TextureHandle* texture_handle)
     {
         return texture_handle && !((TextureFile*)texture_handle)->broken();
     }
 
-    ustring filename_from_handle(TextureHandle* handle) override
+    ustring filename_from_handle(TextureHandle* handle)
     {
         return handle ? ((ImageCache::ImageHandle*)handle)->filename()
                       : ustring();
     }
 
-    int get_colortransform_id(ustring fromspace,
-                              ustring tospace) const override;
-    int get_colortransform_id(ustringhash fromspace,
-                              ustringhash tospace) const override;
+    int get_colortransform_id(ustring fromspace, ustring tospace) const;
+    int get_colortransform_id(ustringhash fromspace, ustringhash tospace) const;
 
     bool texture(ustring filename, TextureOpt& options, float s, float t,
                  float dsdx, float dtdx, float dsdy, float dtdy, int nchannels,
                  float* result, float* dresultds = NULL,
-                 float* dresultdt = NULL) override;
+                 float* dresultdt = NULL);
     bool texture(TextureHandle* texture_handle, Perthread* thread_info,
                  TextureOpt& options, float s, float t, float dsdx, float dtdx,
                  float dsdy, float dtdy, int nchannels, float* result,
-                 float* dresultds = NULL, float* dresultdt = NULL) override;
+                 float* dresultds = NULL, float* dresultdt = NULL);
     bool texture(ustring filename, TextureOptBatch& options, Tex::RunMask mask,
                  const float* s, const float* t, const float* dsdx,
                  const float* dtdx, const float* dsdy, const float* dtdy,
                  int nchannels, float* result, float* dresultds = nullptr,
-                 float* dresultdt = nullptr) override;
+                 float* dresultdt = nullptr);
     bool texture(TextureHandle* texture_handle, Perthread* thread_info,
                  TextureOptBatch& options, Tex::RunMask mask, const float* s,
                  const float* t, const float* dsdx, const float* dtdx,
                  const float* dsdy, const float* dtdy, int nchannels,
                  float* result, float* dresultds = nullptr,
-                 float* dresultdt = nullptr) override;
+                 float* dresultdt = nullptr);
 
     bool texture3d(ustring filename, TextureOpt& options, V3fParam P,
                    V3fParam dPdx, V3fParam dPdy, V3fParam dPdz, int nchannels,
                    float* result, float* dresultds = NULL,
-                   float* dresultdt = NULL, float* dresultdr = NULL) override;
+                   float* dresultdt = NULL, float* dresultdr = NULL);
     bool texture3d(TextureHandle* texture_handle, Perthread* thread_info,
                    TextureOpt& options, V3fParam P, V3fParam dPdx,
                    V3fParam dPdy, V3fParam dPdz, int nchannels, float* result,
                    float* dresultds = NULL, float* dresultdt = NULL,
-                   float* dresultdr = NULL) override;
+                   float* dresultdr = NULL);
     bool texture3d(ustring filename, TextureOptBatch& options,
                    Tex::RunMask mask, const float* P, const float* dPdx,
                    const float* dPdy, const float* dPdz, int nchannels,
                    float* result, float* dresultds = nullptr,
-                   float* dresultdt = nullptr,
-                   float* dresultdr = nullptr) override;
+                   float* dresultdt = nullptr, float* dresultdr = nullptr);
     bool texture3d(TextureHandle* texture_handle, Perthread* thread_info,
                    TextureOptBatch& options, Tex::RunMask mask, const float* P,
                    const float* dPdx, const float* dPdy, const float* dPdz,
                    int nchannels, float* result, float* dresultds = nullptr,
-                   float* dresultdt = nullptr,
-                   float* dresultdr = nullptr) override;
-
-    bool shadow(ustring /*filename*/, TextureOpt& /*options*/, V3fParam /*P*/,
-                V3fParam /*dPdx*/, V3fParam /*dPdy*/, float* /*result*/,
-                float* /*dresultds*/, float* /*dresultdt*/) override
-    {
-        return false;
-    }
-    bool shadow(TextureHandle* /*texture_handle*/, Perthread* /*thread_info*/,
-                TextureOpt& /*options*/, V3fParam /*P*/, V3fParam /*dPdx*/,
-                V3fParam /*dPdy*/, float* /*result*/, float* /*dresultds*/,
-                float* /*dresultdt*/) override
-    {
-        return false;
-    }
-    bool shadow(ustring /*filename*/, TextureOptBatch& /*options*/,
-                Tex::RunMask /*mask*/, const float* /*P*/,
-                const float* /*dPdx*/, const float* /*dPdy*/, float* /*result*/,
-                float* /*dresultds*/, float* /*dresultdt*/) override
-    {
-        return false;
-    }
-    bool shadow(TextureHandle* /*texture_handle*/, Perthread* /*thread_info*/,
-                TextureOptBatch& /*options*/, Tex::RunMask /*mask*/,
-                const float* /*P*/, const float* /*dPdx*/,
-                const float* /*dPdy*/, float* /*result*/, float* /*dresultds*/,
-                float* /*dresultdt*/) override
-    {
-        return false;
-    }
+                   float* dresultdt = nullptr, float* dresultdr = nullptr);
 
     bool environment(ustring filename, TextureOpt& options, V3fParam R,
                      V3fParam dRdx, V3fParam dRdy, int nchannels, float* result,
-                     float* dresultds = NULL, float* dresultdt = NULL) override;
+                     float* dresultds = NULL, float* dresultdt = NULL);
     bool environment(TextureHandle* texture_handle, Perthread* thread_info,
                      TextureOpt& options, V3fParam R, V3fParam dRdx,
                      V3fParam dRdy, int nchannels, float* result,
-                     float* dresultds = NULL, float* dresultdt = NULL) override;
+                     float* dresultds = NULL, float* dresultdt = NULL);
     bool environment(ustring filename, TextureOptBatch& options,
                      Tex::RunMask mask, const float* R, const float* dRdx,
                      const float* dRdy, int nchannels, float* result,
-                     float* dresultds = nullptr,
-                     float* dresultdt = nullptr) override;
+                     float* dresultds = nullptr, float* dresultdt = nullptr);
     bool environment(TextureHandle* texture_handle, Perthread* thread_info,
                      TextureOptBatch& options, Tex::RunMask mask,
                      const float* R, const float* dRdx, const float* dRdy,
                      int nchannels, float* result, float* dresultds = nullptr,
-                     float* dresultdt = nullptr) override;
+                     float* dresultdt = nullptr);
 
-    std::string resolve_filename(const std::string& filename) const override;
+    std::string resolve_filename(const std::string& filename) const;
 
     bool get_texture_info(ustring filename, int subimage, ustring dataname,
-                          TypeDesc datatype, void* data) override;
+                          TypeDesc datatype, void* data);
     bool get_texture_info(TextureHandle* texture_handle, Perthread* thread_info,
                           int subimage, ustring dataname, TypeDesc datatype,
-                          void* data) override;
+                          void* data);
 
-    bool get_imagespec(ustring filename, int subimage,
-                       ImageSpec& spec) override;
+    bool get_imagespec(ustring filename, int subimage, ImageSpec& spec);
     bool get_imagespec(TextureHandle* texture_handle, Perthread* thread_info,
-                       int subimage, ImageSpec& spec) override;
+                       int subimage, ImageSpec& spec);
 
-    const ImageSpec* imagespec(ustring filename, int subimage = 0) override;
+    const ImageSpec* imagespec(ustring filename, int subimage = 0);
     const ImageSpec* imagespec(TextureHandle* texture_handle,
-                               Perthread* thread_info = NULL,
-                               int subimage           = 0) override;
+                               Perthread* thread_info = NULL, int subimage = 0);
 
     bool get_texels(ustring filename, TextureOpt& options, int miplevel,
                     int xbegin, int xend, int ybegin, int yend, int zbegin,
                     int zend, int chbegin, int chend, TypeDesc format,
-                    void* result) override;
+                    void* result);
     bool get_texels(TextureHandle* texture_handle, Perthread* thread_info,
                     TextureOpt& options, int miplevel, int xbegin, int xend,
                     int ybegin, int yend, int zbegin, int zend, int chbegin,
-                    int chend, TypeDesc format, void* result) override;
+                    int chend, TypeDesc format, void* result);
 
-    bool is_udim(ustring filename) override;
-    bool is_udim(TextureHandle* udimfile) override;
-    TextureHandle* resolve_udim(ustring filename, float s, float t) override;
+    bool is_udim(ustring filename);
+    bool is_udim(TextureHandle* udimfile);
+    TextureHandle* resolve_udim(ustring filename, float s, float t);
     TextureHandle* resolve_udim(TextureHandle* udimfile, Perthread* thread_info,
-                                float s, float t) override;
+                                float s, float t);
     void inventory_udim(ustring udimpattern, std::vector<ustring>& filenames,
-                        int& nutiles, int& nvtiles) override;
+                        int& nutiles, int& nvtiles);
     void inventory_udim(TextureHandle* udimfile, Perthread* thread_info,
                         std::vector<ustring>& filenames, int& nutiles,
-                        int& nvtiles) override;
+                        int& nvtiles);
 
-    bool has_error() const override;
-    std::string geterror(bool clear = true) const override;
-    std::string getstats(int level = 1, bool icstats = true) const override;
-    void reset_stats() override;
+    bool has_error() const;
+    std::string geterror(bool clear = true) const;
+    std::string getstats(int level = 1, bool icstats = true) const;
+    void reset_stats();
 
-    void invalidate(ustring filename, bool force) override;
-    void invalidate_all(bool force = false) override;
-    void close(ustring filename) override;
-    void close_all() override;
+    void invalidate(ustring filename, bool force);
+    void invalidate_all(bool force = false);
+    void close(ustring filename);
+    void close_all();
 
-    void operator delete(void* todel) { ::delete ((char*)todel); }
+    // void operator delete(void* todel) { ::delete ((char*)todel); }
 
     typedef bool (*wrap_impl)(int& coord, int origin, int width);
 
     /// Return an opaque, non-owning pointer to the underlying ImageCache
     /// (if there is one).
-    std::shared_ptr<ImageCache> imagecache() const override
-    {
-        return m_imagecache_sp;
-    }
+    std::shared_ptr<ImageCache> imagecache() const { return m_imagecache_sp; }
 
-private:
-    typedef ImageCacheTileRef TileRef;
-    typedef ImageCachePerThreadInfo PerThreadInfo;
+    // private:
+    using TileRef       = ImageCacheTileRef;
+    using PerThreadInfo = ImageCachePerThreadInfo;
 
     void init();
 
@@ -593,9 +550,6 @@ TextureSystemImpl::st_to_texel(float s, float t, TextureFile& texturefile,
     // and to the right).
 }
 
-
-
-}  // end namespace pvt
 
 OIIO_NAMESPACE_END
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -81,6 +81,26 @@ static const OIIO_SIMD4_ALIGN vbool4 channel_masks[5] = {
 }  // end anonymous namespace
 
 
+
+void
+TextureSystem::impl_deleter(TextureSystemImpl* todel)
+{
+    delete todel;
+}
+
+
+
+TextureSystem::TextureSystem(std::shared_ptr<ImageCache> imagecache)
+    : m_impl(new TextureSystemImpl(imagecache), &impl_deleter)
+{
+}
+
+
+
+TextureSystem::~TextureSystem() {}
+
+
+
 std::shared_ptr<TextureSystem>
 TextureSystem::create(bool shared, std::shared_ptr<ImageCache> imagecache)
 {
@@ -96,7 +116,7 @@ TextureSystem::create(bool shared, std::shared_ptr<ImageCache> imagecache)
         // as the shared one.
         spin_lock guard(shared_texturesys_mutex);
         if (!shared_texturesys)
-            shared_texturesys = std::make_shared<TextureSystemImpl>(
+            shared_texturesys = std::make_shared<TextureSystem>(
                 ImageCache::create(true));
         return shared_texturesys;
     }
@@ -107,8 +127,8 @@ TextureSystem::create(bool shared, std::shared_ptr<ImageCache> imagecache)
         imagecache = ImageCache::create(false);
         own_ic     = true;
     }
-    auto ts                = std::make_shared<TextureSystemImpl>(imagecache);
-    ts->m_imagecache_owner = own_ic;
+    auto ts = std::make_shared<TextureSystem>(imagecache);
+    ts->m_impl->m_imagecache_owner = own_ic;
     OIIO_PRAGMA_WARNING_POP
     return ts;
 }
@@ -121,8 +141,8 @@ TextureSystem::destroy(std::shared_ptr<TextureSystem>& ts,
 {
     if (!ts)
         return;
-    TextureSystemImpl* impl = (TextureSystemImpl*)ts.get();
     if (teardown_imagecache) {
+        TextureSystemImpl* impl = ts->m_impl.get();
         if (impl->m_imagecache_owner)
             ImageCache::destroy(impl->m_imagecache_sp, true);
         impl->m_imagecache = nullptr;
@@ -134,7 +154,346 @@ TextureSystem::destroy(std::shared_ptr<TextureSystem>& ts,
 
 
 
-namespace pvt {  // namespace pvt
+TextureSystem::Perthread*
+TextureSystem::get_perthread_info(Perthread* thread_info)
+{
+    return m_impl->get_perthread_info(
+        (TextureSystemImpl::Perthread*)thread_info);
+}
+
+
+
+TextureSystem::Perthread*
+TextureSystem::create_thread_info()
+{
+    return m_impl->create_thread_info();
+}
+
+
+
+void
+TextureSystem::destroy_thread_info(Perthread* threadinfo)
+{
+    m_impl->destroy_thread_info((TextureSystemImpl::Perthread*)threadinfo);
+}
+
+
+
+bool
+TextureSystem::attribute(string_view name, TypeDesc type, const void* val)
+{
+    return m_impl->attribute(name, type, val);
+}
+
+
+
+TypeDesc
+TextureSystem::getattributetype(string_view name) const
+{
+    return m_impl->getattributetype(name);
+}
+
+
+
+bool
+TextureSystem::getattribute(string_view name, TypeDesc type, void* val) const
+{
+    return m_impl->getattribute(name, type, val);
+}
+
+
+
+TextureSystem::TextureHandle*
+TextureSystem::get_texture_handle(ustring filename, Perthread* thread_info,
+                                  const TextureOpt* options)
+{
+    return m_impl->get_texture_handle(
+        filename, (TextureSystemImpl::Perthread*)thread_info, options);
+}
+
+
+
+bool
+TextureSystem::good(TextureHandle* texture_handle)
+{
+    return m_impl->good(texture_handle);
+}
+
+
+
+ustring
+TextureSystem::filename_from_handle(TextureHandle* handle)
+{
+    return m_impl->filename_from_handle(handle);
+}
+
+
+
+int
+TextureSystem::get_colortransform_id(ustring fromspace, ustring tospace) const
+{
+    return m_impl->get_colortransform_id(fromspace, tospace);
+}
+
+
+int
+TextureSystem::get_colortransform_id(ustringhash fromspace,
+                                     ustringhash tospace) const
+{
+    return m_impl->get_colortransform_id(fromspace, tospace);
+}
+
+
+
+bool
+TextureSystem::texture(ustring filename, TextureOpt& options, float s, float t,
+                       float dsdx, float dtdx, float dsdy, float dtdy,
+                       int nchannels, float* result, float* dresultds,
+                       float* dresultdt)
+{
+    return m_impl->texture(filename, options, s, t, dsdx, dtdx, dsdy, dtdy,
+                           nchannels, result, dresultds, dresultdt);
+}
+
+
+bool
+TextureSystem::texture(TextureHandle* texture_handle, Perthread* thread_info,
+                       TextureOpt& options, float s, float t, float dsdx,
+                       float dtdx, float dsdy, float dtdy, int nchannels,
+                       float* result, float* dresultds, float* dresultdt)
+{
+    return m_impl->texture(texture_handle, thread_info, options, s, t, dsdx,
+                           dtdx, dsdy, dtdy, nchannels, result, dresultds,
+                           dresultdt);
+}
+
+
+bool
+TextureSystem::texture(ustring filename, TextureOptBatch& options,
+                       Tex::RunMask mask, const float* s, const float* t,
+                       const float* dsdx, const float* dtdx, const float* dsdy,
+                       const float* dtdy, int nchannels, float* result,
+                       float* dresultds, float* dresultdt)
+{
+    return m_impl->texture(filename, options, mask, s, t, dsdx, dtdx, dsdy,
+                           dtdy, nchannels, result, dresultds, dresultdt);
+}
+
+
+bool
+TextureSystem::texture(TextureHandle* texture_handle, Perthread* thread_info,
+                       TextureOptBatch& options, Tex::RunMask mask,
+                       const float* s, const float* t, const float* dsdx,
+                       const float* dtdx, const float* dsdy, const float* dtdy,
+                       int nchannels, float* result, float* dresultds,
+                       float* dresultdt)
+{
+    return m_impl->texture(texture_handle, thread_info, options, mask, s, t,
+                           dsdx, dtdx, dsdy, dtdy, nchannels, result, dresultds,
+                           dresultdt);
+}
+
+
+
+std::string
+TextureSystem::resolve_filename(const std::string& filename) const
+{
+    return m_impl->resolve_filename(filename);
+}
+
+
+
+bool
+TextureSystem::get_texture_info(ustring filename, int subimage,
+                                ustring dataname, TypeDesc datatype, void* data)
+{
+    return m_impl->get_texture_info(filename, subimage, dataname, datatype,
+                                    data);
+}
+
+
+bool
+TextureSystem::get_texture_info(TextureHandle* texture_handle,
+                                Perthread* thread_info, int subimage,
+                                ustring dataname, TypeDesc datatype, void* data)
+{
+    return m_impl->get_texture_info(texture_handle, thread_info, subimage,
+                                    dataname, datatype, data);
+}
+
+
+bool
+TextureSystem::get_imagespec(ustring filename, int subimage, ImageSpec& spec)
+{
+    return m_impl->get_imagespec(filename, subimage, spec);
+}
+
+
+bool
+TextureSystem::get_imagespec(TextureHandle* texture_handle,
+                             Perthread* thread_info, int subimage,
+                             ImageSpec& spec)
+{
+    return m_impl->get_imagespec(texture_handle, thread_info, subimage, spec);
+}
+
+
+const ImageSpec*
+TextureSystem::imagespec(ustring filename, int subimage)
+{
+    return m_impl->imagespec(filename, subimage);
+}
+
+
+const ImageSpec*
+TextureSystem::imagespec(TextureHandle* texture_handle, Perthread* thread_info,
+                         int subimage)
+{
+    return m_impl->imagespec(texture_handle, thread_info, subimage);
+}
+
+
+bool
+TextureSystem::get_texels(ustring filename, TextureOpt& options, int miplevel,
+                          int xbegin, int xend, int ybegin, int yend,
+                          int zbegin, int zend, int chbegin, int chend,
+                          TypeDesc format, void* result)
+{
+    return m_impl->get_texels(filename, options, miplevel, xbegin, xend, ybegin,
+                              yend, zbegin, zend, chbegin, chend, format,
+                              result);
+}
+
+
+bool
+TextureSystem::get_texels(TextureHandle* texture_handle, Perthread* thread_info,
+                          TextureOpt& options, int miplevel, int xbegin,
+                          int xend, int ybegin, int yend, int zbegin, int zend,
+                          int chbegin, int chend, TypeDesc format, void* result)
+{
+    return m_impl->get_texels(texture_handle, thread_info, options, miplevel,
+                              xbegin, xend, ybegin, yend, zbegin, zend, chbegin,
+                              chend, format, result);
+}
+
+
+
+bool
+TextureSystem::is_udim(ustring filename)
+{
+    return m_impl->is_udim(filename);
+}
+
+
+bool
+TextureSystem::is_udim(TextureHandle* udimfile)
+{
+    return m_impl->is_udim(udimfile);
+}
+
+
+
+TextureSystem::TextureHandle*
+TextureSystem::resolve_udim(ustring udimpattern, float s, float t)
+{
+    return m_impl->resolve_udim(udimpattern, s, t);
+}
+
+
+TextureSystem::TextureHandle*
+TextureSystem::resolve_udim(TextureHandle* udimfile, Perthread* thread_info,
+                            float s, float t)
+{
+    return m_impl->resolve_udim(udimfile, thread_info, s, t);
+}
+
+
+
+void
+TextureSystem::inventory_udim(ustring udimpattern,
+                              std::vector<ustring>& filenames, int& nutiles,
+                              int& nvtiles)
+{
+    m_impl->inventory_udim(udimpattern, filenames, nutiles, nvtiles);
+}
+
+
+void
+TextureSystem::inventory_udim(TextureHandle* udimfile, Perthread* thread_info,
+                              std::vector<ustring>& filenames, int& nutiles,
+                              int& nvtiles)
+{
+    m_impl->inventory_udim(udimfile, thread_info, filenames, nutiles, nvtiles);
+}
+
+
+
+void
+TextureSystem::invalidate(ustring filename, bool force)
+{
+    m_impl->invalidate(filename, force);
+}
+
+
+void
+TextureSystem::invalidate_all(bool force)
+{
+    m_impl->invalidate_all(force);
+}
+
+
+
+void
+TextureSystem::close(ustring filename)
+{
+    m_impl->close(filename);
+}
+
+
+void
+TextureSystem::close_all()
+{
+    m_impl->close_all();
+}
+
+
+
+bool
+TextureSystem::has_error() const
+{
+    return m_impl->has_error();
+}
+
+
+std::string
+TextureSystem::geterror(bool clear) const
+{
+    return m_impl->geterror(clear);
+}
+
+
+
+std::string
+TextureSystem::getstats(int level, bool icstats) const
+{
+    return m_impl->getstats(level, icstats);
+}
+
+
+void
+TextureSystem::reset_stats()
+{
+    m_impl->reset_stats();
+}
+
+
+
+std::shared_ptr<ImageCache>
+TextureSystem::imagecache() const
+{
+    return m_impl->m_imagecache_sp;
+}
+
 
 
 EightBitConverter<float> TextureSystemImpl::uchar2float;
@@ -144,7 +503,6 @@ EightBitConverter<float> TextureSystemImpl::uchar2float;
 // Wrap functions wrap 'coord' around 'width', and return true if the
 // result is a valid pixel coordinate, false if black should be used
 // instead.
-
 
 bool
 TextureSystemImpl::wrap_periodic_sharedborder(int& coord, int origin, int width)
@@ -174,6 +532,7 @@ const TextureSystemImpl::wrap_impl TextureSystemImpl::wrap_functions[] = {
 };
 
 
+namespace pvt {
 
 simd::vbool4
 wrap_black_simd(simd::vint4& coord_, const simd::vint4& origin,
@@ -312,12 +671,15 @@ texture_type_name(TexFormat f)
 }
 
 
+}  // namespace pvt
+
+
 
 TextureSystemImpl::TextureSystemImpl(std::shared_ptr<ImageCache> imagecache)
     : m_id(++txsys_next_id)
 {
-    m_imagecache_sp = imagecache;
-    m_imagecache    = (ImageCacheImpl*)m_imagecache_sp.get();
+    m_imagecache_sp = std::move(imagecache);
+    m_imagecache    = (ImageCacheImpl*)m_imagecache_sp->m_impl.get();
     init();
 }
 
@@ -337,7 +699,7 @@ TextureSystemImpl::init()
     // Allow environment variable to override default options
     const char* options = getenv("OPENIMAGEIO_TEXTURE_OPTIONS");
     if (options)
-        attribute("options", options);
+        attribute("options", TypeString, &options);
 
     if (do_unit_test_texture)
         unit_test_texture();
@@ -2449,33 +2811,33 @@ TextureSystemImpl::sample_bilinear(
 
 namespace {
 
-    // Evaluate Bspline weights for both value and derivatives (if dw is not
-    // NULL) into w[0..3] and dw[0..3]. This is the canonical version for
-    // reference, but we don't actually call it, instead favoring the much
-    // harder to read SIMD versions below.
-    template<typename T>
-    inline void evalBSplineWeights_and_derivs(T* w, T fraction, T* dw = NULL)
-    {
-        T one_frac = 1.0 - fraction;
-        w[0]       = T(1.0 / 6.0) * one_frac * one_frac * one_frac;
-        w[1]       = T(2.0 / 3.0)
-               - T(0.5) * fraction * fraction * (T(2.0) - fraction);
-        w[2] = T(2.0 / 3.0)
-               - T(0.5) * one_frac * one_frac * (T(2.0) - one_frac);
-        w[3] = T(1.0 / 6.0) * fraction * fraction * fraction;
-        if (dw) {
-            dw[0] = T(-0.5) * one_frac * one_frac;
-            dw[1] = T(0.5) * fraction * (T(3.0) * fraction - T(4.0));
-            dw[2] = T(-0.5) * one_frac * (T(3.0) * one_frac - T(4.0));
-            dw[3] = T(0.5) * fraction * fraction;
-        }
+// Evaluate Bspline weights for both value and derivatives (if dw is not
+// NULL) into w[0..3] and dw[0..3]. This is the canonical version for
+// reference, but we don't actually call it, instead favoring the much
+// harder to read SIMD versions below.
+template<typename T>
+inline void
+evalBSplineWeights_and_derivs(T* w, T fraction, T* dw = NULL)
+{
+    T one_frac = 1.0 - fraction;
+    w[0]       = T(1.0 / 6.0) * one_frac * one_frac * one_frac;
+    w[1] = T(2.0 / 3.0) - T(0.5) * fraction * fraction * (T(2.0) - fraction);
+    w[2] = T(2.0 / 3.0) - T(0.5) * one_frac * one_frac * (T(2.0) - one_frac);
+    w[3] = T(1.0 / 6.0) * fraction * fraction * fraction;
+    if (dw) {
+        dw[0] = T(-0.5) * one_frac * one_frac;
+        dw[1] = T(0.5) * fraction * (T(3.0) * fraction - T(4.0));
+        dw[2] = T(-0.5) * one_frac * (T(3.0) * one_frac - T(4.0));
+        dw[3] = T(0.5) * fraction * fraction;
     }
+}
 
-    // Evaluate the 4 Bspline weights (no derivs), returning them as a vfloat4.
-    // The fraction also comes in as a vfloat4 (assuming the same value in all 4
-    // slots).
-    inline vfloat4 evalBSplineWeights(const vfloat4& fraction)
-    {
+// Evaluate the 4 Bspline weights (no derivs), returning them as a vfloat4.
+// The fraction also comes in as a vfloat4 (assuming the same value in all 4
+// slots).
+inline vfloat4
+evalBSplineWeights(const vfloat4& fraction)
+{
 #if 0
     // Version that's easy to read and understand:
     float one_frac = 1.0f - fraction;
@@ -2486,24 +2848,25 @@ namespace {
     w[3] = 0.0f          + (1.0f / 6.0f) * fraction * fraction * fraction;
     return w;
 #else
-        // Not as clear, but fastest version I've been able to achieve:
-        OIIO_SIMD_FLOAT4_CONST4(A, 0.0f, 2.0f / 3.0f, 2.0f / 3.0f, 0.0f);
-        OIIO_SIMD_FLOAT4_CONST4(B, 1.0f / 6.0f, -0.5f, -0.5f, 1.0f / 6.0f);
-        OIIO_SIMD_FLOAT4_CONST4(om1m1o, 1.0f, -1.0f, -1.0f, 1.0f);
-        OIIO_SIMD_FLOAT4_CONST4(z22z, 0.0f, 2.0f, 2.0f, 0.0f);
-        simd::vfloat4 one_frac = vfloat4::One() - fraction;
-        simd::vfloat4 ofof     = AxBxAyBy(one_frac,
-                                          fraction);  // 1-frac, frac, 1-frac, frac
-        simd::vfloat4 C = (*(vfloat4*)&om1m1o) * ofof + (*(vfloat4*)&z22z);
-        return (*(vfloat4*)&A) + (*(vfloat4*)&B) * ofof * ofof * C;
+    // Not as clear, but fastest version I've been able to achieve:
+    OIIO_SIMD_FLOAT4_CONST4(A, 0.0f, 2.0f / 3.0f, 2.0f / 3.0f, 0.0f);
+    OIIO_SIMD_FLOAT4_CONST4(B, 1.0f / 6.0f, -0.5f, -0.5f, 1.0f / 6.0f);
+    OIIO_SIMD_FLOAT4_CONST4(om1m1o, 1.0f, -1.0f, -1.0f, 1.0f);
+    OIIO_SIMD_FLOAT4_CONST4(z22z, 0.0f, 2.0f, 2.0f, 0.0f);
+    simd::vfloat4 one_frac = vfloat4::One() - fraction;
+    simd::vfloat4 ofof     = AxBxAyBy(one_frac,
+                                      fraction);  // 1-frac, frac, 1-frac, frac
+    simd::vfloat4 C        = (*(vfloat4*)&om1m1o) * ofof + (*(vfloat4*)&z22z);
+    return (*(vfloat4*)&A) + (*(vfloat4*)&B) * ofof * ofof * C;
 #endif
-    }
+}
 
-    // Evaluate Bspline weights for both value and derivatives (if dw is not
-    // NULL), returning the 4 coefficients for each as vfloat4's.
-    inline void evalBSplineWeights_and_derivs(simd::vfloat4* w, float fraction,
-                                              simd::vfloat4* dw = NULL)
-    {
+// Evaluate Bspline weights for both value and derivatives (if dw is not
+// NULL), returning the 4 coefficients for each as vfloat4's.
+inline void
+evalBSplineWeights_and_derivs(simd::vfloat4* w, float fraction,
+                              simd::vfloat4* dw = NULL)
+{
 #if 0
     // Version that's easy to read and understand:
     float one_frac = 1.0f - fraction;
@@ -2518,21 +2881,21 @@ namespace {
         (*dw)[3] =  0.5f * fraction * (1.0f * fraction - 0.0f);
     }
 #else
-        // Not as clear, but fastest version I've been able to achieve:
-        OIIO_SIMD_FLOAT4_CONST4(A, 0.0f, 2.0f / 3.0f, 2.0f / 3.0f, 0.0f);
-        OIIO_SIMD_FLOAT4_CONST4(B, 1.0f / 6.0f, -0.5f, -0.5f, 1.0f / 6.0f);
-        float one_frac = 1.0f - fraction;
-        simd::vfloat4 ofof(one_frac, fraction, one_frac, fraction);
-        simd::vfloat4 C(one_frac, 2.0f - fraction, 2.0f - one_frac, fraction);
-        *w = (*(vfloat4*)&A) + (*(vfloat4*)&B) * ofof * ofof * C;
-        if (dw) {
-            const simd::vfloat4 D(-0.5f, 0.5f, -0.5f, 0.5f);
-            const simd::vfloat4 E(1.0f, 3.0f, 3.0f, 1.0f);
-            const simd::vfloat4 F(0.0f, 4.0f, 4.0f, 0.0f);
-            *dw = D * ofof * (E * ofof - F);
-        }
-#endif
+    // Not as clear, but fastest version I've been able to achieve:
+    OIIO_SIMD_FLOAT4_CONST4(A, 0.0f, 2.0f / 3.0f, 2.0f / 3.0f, 0.0f);
+    OIIO_SIMD_FLOAT4_CONST4(B, 1.0f / 6.0f, -0.5f, -0.5f, 1.0f / 6.0f);
+    float one_frac = 1.0f - fraction;
+    simd::vfloat4 ofof(one_frac, fraction, one_frac, fraction);
+    simd::vfloat4 C(one_frac, 2.0f - fraction, 2.0f - one_frac, fraction);
+    *w = (*(vfloat4*)&A) + (*(vfloat4*)&B) * ofof * ofof * C;
+    if (dw) {
+        const simd::vfloat4 D(-0.5f, 0.5f, -0.5f, 0.5f);
+        const simd::vfloat4 E(1.0f, 3.0f, 3.0f, 1.0f);
+        const simd::vfloat4 F(0.0f, 4.0f, 4.0f, 0.0f);
+        *dw = D * ofof * (E * ofof - F);
     }
+#endif
+}
 
 }  // anonymous namespace
 
@@ -3090,8 +3453,6 @@ TextureSystemImpl::unit_test_texture()
     }
 }
 
-}  // end namespace pvt
-
 
 
 void
@@ -3113,9 +3474,6 @@ TextureSystem::unit_test_hash()
     auto imagecache = ImageCache::create();
 
     // Set up the ImageCacheFiles outside of the timing loop
-    using OIIO::pvt::ImageCacheFile;
-    using OIIO::pvt::ImageCacheFileRef;
-    using OIIO::pvt::ImageCacheImpl;
     std::vector<ImageCacheFileRef> icf;
     for (int f = 0; f < nfiles; ++f) {
         ustring filename = ustring::fmtformat("{:06}.tif", f);
@@ -3129,7 +3487,7 @@ TextureSystem::unit_test_hash()
     for (int f = 0; f < nfiles; ++f) {
         for (int y = 0; y < res; y += tilesize) {
             for (int x = 0; x < res; x += tilesize, ++i) {
-                OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
+                TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
                 size_t h = id.hash();
                 hh += h;
             }
@@ -3147,7 +3505,7 @@ TextureSystem::unit_test_hash()
     for (int f = 0; f < nfiles; ++f) {
         for (int y = 0; y < res; y += tilesize) {
             for (int x = 0; x < res; x += tilesize, ++i) {
-                OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
+                TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
                 size_t h = id.hash();
                 ++fourbits[h & 0xf];
                 ++eightbits[h & 0xff];


### PR DESCRIPTION
Background: The ImageCache and TextureSystem had historically been implemented as pure virtual abstract base classe defining an interface, then a hidden concrete subclass. The flexibility this was intended to provide was never really used; instead the imagined main client for the flexibility, OSL, has a different mechanism for customizing the texture system (via their RendererServices class). Meanwhile, this has made the interfaces to IC and TS impossible to change without breaking the ABI.

So this PR does the following:

* ImageCache and TextureSytem are fullly de-virtualized, and are now concrete classes, no hidden subclassing, no virtual methods. As such, removing or changing existing methods will be an ABI break, but adding new methods is not.

* Each now use a PIMPL idiom, where all the data and internal methods are hidden from the public interface and do not affect the ABI.

* Roughly speaking, we added the PIMPL pointers and made the ImageCacheImpl/TextureSystemImpl -- what used to be the hidden concrete subclasses -- into the hidden PIMPL classes.

* Moved a lot of classes that used to be in a "pvt" namespace into the main namespace. If they are opaque types not exposed in public headers or as symbols exported from the library, it doesn't matter, so this just removes some arbitrary clutter.

* Had to rearrange some of the recently added heapsize/footprint code, moved some inline functions in the headers into methods of the classes, defined in the cpp files.

This itself is a huge ABI change, so will only be merged into master, to become part of the 3.0 release. This is not an API change, though! This is all about the internals, and should not require any client software to change a single line of code.

I may do further simplification or refactoring of this code in the future, but that will all be smaller and have no further API/ABI changes that break compatibility.

Although the structure of the class hierarchy has changed around, none of the logic about how IC and TS actually *work* has changed, so there should be no change in observable behavior.
