### PR TITLE
api(IB)!: Add span based ImageBuf methods for getpixel/setpixel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.15)
 
-set (OpenImageIO_VERSION "2.6.6.0")
+set (OpenImageIO_VERSION "2.6.7.0")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OpenImageIO_VERSION_OVERRIDE)

--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -163,10 +163,10 @@ Getting and setting pixel values
 .. doxygenfunction:: OIIO::ImageBuf::getchannel
 .. doxygenfunction:: OIIO::ImageBuf::getpixel(int x, int y, int z, float *pixel, int maxchannels = 1000, WrapMode wrap = WrapBlack) const
 
-.. doxygenfunction:: OIIO::ImageBuf::interppixel
-.. doxygenfunction:: OIIO::ImageBuf::interppixel_bicubic
-.. doxygenfunction:: OIIO::ImageBuf::interppixel_NDC
-.. doxygenfunction:: OIIO::ImageBuf::interppixel_bicubic_NDC
+.. doxygenfunction:: OIIO::ImageBuf::interppixel(float, float, span<float>, WrapMode) const
+.. doxygenfunction:: OIIO::ImageBuf::interppixel_bicubic(float, float, span<float>, WrapMode) const
+.. doxygenfunction:: OIIO::ImageBuf::interppixel_NDC(float, float, span<float>, WrapMode) const
+.. doxygenfunction:: OIIO::ImageBuf::interppixel_bicubic_NDC(float, float, span<float>, WrapMode) const
 
 .. doxygenfunction:: OIIO::ImageBuf::setpixel(int x, int y, int z, cspan<float> pixel)
 .. doxygenfunction:: OIIO::ImageBuf::setpixel(int i, cspan<float> pixel)
@@ -175,8 +175,10 @@ Getting and setting pixel values
 
 **Getting and setting regions of pixels -- fast**
 
-.. doxygenfunction:: OIIO::ImageBuf::get_pixels
-.. doxygenfunction:: OIIO::ImageBuf::set_pixels
+.. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, span<T>, stride_t, stride_t, stride_t) const
+.. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, span<T>, T*, stride_t, stride_t, stride_t) const
+.. doxygenfunction:: OIIO::ImageBuf::set_pixels(ROI, span<T>, stride_t, stride_t, stride_t)
+.. doxygenfunction:: OIIO::ImageBuf::set_pixels(ROI, span<T>, const T*, stride_t, stride_t, stride_t)
 
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3370,6 +3370,19 @@ OIIO_API bool copy_image (int nchannels, int width, int height, int depth,
                           void *dst, stride_t dst_xstride,
                           stride_t dst_ystride, stride_t dst_zstride);
 
+/// Helper: manufacture a span given an image pointer, format, size, and
+/// strides. Use with caution! This is making a lot of assumptions that the
+/// data pointer really does point to memory that's ok to access according to
+/// the sizes and strides you give.
+OIIO_API span<std::byte>
+span_from_buffer(void* data, TypeDesc format, int nchannels, int width,
+                 int height, int depth, stride_t xstride = AutoStride, stride_t ystride = AutoStride,
+                 stride_t zstride = AutoStride);
+OIIO_API cspan<std::byte>
+cspan_from_buffer(const void* data, TypeDesc format, int nchannels, int width,
+                 int height, int depth, stride_t xstride = AutoStride, stride_t ystride = AutoStride,
+                 stride_t zstride = AutoStride);
+
 
 // All the wrap_foo functions implement a wrap mode, wherein coord is
 // altered to be origin <= coord < origin+width.  The return value

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -558,6 +558,35 @@ spanzero(span<T> dst, size_t offset = 0, size_t n = size_t(-1))
 }
 
 
+
+/// Does the byte span `query` lie entirely within the safe `bounds` span?
+inline bool
+span_within(cspan<std::byte> bounds, cspan<std::byte> query)
+{
+    return query.data() >= bounds.data()
+           && query.data() + query.size() <= bounds.data() + bounds.size();
+}
+
+
+
+/// Verify the `ptr[0..len-1]` lies entirely within the given span `s`, which
+/// does not need to be the same data type.  Return true if that is the case,
+/// false if it extends beyond the safe limits fo the span.
+template<typename SpanType, typename PtrType>
+inline bool
+check_span(span<SpanType> s, const PtrType* ptr, size_t len = 1)
+{
+    return span_within(as_bytes(s), as_bytes(make_cspan(ptr, len)));
+}
+
+
+
+/// OIIO_ALLOCASPAN is used to allocate smallish amount of memory on the
+/// stack, equivalent of C99 type var_name[size], and then return a span
+/// encompassing it.
+#define OIIO_ALLOCA_SPAN(type, size) span<type>(OIIO_ALLOCA(type, size), size)
+
+
 OIIO_NAMESPACE_END
 
 

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -116,7 +116,7 @@ public:
     /// color space correction when indicated.
     void pixel_transform(bool srgb_to_linear, int color_mode, int channel);
 
