### PR TITLE
test: Optimize running of oiiotool-demosaic test

### DIFF
--- a/testsuite/oiiotool-demosaic/ref/out.txt
+++ b/testsuite/oiiotool-demosaic/ref/out.txt
@@ -1,64 +1,64 @@
-Computing diff of "testimage_float.exr" vs "result_float_RGGB-linear.exr"
+Computing diff of "testimage.exr" vs "result_float_RGGB-linear.exr"
 PASS
-Computing diff of "testimage_float.exr" vs "result_float_GRBG-linear.exr"
+Computing diff of "testimage.exr" vs "result_float_GRBG-linear.exr"
 PASS
-Computing diff of "testimage_float.exr" vs "result_float_GBRG-linear.exr"
+Computing diff of "testimage.exr" vs "result_float_GBRG-linear.exr"
 PASS
-Computing diff of "testimage_float.exr" vs "result_float_BGGR-linear.exr"
+Computing diff of "testimage.exr" vs "result_float_BGGR-linear.exr"
 PASS
-Computing diff of "testimage_float.exr" vs "result_float_RGGB-MHC.exr"
+Computing diff of "testimage.exr" vs "result_float_RGGB-MHC.exr"
 PASS
-Computing diff of "testimage_float.exr" vs "result_float_GRBG-MHC.exr"
+Computing diff of "testimage.exr" vs "result_float_GRBG-MHC.exr"
 PASS
-Computing diff of "testimage_float.exr" vs "result_float_GBRG-MHC.exr"
+Computing diff of "testimage.exr" vs "result_float_GBRG-MHC.exr"
 PASS
-Computing diff of "testimage_float.exr" vs "result_float_BGGR-MHC.exr"
+Computing diff of "testimage.exr" vs "result_float_BGGR-MHC.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_RGGB-linear.exr"
+Computing diff of "testimage.exr" vs "result_half_RGGB-linear.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_GRBG-linear.exr"
+Computing diff of "testimage.exr" vs "result_half_GRBG-linear.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_GBRG-linear.exr"
+Computing diff of "testimage.exr" vs "result_half_GBRG-linear.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_BGGR-linear.exr"
+Computing diff of "testimage.exr" vs "result_half_BGGR-linear.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_RGGB-MHC.exr"
+Computing diff of "testimage.exr" vs "result_half_RGGB-MHC.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_GRBG-MHC.exr"
+Computing diff of "testimage.exr" vs "result_half_GRBG-MHC.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_GBRG-MHC.exr"
+Computing diff of "testimage.exr" vs "result_half_GBRG-MHC.exr"
 PASS
-Computing diff of "testimage_half.exr" vs "result_half_BGGR-MHC.exr"
+Computing diff of "testimage.exr" vs "result_half_BGGR-MHC.exr"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_RGGB-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_RGGB-linear.tiff"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_GRBG-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_GRBG-linear.tiff"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_GBRG-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_GBRG-linear.tiff"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_BGGR-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_BGGR-linear.tiff"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_RGGB-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_RGGB-MHC.tiff"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_GRBG-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_GRBG-MHC.tiff"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_GBRG-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_GBRG-MHC.tiff"
 PASS
-Computing diff of "testimage_uint16.tiff" vs "result_uint16_BGGR-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint16_BGGR-MHC.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_RGGB-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_RGGB-linear.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_GRBG-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_GRBG-linear.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_GBRG-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_GBRG-linear.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_BGGR-linear.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_BGGR-linear.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_RGGB-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_RGGB-MHC.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_GRBG-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_GRBG-MHC.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_GBRG-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_GBRG-MHC.tiff"
 PASS
-Computing diff of "testimage_uint8.tiff" vs "result_uint8_BGGR-MHC.tiff"
+Computing diff of "testimage.exr" vs "result_uint8_BGGR-MHC.tiff"
 PASS

