### PR TITLE
api: Adjust IBA::perpixel_op function signature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.15)
 
-set (OpenImageIO_VERSION "2.6.5.1")
+set (OpenImageIO_VERSION "2.6.6.0")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OpenImageIO_VERSION_OVERRIDE)

--- a/src/include/OpenImageIO/function_view.h
+++ b/src/include/OpenImageIO/function_view.h
@@ -77,7 +77,8 @@ template<typename Ret, typename... Params> class function_view<Ret(Params...)> {
     template<typename Callable>
     static Ret callback_fn(intptr_t callable, Params... params)
     {
-        return (*reinterpret_cast<Callable*>(callable))(params...);
+        return (*reinterpret_cast<Callable*>(callable))(
+            std::forward<Params>(params)...);
     }
 
 public:
@@ -97,7 +98,7 @@ public:
 
     Ret operator()(Params... params) const
     {
-        return callback(callable, params...);
+        return callback(callable, std::forward<Params>(params)...);
     }
 
     operator bool() const { return callback; }

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -7,6 +7,7 @@
 
 #include <functional>
 
+#include <OpenImageIO/function_view.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/parallel.h>
 
@@ -610,6 +611,8 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
 #define IBA_FIX_PERCHAN_LEN_DEF(av,len)                                 \
     IBA_FIX_PERCHAN_LEN (av, len, 0.0f, av.size() ? av.back() : 0.0f);
 
+// clang-format on
+
 
 
 /// Simple image per-pixel unary operation: Given a source image `src`, return
@@ -658,22 +661,20 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
 ///   version of the operation that allows specialization to any other pixel
 ///   data types
 //
-OIIO_NODISCARD OIIO_API
-ImageBuf
-perpixel_op(const ImageBuf& src, bool(*op)(span<float>, cspan<float>),
+OIIO_NODISCARD OIIO_API ImageBuf
+perpixel_op(const ImageBuf& src,
+            function_view<bool(span<float>, cspan<float>)> op,
             KWArgs options = {});
 
 /// A version of perpixel_op that performs a binary operation, taking two
 /// source images and a 3-argument `op` function that receives a destination
 /// and two source pixels.
-OIIO_NODISCARD OIIO_API
-ImageBuf
+OIIO_NODISCARD OIIO_API ImageBuf
 perpixel_op(const ImageBuf& srcA, const ImageBuf& srcB,
-            bool(*op)(span<float>, cspan<float>, cspan<float>),
+            function_view<bool(span<float>, cspan<float>, cspan<float>)> op,
             KWArgs options = {});
 
 }  // end namespace ImageBufAlgo
 
-// clang-format on
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -629,7 +629,8 @@ ImageBufAlgo::IBAprep(ROI& roi, ImageBuf& dst, cspan<const ImageBuf*> srcs,
 
 ImageBuf
 ImageBufAlgo::perpixel_op(const ImageBuf& src,
-                          bool (*op)(span<float>, cspan<float>), KWArgs options)
+                          function_view<bool(span<float>, cspan<float>)> op,
+                          KWArgs options)
 {
     using namespace ImageBufAlgo;
     ImageBuf result;
@@ -680,9 +681,10 @@ ImageBufAlgo::perpixel_op(const ImageBuf& src,
 
 
 ImageBuf
-ImageBufAlgo::perpixel_op(const ImageBuf& srcA, const ImageBuf& srcB,
-                          bool (*op)(span<float>, cspan<float>, cspan<float>),
-                          KWArgs options)
+ImageBufAlgo::perpixel_op(
+    const ImageBuf& srcA, const ImageBuf& srcB,
+    function_view<bool(span<float>, cspan<float>, cspan<float>)> op,
+    KWArgs options)
 {
     using namespace ImageBufAlgo;
     ImageBuf result;


### PR DESCRIPTION
When I added perpixel_op recently, I didn't get the function signature right. It only would work for plain old function pointers, and would not work properly for "functors" or lambdas with capture. I should have used function_view which can do a light-weight wrapper of all three, so now I do. Also modified imagebufalgo_test to explicitly test all three forms to be sure they work.

Also update function_view ever so slightly.