-    bool get_pixels(ROI roi, TypeDesc format, void* result)
+    bool get_pixels(ROI roi, TypeDesc format, span<std::byte> result)
     {
         if (m_corrected_image.localpixels())
             return m_corrected_image.get_pixels(roi, format, result);

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -84,6 +84,54 @@ set_roi_full(ImageSpec& spec, const ROI& newroi)
 
 
 
+span<std::byte>
+span_from_buffer(void* data, TypeDesc format, int nchannels, int width,
+                 int height, int depth, stride_t xstride, stride_t ystride,
+                 stride_t zstride)
+{
+    ImageSpec::auto_stride(xstride, ystride, zstride, format.size(), nchannels,
+                           width, height);
+    // Need to figure out the span based on the origin and strides.
+    // Start with the span range of one pixel.
+    std::byte* bufstart = (std::byte*)data;
+    std::byte* bufend   = bufstart + format.size() * nchannels;
+    // Expand to the span range for one row. Remember negative strides!
+    if (xstride >= 0) {
+        bufend += xstride * (width - 1);
+    } else {
+        bufstart -= xstride * (width - 1);
+    }
+    // Expand to the span range for a whole image plane.
+    if (ystride >= 0) {
+        bufend += ystride * (height - 1);
+    } else {
+        bufstart -= ystride * (height - 1);
+    }
+    // Expand to the span range for a whole volume.
+    if (depth > 1 && zstride != 0) {
+        if (zstride >= 0) {
+            bufend += zstride * (depth - 1);
+        } else {
+            bufstart -= zstride * (depth - 1);
+        }
+    }
+    return { bufstart, size_t(bufend - bufstart) };
+}
+
+
+
+cspan<std::byte>
+cspan_from_buffer(const void* data, TypeDesc format, int nchannels, int width,
+                  int height, int depth, stride_t xstride, stride_t ystride,
+                  stride_t zstride)
+{
+    auto s = span_from_buffer(const_cast<void*>(data), format, nchannels, width,
+                              height, depth, xstride, ystride, zstride);
+    return { s.data(), s.size() };
+}
+
+
+
 // Expansion of the opaque type that hides all the ImageBuf implementation
 // detail.
 class ImageBufImpl {
@@ -836,34 +884,14 @@ ImageBufImpl::set_bufspan_localpixels(span<std::byte> bufspan,
     if (bufspan.size() && !buforigin) {
         buforigin = bufspan.data();
     } else if (buforigin && (!bufspan.data() || bufspan.empty())) {
-        // Need to figure out the span based on the origin and strides.
-        // Start with the span range of one pixel.
-        std::byte* bufstart = (std::byte*)buforigin;
-        std::byte* bufend   = bufstart + m_spec.format.size();
-        // Expand to the span range for one row. Remember negative strides!
-        if (m_xstride >= 0) {
-            bufend += m_xstride * (m_spec.width - 1);
-        } else {
-            bufstart -= m_xstride * (m_spec.width - 1);
-        }
-        // Expand to the span range for a whole image plane.
-        if (m_ystride >= 0) {
-            bufend += m_ystride * (m_spec.height - 1);
-        } else {
-            bufstart -= m_ystride * (m_spec.height - 1);
-        }
-        // Expand to the span range for a whole volume.
-        if (m_spec.depth > 1 && m_zstride != 0) {
-            if (m_zstride >= 0) {
-                bufend += m_zstride * (m_spec.depth - 1);
-            } else {
-                bufstart -= m_zstride * (m_spec.depth - 1);
-            }
-        }
-        bufspan = span { bufstart, size_t(bufend - bufstart) };
+        bufspan = span_from_buffer(const_cast<void*>(buforigin), m_spec.format,
+                                   m_spec.nchannels, m_spec.width,
+                                   m_spec.height, m_spec.depth, m_xstride,
+                                   m_ystride, m_zstride);
     }
     m_bufspan     = bufspan;
     m_localpixels = (char*)buforigin;
+    OIIO_DASSERT(check_span(m_bufspan, m_localpixels, spec().format));
 }
 
 
@@ -1460,9 +1488,9 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
         imagesize_t imagesize    = bufspec.image_bytes();
         if (imagesize <= budget) {
             // whole image can fit within our budget
-            std::unique_ptr<char[]> tmp(new char[imagesize]);
-            ok &= get_pixels(roi(), bufformat, &tmp[0]);
-            ok &= out->write_image(bufformat, &tmp[0], AutoStride, AutoStride,
+            std::unique_ptr<std::byte[]> tmp(new std::byte[imagesize]);
+            ok &= get_pixels(roi(), bufformat, make_span(tmp.get(), imagesize));
+            ok &= out->write_image(bufformat, tmp.get(), AutoStride, AutoStride,
                                    AutoStride, progress_callback,
                                    progress_callback_data);
         } else if (outspec.tile_width) {
@@ -1470,7 +1498,8 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
             size_t pixelsize = bufspec.pixel_bytes();
             size_t chunksize = pixelsize * outspec.width * outspec.tile_height
                                * outspec.tile_depth;
-            std::unique_ptr<char[]> tmp(new char[chunksize]);
+            std::unique_ptr<std::byte[]> tmp(new std::byte[chunksize]);
+            auto tmpspan = make_span(tmp.get(), chunksize);
             for (int z = 0; z < outspec.depth; z += outspec.tile_depth) {
                 int zend = std::min(z + outspec.z + outspec.tile_depth,
                                     outspec.z + outspec.depth);
@@ -1481,7 +1510,7 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
                     ok &= get_pixels(ROI(outspec.x, outspec.x + outspec.width,
                                          outspec.y + y, yend, outspec.z + z,
                                          zend),
-                                     bufformat, &tmp[0]);
+                                     bufformat, tmpspan);
                     ok &= out->write_tiles(outspec.x, outspec.x + outspec.width,
                                            y + outspec.y, yend, z + outspec.z,
                                            zend, bufformat, &tmp[0]);
@@ -1498,7 +1527,8 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
             imagesize_t slsize = bufspec.scanline_bytes();
             int chunk = clamp(round_to_multiple(int(budget / slsize), 64), 1,
                               1024);
-            std::unique_ptr<char[]> tmp(new char[chunk * slsize]);
+            std::unique_ptr<std::byte[]> tmp(new std::byte[chunk * slsize]);
+            auto tmpspan = make_span(tmp.get(), chunk * slsize);
 
             // Special handling for flipped vertical scanline order. Right now, OpenEXR
             // is the only format that allows it, so we special case it by name. For
@@ -1521,7 +1551,7 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
                     ok &= get_pixels(ROI(outspec.x, outspec.x + outspec.width,
                                          outspec.y + y, yend, outspec.z,
                                          outspec.z + outspec.depth),
-                                     bufformat, &tmp[0]);
+                                     bufformat, tmpspan);
                     ok &= out->write_scanlines(y + outspec.y, yend,
                                                z + outspec.z, bufformat,
                                                &tmp[0]);
@@ -2188,11 +2218,12 @@ ImageBuf::getchannel(int x, int y, int z, int c, WrapMode wrap) const
 
 template<typename T>
 static bool
-getpixel_(const ImageBuf& buf, int x, int y, int z, float* result, int chans,
+getpixel_(const ImageBuf& buf, int x, int y, int z, span<float> result,
           ImageBuf::WrapMode wrap)
 {
+    OIIO_DASSERT(result.size() <= size_t(buf.spec().nchannels));
     ImageBuf::ConstIterator<T> pixel(buf, x, y, z, wrap);
-    for (int i = 0; i < chans; ++i)
+    for (size_t i = 0, e = result.size(); i < e; ++i)
         result[i] = pixel[i];
     return true;
 }
@@ -2200,33 +2231,32 @@ getpixel_(const ImageBuf& buf, int x, int y, int z, float* result, int chans,
 
 
 inline bool
-getpixel_wrapper(int x, int y, int z, float* pixel, int nchans,
+getpixel_wrapper(int x, int y, int z, span<float> pixel,
                  ImageBuf::WrapMode wrap, const ImageBuf& ib)
 {
     bool ok;
     OIIO_DISPATCH_TYPES(ok, "getpixel", getpixel_, ib.spec().format, ib, x, y,
-                        z, pixel, nchans, wrap);
+                        z, pixel, wrap);
     return ok;
 }
 
 
 
 void
-ImageBuf::getpixel(int x, int y, int z, float* pixel, int maxchannels,
-                   WrapMode wrap) const
+ImageBuf::getpixel(int x, int y, int z, span<float> pixel, WrapMode wrap) const
 {
-    int nchans = std::min(spec().nchannels, maxchannels);
-    getpixel_wrapper(x, y, z, pixel, nchans, wrap, *this);
+    pixel = pixel.subspan(0, std::min(size_t(spec().nchannels), pixel.size()));
+    getpixel_wrapper(x, y, z, pixel, wrap, *this);
 }
 
 
 
 template<class T>
 static bool
-interppixel_(const ImageBuf& img, float x, float y, float* pixel,
+interppixel_(const ImageBuf& img, float x, float y, span<float> pixel,
              ImageBuf::WrapMode wrap)
 {
-    int n             = img.spec().nchannels;
+    int n             = std::min(int(pixel.size()), img.spec().nchannels);
     float* localpixel = OIIO_ALLOCA(float, n * 4);
     float* p[4]       = { localpixel, localpixel + n, localpixel + 2 * n,
                           localpixel + 3 * n };
@@ -2241,15 +2271,15 @@ interppixel_(const ImageBuf& img, float x, float y, float* pixel,
     for (int i = 0; i < 4; ++i, ++it)
         for (int c = 0; c < n; ++c)
             p[i][c] = it[c];  //NOSONAR
-    bilerp(p[0], p[1], p[2], p[3], xfrac, yfrac, n, pixel);
+    bilerp(p[0], p[1], p[2], p[3], xfrac, yfrac, n, pixel.data());
     return true;
 }
 
 
 
 inline bool
-interppixel_wrapper(float x, float y, float* pixel, ImageBuf::WrapMode wrap,
-                    const ImageBuf& img)
+interppixel_wrapper(float x, float y, span<float> pixel,
+                    ImageBuf::WrapMode wrap, const ImageBuf& img)
 {
     bool ok;
     OIIO_DISPATCH_TYPES(ok, "interppixel", interppixel_, img.spec().format, img,
@@ -2260,7 +2290,7 @@ interppixel_wrapper(float x, float y, float* pixel, ImageBuf::WrapMode wrap,
 
 
 void
-ImageBuf::interppixel(float x, float y, float* pixel, WrapMode wrap) const
+ImageBuf::interppixel(float x, float y, span<float> pixel, WrapMode wrap) const
 {
     interppixel_wrapper(x, y, pixel, wrap, *this);
 }
@@ -2268,7 +2298,8 @@ ImageBuf::interppixel(float x, float y, float* pixel, WrapMode wrap) const
 
 
 void
-ImageBuf::interppixel_NDC(float x, float y, float* pixel, WrapMode wrap) const
+ImageBuf::interppixel_NDC(float x, float y, span<float> pixel,
+                          WrapMode wrap) const
 {
     const ImageSpec& spec(m_impl->spec());
     interppixel(static_cast<float>(spec.full_x)
@@ -2282,10 +2313,10 @@ ImageBuf::interppixel_NDC(float x, float y, float* pixel, WrapMode wrap) const
 
 template<class T>
 static bool
-interppixel_bicubic_(const ImageBuf& img, float x, float y, float* pixel,
+interppixel_bicubic_(const ImageBuf& img, float x, float y, span<float> pixel,
                      ImageBuf::WrapMode wrap)
 {
-    int n = img.spec().nchannels;
+    int n = std::min(img.spec().nchannels, int(pixel.size()));
     x -= 0.5f;
     y -= 0.5f;
     int xtexel, ytexel;
@@ -2314,7 +2345,7 @@ interppixel_bicubic_(const ImageBuf& img, float x, float y, float* pixel,
 
 
 inline bool
-interppixel_bicubic_wrapper(float x, float y, float* pixel,
+interppixel_bicubic_wrapper(float x, float y, span<float> pixel,
                             ImageBuf::WrapMode wrap, const ImageBuf& img)
 {
     bool ok;
@@ -2326,7 +2357,7 @@ interppixel_bicubic_wrapper(float x, float y, float* pixel,
 
 
 void
-ImageBuf::interppixel_bicubic(float x, float y, float* pixel,
+ImageBuf::interppixel_bicubic(float x, float y, span<float> pixel,
                               WrapMode wrap) const
 {
     interppixel_bicubic_wrapper(x, y, pixel, wrap, *this);
@@ -2335,7 +2366,7 @@ ImageBuf::interppixel_bicubic(float x, float y, float* pixel,
 
 
 void
-ImageBuf::interppixel_bicubic_NDC(float x, float y, float* pixel,
+ImageBuf::interppixel_bicubic_NDC(float x, float y, span<float> pixel,
                                   WrapMode wrap) const
 {
     const ImageSpec& spec(m_impl->spec());
@@ -2362,9 +2393,10 @@ setpixel_(ImageBuf& buf, int x, int y, int z, const float* data, int chans)
 
 
 void
-ImageBuf::setpixel(int x, int y, int z, const float* pixel, int maxchannels)
+ImageBuf::setpixel(int x, int y, int z, cspan<float> pixelspan)
 {
-    int n = std::min(spec().nchannels, maxchannels);
+    const float* pixel = pixelspan.data();
+    int n              = std::min(spec().nchannels, int(pixelspan.size()));
     switch (spec().format.basetype) {
     case TypeDesc::FLOAT: setpixel_<float>(*this, x, y, z, pixel, n); break;
     case TypeDesc::UINT8:
@@ -2389,15 +2421,6 @@ ImageBuf::setpixel(int x, int y, int z, const float* pixel, int maxchannels)
         OIIO_ASSERT_MSG(0, "Unknown/unsupported data type %d",
                         spec().format.basetype);
     }
-}
-
-
-
-void
-ImageBuf::setpixel(int i, const float* pixel, int maxchannels)
-{
-    setpixel(spec().x + (i % spec().width), spec().y + (i / spec().width),
-             pixel, maxchannels);
 }
 
 
@@ -2431,14 +2454,23 @@ get_pixels_(const ImageBuf& buf, const ImageBuf& /*dummy*/, ROI whole_roi,
 
 
 bool
-ImageBuf::get_pixels(ROI roi, TypeDesc format, void* result, stride_t xstride,
-                     stride_t ystride, stride_t zstride) const
+ImageBuf::get_pixels(ROI roi, TypeDesc format, span<std::byte> buffer,
+                     void* buforigin, stride_t xstride, stride_t ystride,
+                     stride_t zstride) const
 {
     if (!roi.defined())
         roi = this->roi();
     roi.chend = std::min(roi.chend, nchannels());
     ImageSpec::auto_stride(xstride, ystride, zstride, format.size(),
                            roi.nchannels(), roi.width(), roi.height());
+    void* result = buforigin ? buforigin : buffer.data();
+    auto range = span_from_buffer(result, format, roi.nchannels(), roi.width(),
+                                  roi.height(), roi.depth(), xstride, ystride,
+                                  zstride);
+    if (!span_within(buffer, range)) {
+        errorfmt("get_pixels: buffer span does not contain the ROI dimensions");
+        return false;
+    }
     if (localpixels() && this->roi().contains(roi)) {
         // Easy case -- if the buffer is already fully in memory and the roi
         // is completely contained in the pixel window, this reduces to a
@@ -2462,14 +2494,30 @@ ImageBuf::get_pixels(ROI roi, TypeDesc format, void* result, stride_t xstride,
 
 
 
+bool
+ImageBuf::get_pixels(ROI roi, TypeDesc format, void* result, stride_t xstride,
+                     stride_t ystride, stride_t zstride) const
+{
+    if (!roi.defined())
+        roi = this->roi();
+    roi.chend = std::min(roi.chend, nchannels());
+    ImageSpec::auto_stride(xstride, ystride, zstride, format.size(),
+                           roi.nchannels(), roi.width(), roi.height());
+    auto range = span_from_buffer(result, format, roi.nchannels(), roi.width(),
+                                  roi.height(), roi.depth(), xstride, ystride,
+                                  zstride);
+    return get_pixels(roi, format, range, result, xstride, ystride, zstride);
+}
+
+
+
 template<typename D, typename S>
 static bool
 set_pixels_(ImageBuf& buf, ROI roi, const void* data_, stride_t xstride,
             stride_t ystride, stride_t zstride)
 {
     const D* data = (const D*)data_;
-    int w = roi.width(), h = roi.height(), nchans = roi.nchannels();
-    ImageSpec::auto_stride(xstride, ystride, zstride, sizeof(S), nchans, w, h);
+    int nchans    = roi.nchannels();
     for (ImageBuf::Iterator<D, S> p(buf, roi); !p.done(); ++p) {
         if (!p.exists())
             continue;
@@ -2493,12 +2541,48 @@ ImageBuf::set_pixels(ROI roi, TypeDesc format, const void* data,
         errorfmt("Cannot set_pixels() on an uninitialized ImageBuf");
         return false;
     }
+    if (!roi.defined())
+        roi = this->roi();
+    roi.chend = std::min(roi.chend, nchannels());
+
+    ImageSpec::auto_stride(xstride, ystride, zstride, format.size(),
+                           roi.nchannels(), roi.width(), roi.height());
+
+    bool ok;
+    OIIO_DISPATCH_TYPES2(ok, "set_pixels", set_pixels_, spec().format, format,
+                         *this, roi, data, xstride, ystride, zstride);
+    return ok;
+}
+
+
+
+bool
+ImageBuf::set_pixels(ROI roi, TypeDesc format, cspan<std::byte> buffer,
+                     const void* buforigin, stride_t xstride, stride_t ystride,
+                     stride_t zstride)
+{
+    if (!initialized()) {
+        errorfmt("Cannot set_pixels() on an uninitialized ImageBuf");
+        return false;
+    }
     bool ok;
     if (!roi.defined())
         roi = this->roi();
     roi.chend = std::min(roi.chend, nchannels());
+
+    ImageSpec::auto_stride(xstride, ystride, zstride, format.size(),
+                           roi.nchannels(), roi.width(), roi.height());
+    const void* result = buforigin ? buforigin : buffer.data();
+    auto range = cspan_from_buffer(result, format, roi.nchannels(), roi.width(),
+                                   roi.height(), roi.depth(), xstride, ystride,
+                                   zstride);
+    if (!span_within(buffer, range)) {
+        errorfmt("set_pixels: buffer span does not contain the ROI dimensions");
+        return false;
+    }
+
     OIIO_DISPATCH_TYPES2(ok, "set_pixels", set_pixels_, spec().format, format,
-                         *this, roi, data, xstride, ystride, zstride);
+                         *this, roi, result, xstride, ystride, zstride);
     return ok;
 }
 
@@ -2843,7 +2927,7 @@ ImageBuf::set_roi_full(const ROI& newroi)
 
 
 bool
-ImageBuf::contains_roi(ROI roi) const
+ImageBuf::contains_roi(const ROI& roi) const
 {
     ROI myroi = this->roi();
     return (roi.defined() && myroi.defined() && roi.xbegin >= myroi.xbegin

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -923,7 +923,7 @@ ImageBufAlgo::make_kernel(string_view name, float width, float height,
     } else if (Strutil::iequals(name, "laplacian") && w == 3 && h == 3
                && d == 1) {
         const float vals[9] = { 0, 1, 0, 1, -4, 1, 0, 1, 0 };
-        dst.set_pixels(dst.roi(), TypeDesc::FLOAT, vals, sizeof(float),
+        dst.set_pixels(dst.roi(), make_cspan(vals), sizeof(float),
                        h * sizeof(float));
         normalize = false;  // sums to zero, so don't normalize it */
     } else {

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -826,7 +826,7 @@ simplePixelHashSHA1(const ImageBuf& src, string_view extrainfo, ROI roi)
     // Do it a few scanlines at a time
     int chunk = std::max(1, int(16 * 1024 * 1024 / scanline_bytes));
 
-    std::vector<unsigned char> tmp;
+    std::vector<std::byte> tmp;
     if (!localpixels)
         tmp.resize(chunk * scanline_bytes);
 
@@ -839,7 +839,7 @@ simplePixelHashSHA1(const ImageBuf& src, string_view extrainfo, ROI roi)
                            size_t(scanline_bytes * (y1 - y)));
             } else {
                 src.get_pixels(ROI(roi.xbegin, roi.xend, y, y1, z, z + 1),
-                               src.spec().format, &tmp[0]);
+                               src.spec().format, tmp);
                 sha.append(&tmp[0], size_t(scanline_bytes) * (y1 - y));
             }
         }

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -177,7 +177,7 @@ ImageBufAlgo::deepen(ImageBuf& dst, const ImageBuf& src, float zvalue, ROI roi,
         return false;
     }
 
-    float* pixel = OIIO_ALLOCA(float, nc);
+    span<float> pixel = OIIO_ALLOCA_SPAN(float, nc);
 
     // First, figure out which pixels get a sample and which do not
     for (int z = roi.zbegin; z < roi.zend; ++z)

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -1138,7 +1138,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
                 int rx  = x + i + slot->bitmap_left;
                 float b = slot->bitmap.buffer[slot->bitmap.pitch * j + i]
                           / 255.0f;
-                textimg.setpixel(rx, ry, &b, 1);
+                textimg.setpixel(rx, ry, b);
             }
         }
         // increment pen position
@@ -1160,7 +1160,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     roi = roi_intersection(textroi, R.roi());
 
     // Now fill in the pixels of our destination image
-    float* pixelcolor = OIIO_ALLOCA(float, nchannels);
+    span<float> pixelcolor = OIIO_ALLOCA_SPAN(float, nchannels);
     ImageBuf::ConstIterator<float> t(textimg, roi, ImageBuf::WrapBlack);
     ImageBuf::ConstIterator<float> a(alphaimg, roi, ImageBuf::WrapBlack);
     ImageBuf::Iterator<float> r(R, roi);

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -140,9 +140,9 @@ test_zero_fill()
 
     // Set a pixel to an odd value, make sure it takes
     const float arbitrary1[CHANNELS] = { 0.2f, 0.3f, 0.4f, 0.5f };
-    A.setpixel(1, 1, arbitrary1);
+    A.setpixel(1, 1, make_span(arbitrary1));
     float pixel[CHANNELS];  // test pixel
-    A.getpixel(1, 1, pixel);
+    A.getpixel(1, 1, make_span(pixel));
     for (int c = 0; c < CHANNELS; ++c)
         OIIO_CHECK_EQUAL(pixel[c], arbitrary1[c]);
 
@@ -151,7 +151,7 @@ test_zero_fill()
     for (int j = 0; j < HEIGHT; ++j) {
         for (int i = 0; i < WIDTH; ++i) {
             float pixel[CHANNELS];
-            A.getpixel(i, j, pixel);
+            A.getpixel(i, j, make_span(pixel));
             for (int c = 0; c < CHANNELS; ++c)
                 OIIO_CHECK_EQUAL(pixel[c], 0.0f);
         }
@@ -163,7 +163,7 @@ test_zero_fill()
     for (int j = 0; j < HEIGHT; ++j) {
         for (int i = 0; i < WIDTH; ++i) {
             float pixel[CHANNELS];
-            A.getpixel(i, j, pixel);
+            A.getpixel(i, j, make_span(pixel));
             for (int c = 0; c < CHANNELS; ++c)
                 OIIO_CHECK_EQUAL(pixel[c], arbitrary2[c]);
         }
@@ -178,7 +178,7 @@ test_zero_fill()
         for (int j = 0; j < HEIGHT; ++j) {
             for (int i = 0; i < WIDTH; ++i) {
                 float pixel[CHANNELS];
-                A.getpixel(i, j, pixel);
+                A.getpixel(i, j, make_span(pixel));
                 if (j >= ybegin && j < yend && i >= xbegin && i < xend) {
                     for (int c = 0; c < CHANNELS; ++c)
                         OIIO_CHECK_EQUAL(pixel[c], arbitrary3[c]);
@@ -307,7 +307,7 @@ test_crop()
     OIIO_CHECK_EQUAL(B.spec().width, xend - xbegin);
     OIIO_CHECK_EQUAL(B.spec().y, ybegin);
     OIIO_CHECK_EQUAL(B.spec().height, yend - ybegin);
-    float* pixel = OIIO_ALLOCA(float, CHANNELS);
+    span<float> pixel = OIIO_ALLOCA_SPAN(float, CHANNELS);
     for (int j = 0; j < B.spec().height; ++j) {
         for (int i = 0; i < B.spec().width; ++i) {
             B.getpixel(i + B.xbegin(), j + B.ybegin(), pixel);
@@ -345,19 +345,19 @@ test_paste()
 
     // Spot check
     float a[3], b[3];
-    B.getpixel(1, 1, 0, b);
+    B.getpixel(1, 1, 0, make_span(b));
     OIIO_CHECK_EQUAL(b[0], gray[0]);
     OIIO_CHECK_EQUAL(b[1], gray[1]);
     OIIO_CHECK_EQUAL(b[2], gray[2]);
 
-    B.getpixel(2, 2, 0, b);
-    A.getpixel(1, 1, 0, a);
+    B.getpixel(2, 2, 0, make_span(b));
+    A.getpixel(1, 1, 0, make_span(a));
     OIIO_CHECK_EQUAL(b[0], gray[0]);
     OIIO_CHECK_EQUAL(b[1], a[0]);
     OIIO_CHECK_EQUAL(b[2], a[1]);
 
-    B.getpixel(3, 4, 0, b);
-    A.getpixel(2, 3, 0, a);
+    B.getpixel(3, 4, 0, make_span(b));
+    A.getpixel(2, 3, 0, make_span(a));
     OIIO_CHECK_EQUAL(b[0], gray[0]);
     OIIO_CHECK_EQUAL(b[1], a[0]);
     OIIO_CHECK_EQUAL(b[2], a[1]);
@@ -784,7 +784,7 @@ test_isMonochrome()
 
     // Now introduce a tiny difference
     const float another[CHANNELS] = { 0.25f, 0.25f, 0.26f };
-    A.setpixel(2, 2, 0, another, 3);
+    A.setpixel(2, 2, 0, make_span(another));
     // It should still pass if within the threshold
     OIIO_CHECK_EQUAL(ImageBufAlgo::isMonochrome(A, 0.015f), true);
     // But not with lower threshold
@@ -807,10 +807,10 @@ test_computePixelStats()
     std::cout << "test computePixelStats\n";
     ImageBuf img(ImageSpec(2, 2, 3, TypeDesc::FLOAT));
     float black[3] = { 0, 0, 0 }, white[3] = { 1, 1, 1 };
-    img.setpixel(0, 0, black);
-    img.setpixel(1, 0, white);
-    img.setpixel(0, 1, black);
-    img.setpixel(1, 1, white);
+    img.setpixel(0, 0, make_span(black));
+    img.setpixel(1, 0, make_span(white));
+    img.setpixel(0, 1, make_span(black));
+    img.setpixel(1, 1, make_span(white));
     auto stats = ImageBufAlgo::computePixelStats(img);
     for (int c = 0; c < 3; ++c) {
         OIIO_CHECK_EQUAL(stats.min[c], 0.0f);

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -1094,7 +1094,7 @@ resample_(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
         float dstfh          = dstspec.full_height;
         float dstpixelwidth  = 1.0f / dstfw;
         float dstpixelheight = 1.0f / dstfh;
-        float* pel           = OIIO_ALLOCA(float, nchannels);
+        span<float> pel      = OIIO_ALLOCA_SPAN(float, nchannels);
 
         ImageBuf::Iterator<DSTTYPE> out(dst, roi);
         ImageBuf::ConstIterator<SRCTYPE> srcpel(src);

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -3349,15 +3349,15 @@ TextureSystemImpl::visualize_ellipse(const std::string& name, float dsdx,
             float x  = (i - w / 2) / scale;
             float d2 = ABCF[0] * x * x + ABCF[1] * x * y + ABCF[2] * y * y;
             if (d2 < 1.0f)
-                ib.setpixel(i, h - 1 - j, dark);
+                ib.setpixel(i, h - 1 - j, make_span(dark));
         }
     }
 
     // Draw red and green axes for the dx and dy derivatives, respectively
     ImageBufAlgo::render_line(ib, w / 2, h / 2, w / 2 + int(dsdx * scale),
-                              h / 2 - int(dtdx * scale), red);
+                              h / 2 - int(dtdx * scale), make_span(red));
     ImageBufAlgo::render_line(ib, w / 2, h / 2, w / 2 + int(dsdy * scale),
-                              h / 2 - int(dtdy * scale), green);
+                              h / 2 - int(dtdy * scale), make_span(green));
 
     // Draw yellow and blue axes for the ellipse axes, with blur
     ImageBufAlgo::render_line(ib, w / 2, h / 2,

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -392,6 +392,18 @@ C_to_tuple(cspan<T> vals)
 
 template<typename T>
 inline py::tuple
+C_to_tuple(span<T> vals)
+{
+    size_t size = vals.size();
+    py::tuple result(size);
+    for (size_t i = 0; i < size; ++i)
+        result[i] = typename PyTypeForCType<T>::type(vals[i]);
+    return result;
+}
+
+
+template<typename T>
+inline py::tuple
 C_to_tuple(const T* vals, size_t size)
 {
     py::tuple result(size);

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -722,10 +722,10 @@ plain_tex_region(ImageBuf& image, ustring filename, Mapping2D mapping,
         // Save filtered pixels back to the image.
         for (int i = 0; i < nchannels; ++i)
             result[i] *= scalefactor;
-        image.setpixel(p.x(), p.y(), result);
+        image.setpixel(p.x(), p.y(), make_span(result, nchannels));
         if (test_derivs) {
-            image_ds->setpixel(p.x(), p.y(), dresultds);
-            image_dt->setpixel(p.x(), p.y(), dresultdt);
+            image_ds->setpixel(p.x(), p.y(), make_span(dresultds, nchannels));
+            image_dt->setpixel(p.x(), p.y(), make_span(dresultdt, nchannels));
         }
     }
 }
@@ -985,7 +985,7 @@ tex3d_region(ImageBuf& image, ustring filename, Mapping3D mapping, ROI roi)
         // Save filtered pixels back to the image.
         for (int i = 0; i < nchannels; ++i)
             result[i] *= scalefactor;
-        image.setpixel(p.x(), p.y(), result);
+        image.setpixel(p.x(), p.y(), make_span(result, nchannels));
     }
 }
 
@@ -1161,11 +1161,11 @@ env_region(ImageBuf& image, ustring filename, MappingEnv mapping,
         // Save filtered pixels back to the image.
         for (int i = 0; i < nchannels; ++i)
             result[i] *= scalefactor;
-        image.setpixel(p.x(), p.y(), result);
+        image.setpixel(p.x(), p.y(), make_span(result, nchannels));
         if (image_ds)
-            image_ds->setpixel(p.x(), p.y(), dresultds);
+            image_ds->setpixel(p.x(), p.y(), make_span(dresultds, nchannels));
         if (image_dt)
-            image_dt->setpixel(p.x(), p.y(), dresultdt);
+            image_dt->setpixel(p.x(), p.y(), make_span(dresultdt, nchannels));
     }
 }
 
@@ -1381,7 +1381,8 @@ test_getimagespec_gettexels(ustring filename)
     for (int y = 0; y < h; ++y)
         for (int x = 0; x < w; ++x) {
             imagesize_t texoffset = (y * w + x) * spec.nchannels;
-            buf.setpixel(x, y, &tmp[texoffset]);
+            buf.setpixel(x, y,
+                         make_span(tmp.data() + texoffset, spec.nchannels));
         }
     TypeDesc fmt(dataformatname);
     if (fmt != TypeDesc::UNKNOWN)


### PR DESCRIPTION
Next round of making safer interfaces. Primarily, this adds new span-baesd versions of ImageBuf::get_pixels, set_pixels, setpixel, getpixel, interppixel, interppixel_NDC, interppixel_bucibuc, interppixel_bicubic_NDC.

The old ones took raw pointers and implied sizes -- these still exist but are considered "unsafe" and aimed at experts and special cases. (If a downstream project wants to be sure not to use them, they can define symbol "OIIO_IMAGEBUF_DEPRECATE_RAW_PTR" before including imagebuf.h to force deprecation warnings.)

The new additions instead take a span -- a combined pointer and length that can be bounds-checked (in debug mode). I strongly encourage people to use the new interface, as it forces the caller to think hard about the exact region of memory that's ok to read from or write to, and then for the OIIO side to honor that and enfoce/debug with bounds checks against that if we add such plumbing.

Along the way, I added some interesting helper functions:

In span.h:
* `span_within()` checks that one byte span lies entirely within another.
* `check_span()` checks if a pointer and length lies entirely within a span.
* `OIIO_ALLOCA_SPAN` is a macro much like OIIO_ALLOCA, except what it returns is a span rather than a raw pointer to the stack-allocated region.

In imageio.h:
* `span_from_buffer()`/`cspan_from_bufffer()` : Given a raw pointer, pixel data type (TypeDesc), and image dimensions and strides, returns a byte stride describing the extent of memory that encompasses all pixels laid out by that description.

I hope the switch to spans is not very onerous for people. I really think that this will help us write more solid and deliberate code to begin with, and when things do go wrong, the various debug-mode checks and assertions that spans provide should help us more quickly identify exactly where buffer overruns and the like occurred.
