### PR TITLE
fix: Stop suppressing fmtlib exceptions

### DIFF
--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -14,20 +14,6 @@
 #    define FMT_HEADER_ONLY
 #endif
 
-// Disable fmt exceptions
-#ifndef FMT_EXCEPTIONS
-#    define FMT_EXCEPTIONS 0
-#endif
-
-// Redefining FMT_THROW to something benign seems to avoid some UB or possibly
-// gcc 11+ compiler bug triggered by the definition of FMT_THROW in fmt 10.1+
-// when FMT_EXCEPTIONS=0, which results in mangling SIMD math. This nugget
-// below works around the problems for hard to understand reasons.
-#if !defined(FMT_THROW) && !FMT_EXCEPTIONS && OIIO_GNUC_VERSION >= 110000
-#    define FMT_THROW(x) \
-        OIIO_ASSERT_MSG(0, "fmt exception: %s", (x).what()), std::terminate()
-#endif
-
 // Use the grisu fast floating point formatting for old fmt versions
 // (irrelevant for >= 7.1).
 #ifndef FMT_USE_GRISU


### PR DESCRIPTION
It can't be worse than terminating.