--- a/testsuite/oiiotool-demosaic/run.py
+++ b/testsuite/oiiotool-demosaic/run.py
@@ -23,10 +23,6 @@ layouts = {
     "BGGR": make_pattern_BGGR
 }
 
-# Create a test image with color gradients
-make_testimage = f"--pattern fill:topleft=0,0,1:topright=0,1,0:bottomleft=1,0,1:bottomright=1,1,0 {width}x{height} 3 "
-
-
 types = [
     {
         "type" : "float",
@@ -51,6 +47,18 @@ types = [
 ]
 
     
+# Create a test image with color gradient
+make_testimage = f"--pattern fill:topleft=0,0,1:topright=0,1,0:bottomleft=1,0,1:bottomright=1,1,0 {width}x{height} 3 "
+command += oiiotool (make_testimage + f" -o:type=float testimage.exr")
+
+# For each Bayer pattern (RGGB, RGRB, GBRG, BGGR), create an image with that
+# pure pattern ({pattern}.exr), then multiply it by the test image and take
+# the channel sum to get a Bayer mosaic image ({pattern}-bayer.exr).
+# This is somewhat expensive, so we do it only once (for float) and then will
+# convert it to the appropriate type upon input.
+for pattern, maker in layouts.items():
+    command += oiiotool (f"{maker} -o:type=float pattern_{pattern}.exr testimage.exr -mul -chsum -o:type=float bayer_{pattern}.exr")
+
 
 for dict in types:
 
@@ -58,22 +66,13 @@ for dict in types:
     ext = dict["ext"]
     threshold = dict["threshold"]
 
-    command += oiiotool (make_testimage + f" -o:type={type} testimage_{type}.{ext}")
-
-    # For each Bayer pattern (RGGB, RGRB, GBRG, BGGR), create an image with that
-    # pure pattern ({pattern}.exr), then multiply it by the test image and take
-    # the channel sum to get a Bayer mosaic image ({pattern}-bayer.exr).
-    for pattern, maker in layouts.items():
-        command += oiiotool (f"{maker} -o:type={type} pattern_{type}_{pattern}.{ext} testimage_{type}.{ext} -mul -chsum -o:type={type} bayer_{type}_{pattern}.{ext}")
-
     test = f" --fail {threshold} --hardfail {threshold} --warn {threshold} --diff "
-
 
     # For each algorithm, try demosaicing each pattern test image and compare to
     # the original test image.
     for algo in ['linear', 'MHC']:
         for pattern, maker in layouts.items():
-            command += oiiotool (f"-i:type={type} testimage_{type}.{ext} -i:type={type} bayer_{type}_{pattern}.{ext} --demosaic:algorithm={algo}:layout={pattern} -o:type={type} result_{type}_{pattern}-{algo}.{ext} ")
+            command += oiiotool (f"-i:type={type} testimage.exr -i:type={type} bayer_{pattern}.exr --demosaic:algorithm={algo}:layout={pattern} -o:type={type} result_{type}_{pattern}-{algo}.{ext} ")
             
             crop = 2
             
@@ -82,4 +81,4 @@ for dict in types:
             else:
                 cut_cmd = ""
                         
-            command += oiiotool (f"testimage_{type}.{ext} " + cut_cmd + f"result_{type}_{pattern}-{algo}.{ext} " + cut_cmd + test)
+            command += oiiotool (f"testimage.exr " + cut_cmd + f"result_{type}_{pattern}-{algo}.{ext} " + cut_cmd + test)


### PR DESCRIPTION
This test was running very slowly, taking too long in all circumstances, but shockly causing GHA CI Mac runners to hit the test timeout sometimes.

It turns out we were doing a lot of redundant work. There was no need to make separate pattern and bayer images for every data type. Instead, hoist the test image generation out of the loop and just make one (float), then use `-i:type=<type>` to read it into an ImageBuf of the appropriate data type.

This cuts the time for this test to run by about 3x.
