### PR TITLE
fix(iba): IBA::transpose() didn't set output image's format to input

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -158,6 +158,12 @@ parallel_image(ROI roi, std::function<void(ROI)> f)
 ///     If nonzero and dst is uninitialized, then initialize it to float
 ///     regardless of the pixel types of the input images.
 ///
+///   - "dst_datatype" : string (default: "")
+///
+///     If not empty and dst is uninitialized, then initialize it to the data
+///     type indicated by the string regardless of the pixel types of any
+///     input images.
+///
 ///   - "minimize_nchannels" : int (default: 0)
 ///
 ///     If nonzero and dst is uninitialized and the multiple input images do

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -504,6 +504,13 @@ ImageBufAlgo::IBAprep(ROI& roi, ImageBuf& dst, cspan<const ImageBuf*> srcs,
             spec.nchannels = roi.chend;
             spec.default_channel_names();
         }
+
+        // If the user passed a dst_format, use it.
+        TypeDesc requested_format(options.get_string("dst_format"));
+        if (requested_format != TypeUnknown) {
+            spec.set_format(requested_format);
+        }
+
         // Set the image dimensions based on ROI.
         set_roi(spec, roi);
         if (full_roi.defined())

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -427,7 +427,8 @@ ImageBufAlgo::transpose(ImageBuf& dst, const ImageBuf& src, ROI roi,
     ROI dst_roi(roi.ybegin, roi.yend, roi.xbegin, roi.xend, roi.zbegin,
                 roi.zend, roi.chbegin, roi.chend);
     bool dst_initialized = dst.initialized();
-    if (!IBAprep(dst_roi, &dst))
+    ParamValue options[] = { { "dst_format", src.spec().format.c_str() } };
+    if (!IBAprep(dst_roi, dst, {}, options))
         return false;
     if (!dst_initialized) {
         ROI r = src.roi_full();


### PR DESCRIPTION
Because IBA::transpose changes resolution, it doesn't pass the input image to IBAPrep(), and there was a special case there that always set destination to float if there were no source images.

So change transpose to specifically request a format, to be the same as the input image.

And that required a tweak to IBAPrep allowing us to specify such a thing (there was already an option that meant "force it to float", but not the general case of an arbitrary type).
