### PR TITLE
fix: Don't let fmtlib exceptions crash the app

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -281,7 +281,11 @@ using sync::print;
 
 
 namespace pvt {
+// Internal use only
 OIIO_UTIL_API void debug(string_view str);
+OIIO_UTIL_API void append_error(string_view str);
+OIIO_UTIL_API bool has_error();
+OIIO_UTIL_API std::string geterror(bool clear);
 }
 
 /// `debug(format, ...)` prints debugging message when attribute "debug" is

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -39,6 +39,7 @@ extern std::string output_format_list;
 extern std::string extension_list;
 extern std::string library_list;
 extern OIIO_UTIL_API int oiio_print_debug;
+extern OIIO_UTIL_API int oiio_print_uncaught_errors;
 extern int oiio_log_times;
 extern int openexr_core;
 extern int limit_channels;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -6372,6 +6372,12 @@ Oiiotool::getargs(int argc, char* argv[])
     ap.arg("--crash")
       .hidden()
       .action(crash_me);
+    ap.arg("--test-bad-format")
+      .hidden()
+      .action([&](cspan<const char*>){
+                  print("{}\n", Strutil::fmt::format("hey hey {:d} {}",
+                                                     "foo", "bar", "oops"));
+              });
 
     ap.separator("Commands that read images:");
     ap.arg("-i %s:FILENAME")

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -57,6 +57,12 @@ half data[2][2][3] =
   { /* (0, 1): */ { 0.000000000, 0.000000000, 0.000000000 },
     /* (1, 1): */ { 1.000000000, 1.000000000, 0.000000000 } },
 };
+testing bad format
+fmt exception: invalid format specifier
+hey hey foo bar
+OpenImageIO exited with a pending error message that was never
+retrieved via OIIO::geterror(). This was the error message:
+fmt exception: invalid format specifier
 Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -234,6 +234,9 @@ command += oiiotool ("--pattern fill:left=0,0,0:right=1,1,0 2x2 3 -d half -o dum
 command += oiiotool ("-echo dumpdata: --dumpdata dump.exr")
 command += oiiotool ("-echo dumpdata:C --dumpdata:C=data dump.exr")
 
+# Test printing uncaught errors (and finding bad fmt strings)
+command += oiiotool ("--echo \"testing bad format\" --test-bad-format")
+
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,
 # below.


### PR DESCRIPTION
When fmt arguments don't match the format string, fmt will throw an exception, or terminate if we disable exceptions (which we do).  For gcc11+, we tried intercepting these, but let's do it for all platforms, and let's not terminate ourselves, but insted print and log the error.

But, oof, to do this properly, I needed to move some error recording functionality from libOpenImageIO to libOpenImageIO_Util and make it owned more properly by strutil.cpp, so that this all works even when only using the util library. The logic isn't changing, it's just moving over to the other library.

This all helps to address #4388

Unfortunately, the exception thrown by fmt doesn't tell us the bad format string itself. That would have really allowed to probably zero right in on it. But at least we know it's occurring, and one could put a breakpoint on pvt::log_fmt_error to catch it in the act and see where it's being called, revealing the bad line.
