### PR TITLE
docs: Switch license name in docs

### DIFF
--- a/src/doc/index.rst
+++ b/src/doc/index.rst
@@ -27,7 +27,7 @@ OpenImageIO |version|
     `Web site <https://openimageio.org>`_ /
     `GitHub repository <https://github.com/AcademySoftwareFoundation/OpenImageIO>`_ /
     `Developer mail list <https://lists.aswf.io/g/oiio-dev>`_ /
-    `BSD License <https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/LICENSE.md>`_
+    `Apache 2.0 BSD License <https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/LICENSE.md>`_
 
 
 ------------


### PR DESCRIPTION
The link points to the Apache 2.0 license, we just never changed the label here.
