### PR TITLE
fix demosaicing of int images

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_demosaic.cpp
+++ b/src/libOpenImageIO/imagebufalgo_demosaic.cpp
@@ -31,7 +31,7 @@ protected:
         /// the source iterator.
         struct Row {
             ImageBuf::ConstIterator<Atype> iterator;
-            Atype data[size];
+            float data[size];
         };
 
         std::vector<Row> rows;
@@ -270,7 +270,7 @@ private:
     mix1(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
          float& out_mix1, float& out_mix2)
     {
-        Atype tmp = w(0, 2) + w(4, 2) + w(2, 0) + w(2, 4);
+        float tmp = w(0, 2) + w(4, 2) + w(2, 0) + w(2, 4);
         out_mix1  = (8.0f * w(2, 2)
                     + 4.0f * (w(1, 2) + w(3, 2) + w(2, 1) + w(2, 3))
                     - 2.0f * tmp)

--- a/testsuite/oiiotool-demosaic/ref/out.txt
+++ b/testsuite/oiiotool-demosaic/ref/out.txt
@@ -1,16 +1,64 @@
-Computing diff of "testimage.exr" vs "RGGB-linear-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_RGGB-linear.exr"
 PASS
-Computing diff of "testimage.exr" vs "GRBG-linear-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_GRBG-linear.exr"
 PASS
-Computing diff of "testimage.exr" vs "GBRG-linear-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_GBRG-linear.exr"
 PASS
-Computing diff of "testimage.exr" vs "BGGR-linear-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_BGGR-linear.exr"
 PASS
-Computing diff of "testimage.exr" vs "RGGB-MHC-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_RGGB-MHC.exr"
 PASS
-Computing diff of "testimage.exr" vs "GRBG-MHC-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_GRBG-MHC.exr"
 PASS
-Computing diff of "testimage.exr" vs "GBRG-MHC-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_GBRG-MHC.exr"
 PASS
-Computing diff of "testimage.exr" vs "BGGR-MHC-result.exr"
+Computing diff of "testimage_float.exr" vs "result_float_BGGR-MHC.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_RGGB-linear.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_GRBG-linear.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_GBRG-linear.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_BGGR-linear.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_RGGB-MHC.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_GRBG-MHC.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_GBRG-MHC.exr"
+PASS
+Computing diff of "testimage_half.exr" vs "result_half_BGGR-MHC.exr"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_RGGB-linear.tiff"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_GRBG-linear.tiff"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_GBRG-linear.tiff"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_BGGR-linear.tiff"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_RGGB-MHC.tiff"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_GRBG-MHC.tiff"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_GBRG-MHC.tiff"
+PASS
+Computing diff of "testimage_uint16.tiff" vs "result_uint16_BGGR-MHC.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_RGGB-linear.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_GRBG-linear.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_GBRG-linear.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_BGGR-linear.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_RGGB-MHC.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_GRBG-MHC.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_GBRG-MHC.tiff"
+PASS
+Computing diff of "testimage_uint8.tiff" vs "result_uint8_BGGR-MHC.tiff"
 PASS

--- a/testsuite/oiiotool-demosaic/run.py
+++ b/testsuite/oiiotool-demosaic/run.py
@@ -25,27 +25,61 @@ layouts = {
 
 # Create a test image with color gradients
 make_testimage = f"--pattern fill:topleft=0,0,1:topright=0,1,0:bottomleft=1,0,1:bottomright=1,1,0 {width}x{height} 3 "
-command += oiiotool (make_testimage + " -o:type=half testimage.exr")
 
-# For each Bayer pattern (RGGB, RGRB, GBRG, BGGR), create an image with that
-# pure pattern ({pattern}.exr), then multiply it by the test image and take
-# the channel sum to get a Bayer mosaic image ({pattern}-bayer.exr).
-for pattern, maker in layouts.items():
-    command += oiiotool (f"{maker} -o:type=half {pattern}.exr testimage.exr -mul -chsum -o:type=half {pattern}-bayer.exr")
 
-test = " --fail 0.0005 --hardfail 0.0005 --warn 0.0005 --diff "
+types = [
+    {
+        "type" : "float",
+        "ext" : "exr",
+        "threshold": 0.0000003
+    },
+    {
+        "type" : "half",
+        "ext" : "exr",
+        "threshold": 0.0005
+    },
+    {
+        "type" : "uint16",
+        "ext" : "tiff",
+        "threshold": 0.000016
+    },
+    {
+        "type" : "uint8",
+        "ext" : "tiff",
+        "threshold": 0.004
+    }
+]
 
-# For each algorithm, try demosaicing each pattern test image and compare to
-# the original test image.
-for algo in ['linear', 'MHC']:
+    
+
+for dict in types:
+
+    type = dict["type"]
+    ext = dict["ext"]
+    threshold = dict["threshold"]
+
+    command += oiiotool (make_testimage + f" -o:type={type} testimage_{type}.{ext}")
+
+    # For each Bayer pattern (RGGB, RGRB, GBRG, BGGR), create an image with that
+    # pure pattern ({pattern}.exr), then multiply it by the test image and take
+    # the channel sum to get a Bayer mosaic image ({pattern}-bayer.exr).
     for pattern, maker in layouts.items():
-        command += oiiotool (f"testimage.exr {pattern}-bayer.exr --demosaic:algorithm={algo}:layout={pattern} -o:type=half {pattern}-{algo}-result.exr ")
-        
-        crop = 2
-        
-        if crop > 0:
-            cut_cmd = f"-cut {{TOP.width-{crop}*2}}x{{TOP.height-{crop}*2}}+{{TOP.x+{crop}}}+{{TOP.y+{crop}}} "
-        else:
-            cut_cmd = ""
-                    
-        command += oiiotool ("testimage.exr " + cut_cmd + f"{pattern}-{algo}-result.exr " + cut_cmd + test)
+        command += oiiotool (f"{maker} -o:type={type} pattern_{type}_{pattern}.{ext} testimage_{type}.{ext} -mul -chsum -o:type={type} bayer_{type}_{pattern}.{ext}")
+
+    test = f" --fail {threshold} --hardfail {threshold} --warn {threshold} --diff "
+
+
+    # For each algorithm, try demosaicing each pattern test image and compare to
+    # the original test image.
+    for algo in ['linear', 'MHC']:
+        for pattern, maker in layouts.items():
+            command += oiiotool (f"-i:type={type} testimage_{type}.{ext} -i:type={type} bayer_{type}_{pattern}.{ext} --demosaic:algorithm={algo}:layout={pattern} -o:type={type} result_{type}_{pattern}-{algo}.{ext} ")
+            
+            crop = 2
+            
+            if crop > 0:
+                cut_cmd = f"-cut {{TOP.width-{crop}*2}}x{{TOP.height-{crop}*2}}+{{TOP.x+{crop}}}+{{TOP.y+{crop}}} "
+            else:
+                cut_cmd = ""
+                        
+            command += oiiotool (f"testimage_{type}.{ext} " + cut_cmd + f"result_{type}_{pattern}-{algo}.{ext} " + cut_cmd + test)


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Fixes the bug where IBA::demosaic only works with float images. 

Fixes#4416

## Tests

I've extended the unit tests to run on float, half, uint16, uint8 images.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
