### PR TITLE
fix(png): bug in associateAlpha botched alpha=0 pixels

### DIFF
--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -232,7 +232,7 @@ PNGInput::associateAlpha(T* data, int size, int channels, int alpha_channel,
         for (int x = 0; x < size; ++x, data += channels) {
             DataArrayProxy<T, float> val(data);
             float alpha = val[alpha_channel];
-            if (alpha != 0.0f && alpha != 1.0f) {
+            if (alpha != 1.0f) {
                 for (int c = 0; c < channels; c++) {
                     if (c != alpha_channel) {
                         float f = sRGB_to_linear(val[c]);
@@ -245,7 +245,7 @@ PNGInput::associateAlpha(T* data, int size, int channels, int alpha_channel,
         for (int x = 0; x < size; ++x, data += channels) {
             DataArrayProxy<T, float> val(data);
             float alpha = val[alpha_channel];
-            if (alpha != 0.0f && alpha != 1.0f) {
+            if (alpha != 1.0f) {
                 for (int c = 0; c < channels; c++)
                     if (c != alpha_channel)
                         data[c] = data[c] * alpha;
@@ -256,7 +256,7 @@ PNGInput::associateAlpha(T* data, int size, int channels, int alpha_channel,
         for (int x = 0; x < size; ++x, data += channels) {
             DataArrayProxy<T, float> val(data);
             float alpha = val[alpha_channel];
-            if (alpha != 0.0f && alpha != 1.0f) {
+            if (alpha != 1.0f) {
                 for (int c = 0; c < channels; c++)
                     if (c != alpha_channel)
                         val[c] = powf((powf(val[c], gamma)) * alpha, inv_gamma);

--- a/testsuite/png/ref/out-libpng15.txt
+++ b/testsuite/png/ref/out-libpng15.txt
@@ -12,7 +12,7 @@ Comparing "../oiio-images/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
 PASS
 Reading ../oiio-images/oiio-logo-with-alpha.png
 ../oiio-images/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
-    SHA-1: 9F3C517AC714A93C0FE93F8B4B40C68338504DC8
+    SHA-1: 8AED04DCCE8F83B068C537DC0982A42EFBE431B6
     channel list: R, G, B, A
     Comment: "Created with GIMP"
     DateTime: "2009:03:26 18:44:26"

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -12,7 +12,7 @@ Comparing "../oiio-images/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
 PASS
 Reading ../oiio-images/oiio-logo-with-alpha.png
 ../oiio-images/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
-    SHA-1: 9F3C517AC714A93C0FE93F8B4B40C68338504DC8
+    SHA-1: 8AED04DCCE8F83B068C537DC0982A42EFBE431B6
     channel list: R, G, B, A
     Comment: "Created with GIMP"
     DateTime: "2009:03:26 18:44:26"


### PR DESCRIPTION
In trying to avoid doing the color conversion pointlessly for pixels with alpha=0, I accidentally also managed to skip the multiplication by alpha for those pixels. Oops.
