### PR TITLE
deps: Add a build recipe for yaml-cpp

### DIFF
--- a/src/cmake/build_OpenColorIO.cmake
+++ b/src/cmake/build_OpenColorIO.cmake
@@ -15,6 +15,9 @@ set_cache (OpenColorIO_BUILD_SHARED_LIBS  ON
 # it all work with the static dependencies, it just makes things complicated
 # downstream.
 
+checked_find_package (yaml-cpp
+                      VERSION_MIN 0.6.0 )  # Used by OpenColorIO
+
 # Clear variables from the failed find_package
 unset (OPENCOLORIO_LIBRARY)
 unset (OPENCOLORIO_INCLUDE_DIR)

--- a/src/cmake/build_yaml-cpp.cmake
+++ b/src/cmake/build_yaml-cpp.cmake
@@ -1,0 +1,41 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+######################################################################
+# yaml-cpp by hand!
+######################################################################
+
+set_cache (yaml-cpp_BUILD_VERSION 0.8.0 "yaml-cpp version for local builds")
+set (yaml-cpp_GIT_REPOSITORY "https://github.com/jbeder/yaml-cpp")
+set (yaml-cpp_GIT_TAG "${yaml-cpp_BUILD_VERSION}") # NB: versions earlier than 0.8.0 had a "yaml-cpp-" prefix
+
+set_cache (yaml-cpp_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
+           DOC "Should a local yaml-cpp build, if necessary, build shared libraries" ADVANCED)
+
+string (MAKE_C_IDENTIFIER ${yaml-cpp_BUILD_VERSION} yaml-cpp_VERSION_IDENT)
+
+build_dependency_with_cmake(yaml-cpp
+    VERSION         ${yaml-cpp_BUILD_VERSION}
+    GIT_REPOSITORY  ${yaml-cpp_GIT_REPOSITORY}
+    GIT_TAG         ${yaml-cpp_GIT_TAG}
+    CMAKE_ARGS
+        -D YAML_CPP_BUILD_TESTS=OFF
+        -D YAML_CPP_BUILD_TOOLS=OFF
+        -D YAML_CPP_BUILD_CONTRIB=OFF
+        -D YAML_BUILD_SHARED_LIBS=${yaml-cpp_BUILD_SHARED_LIBS}
+        -D CMAKE_INSTALL_LIBDIR=lib
+    )
+
+set (yaml-cpp_ROOT ${yaml-cpp_LOCAL_INSTALL_DIR})
+set (yaml-cpp_DIR ${yaml-cpp_LOCAL_INSTALL_DIR})
+set (yaml-cpp_VERSION ${yaml-cpp_BUILD_VERSION})
+
+set (yaml-cpp_REFIND TRUE)
+set (yaml-cpp_REFIND_ARGS CONFIG)
+set (yaml-cpp_REFIND_VERSION ${yaml-cpp_BUILD_VERSION})
+
+
+if (yaml-cpp_BUILD_SHARED_LIBS)
+    install_local_dependency_libs (yaml-cpp yaml-cpp)
+endif ()

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -129,6 +129,9 @@ checked_find_package (Freetype
                       VERSION_MIN 2.10.0
                       DEFINITIONS USE_FREETYPE=1 )
 
+checked_find_package (yaml-cpp
+                      VERSION_MIN 0.6.0 )  # Used by OpenColorIO
+
 checked_find_package (OpenColorIO REQUIRED
                       VERSION_MIN 2.2
                       VERSION_MAX 2.9

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -129,9 +129,6 @@ checked_find_package (Freetype
                       VERSION_MIN 2.10.0
                       DEFINITIONS USE_FREETYPE=1 )
 
-checked_find_package (yaml-cpp
-                      VERSION_MIN 0.6.0 )  # Used by OpenColorIO
-
 checked_find_package (OpenColorIO REQUIRED
                       VERSION_MIN 2.2
                       VERSION_MAX 2.9


### PR DESCRIPTION
Apparently necessary for producing working Python binary distributions on Windows (if OpenColorIO is not already available).

I've briefly discussed this in the ASWF/openimageio and OpenColorIO/dev Slack channels. It's not immediately clear why, but the Windows Wheel workflow runners seem to run into trouble when the OCIO build system tries to build the missing yaml-cpp dependency itself. It ends up building both static and dynamic libraries, and getting confused shortly after.

