### PR TITLE
build: No need for OCIO search to use PREFER_CONFIG

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -132,7 +132,6 @@ checked_find_package (Freetype
 checked_find_package (OpenColorIO REQUIRED
                       VERSION_MIN 2.2
                       VERSION_MAX 2.9
-                      PREFER_CONFIG
                      )
 if (NOT OPENCOLORIO_INCLUDES)
     get_target_property(OPENCOLORIO_INCLUDES OpenColorIO::OpenColorIO INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
We no longer supply a FindOpenColorIO.cmake, so it makes no difference. But it was getting in the way of a weird case where a wrapping project wanted to supply one.
