### PR TITLE
feat: add iv data and display windows overlay

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -386,15 +386,10 @@ ImageViewer::createActions()
     //    toggleImageAct->setEnabled(true);
     connect(toggleImageAct, SIGNAL(triggered()), this, SLOT(toggleImage()));
 
-    showDataWindowAct = new QAction(tr("Show Data Window (solid line)"), this);
-    showDataWindowAct->setCheckable(true);
-    connect(showDataWindowAct, SIGNAL(triggered()), this,
-            SLOT(toggleDataWindow()));
-
-    showDisplayWindowAct = new QAction(tr("Show Display Window (dotted line)"), this);
-    showDisplayWindowAct->setCheckable(true);
-    connect(showDisplayWindowAct, SIGNAL(triggered()), this,
-            SLOT(toggleDisplayWindow()));
+    toggleWindowGuidesAct = new QAction(tr("Show display and data window borders"), this);
+    toggleWindowGuidesAct->setCheckable(true);
+    connect(toggleWindowGuidesAct, SIGNAL(triggered()), this,
+            SLOT(toggleWindowGuides()));
 
     slideShowAct = new QAction(tr("Start Slide Show"), this);
     connect(slideShowAct, SIGNAL(triggered()), this, SLOT(slideShow()));
@@ -684,8 +679,7 @@ ImageViewer::createMenus()
     viewMenu->addAction(prevImageAct);
     viewMenu->addAction(nextImageAct);
     viewMenu->addAction(toggleImageAct);
-    viewMenu->addAction(showDataWindowAct);
-    viewMenu->addAction(showDisplayWindowAct);
+    viewMenu->addAction(toggleWindowGuidesAct);
     viewMenu->addSeparator();
     viewMenu->addAction(zoomInAct);
     viewMenu->addAction(zoomOutAct);
@@ -1362,15 +1356,7 @@ ImageViewer::toggleImage()
 
 
 void
-ImageViewer::toggleDataWindow()
-{
-    ((QOpenGLWidget*)(glwin))->update();
-}
-
-
-
-void
-ImageViewer::toggleDisplayWindow()
+ImageViewer::toggleWindowGuides()
 {
     ((QOpenGLWidget*)(glwin))->update();
 }

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -2142,8 +2142,8 @@ ImageViewer::fitWindowToImage(bool zoomok, bool minsize)
     // (or we failed to open it).
     if (!img || !img->image_valid())
         return;
-    // FIXME -- figure out a way to make it exactly right, even for the
-    // main window border, etc.
+        // FIXME -- figure out a way to make it exactly right, even for the
+        // main window border, etc.
 #ifdef __APPLE__
     int extraw = 0;  //12; // width() - minimumWidth();
     int extrah = statusBar()->height()
@@ -2279,7 +2279,7 @@ calc_subimage_from_zoom(const IvImage* img, int& subimage, float& zoom,
 {
     int rel_subimage = std::trunc(std::log2(1.0f / zoom));
     subimage         = clamp<int>(img->subimage() + rel_subimage, 0,
-                                  img->nsubimages() - 1);
+                          img->nsubimages() - 1);
     if (!(img->subimage() == 0 && zoom > 1)
         && !(img->subimage() == img->nsubimages() - 1 && zoom < 1)) {
         float pow_zoom = powf(2.0f, (float)rel_subimage);

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -386,7 +386,8 @@ ImageViewer::createActions()
     //    toggleImageAct->setEnabled(true);
     connect(toggleImageAct, SIGNAL(triggered()), this, SLOT(toggleImage()));
 
-    toggleWindowGuidesAct = new QAction(tr("Show display and data window borders"), this);
+    toggleWindowGuidesAct
+        = new QAction(tr("Show display and data window borders"), this);
     toggleWindowGuidesAct->setCheckable(true);
     connect(toggleWindowGuidesAct, SIGNAL(triggered()), this,
             SLOT(toggleWindowGuides()));

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -386,16 +386,15 @@ ImageViewer::createActions()
     //    toggleImageAct->setEnabled(true);
     connect(toggleImageAct, SIGNAL(triggered()), this, SLOT(toggleImage()));
 
-    showDataWindowAct = new QAction(tr("Show Data Window"), this);
+    showDataWindowAct = new QAction(tr("Show Data Window (solid line)"), this);
     showDataWindowAct->setCheckable(true);
     connect(showDataWindowAct, SIGNAL(triggered()), this,
             SLOT(toggleDataWindow()));
 
-    showDisplayWindowAct = new QAction(tr("Show Display Window"), this);
+    showDisplayWindowAct = new QAction(tr("Show Display Window (dotted line)"), this);
     showDisplayWindowAct->setCheckable(true);
     connect(showDisplayWindowAct, SIGNAL(triggered()), this,
             SLOT(toggleDisplayWindow()));
-    showDisplayWindowAct->setChecked(true);  // Show display window by default
 
     slideShowAct = new QAction(tr("Start Slide Show"), this);
     connect(slideShowAct, SIGNAL(triggered()), this, SLOT(slideShow()));

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -386,6 +386,17 @@ ImageViewer::createActions()
     //    toggleImageAct->setEnabled(true);
     connect(toggleImageAct, SIGNAL(triggered()), this, SLOT(toggleImage()));
 
+    showDataWindowAct = new QAction(tr("Show Data Window"), this);
+    showDataWindowAct->setCheckable(true);
+    connect(showDataWindowAct, SIGNAL(triggered()), this,
+            SLOT(toggleDataWindow()));
+
+    showDisplayWindowAct = new QAction(tr("Show Display Window"), this);
+    showDisplayWindowAct->setCheckable(true);
+    connect(showDisplayWindowAct, SIGNAL(triggered()), this,
+            SLOT(toggleDisplayWindow()));
+    showDisplayWindowAct->setChecked(true);  // Show display window by default
+
     slideShowAct = new QAction(tr("Start Slide Show"), this);
     connect(slideShowAct, SIGNAL(triggered()), this, SLOT(slideShow()));
 
@@ -674,6 +685,8 @@ ImageViewer::createMenus()
     viewMenu->addAction(prevImageAct);
     viewMenu->addAction(nextImageAct);
     viewMenu->addAction(toggleImageAct);
+    viewMenu->addAction(showDataWindowAct);
+    viewMenu->addAction(showDisplayWindowAct);
     viewMenu->addSeparator();
     viewMenu->addAction(zoomInAct);
     viewMenu->addAction(zoomOutAct);
@@ -1345,6 +1358,22 @@ void
 ImageViewer::toggleImage()
 {
     current_image(m_last_image);
+}
+
+
+
+void
+ImageViewer::toggleDataWindow()
+{
+    ((QOpenGLWidget*)(glwin))->update();
+}
+
+
+
+void
+ImageViewer::toggleDisplayWindow()
+{
+    ((QOpenGLWidget*)(glwin))->update();
 }
 
 
@@ -2113,8 +2142,8 @@ ImageViewer::fitWindowToImage(bool zoomok, bool minsize)
     // (or we failed to open it).
     if (!img || !img->image_valid())
         return;
-        // FIXME -- figure out a way to make it exactly right, even for the
-        // main window border, etc.
+    // FIXME -- figure out a way to make it exactly right, even for the
+    // main window border, etc.
 #ifdef __APPLE__
     int extraw = 0;  //12; // width() - minimumWidth();
     int extrah = statusBar()->height()
@@ -2250,7 +2279,7 @@ calc_subimage_from_zoom(const IvImage* img, int& subimage, float& zoom,
 {
     int rel_subimage = std::trunc(std::log2(1.0f / zoom));
     subimage         = clamp<int>(img->subimage() + rel_subimage, 0,
-                          img->nsubimages() - 1);
+                                  img->nsubimages() - 1);
     if (!(img->subimage() == 0 && zoom > 1)
         && !(img->subimage() == img->nsubimages() - 1 && zoom < 1)) {
         float pow_zoom = powf(2.0f, (float)rel_subimage);

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -223,6 +223,16 @@ public:
         return showPixelviewWindowAct && showPixelviewWindowAct->isChecked();
     }
 
+    bool datawindowOn(void) const
+    {
+        return showDataWindowAct && showDataWindowAct->isChecked();
+    }
+
+    bool displaywindowOn(void) const
+    {
+        return showDisplayWindowAct && showDisplayWindowAct->isChecked();
+    }
+
     bool pixelviewFollowsMouse(void) const
     {
         return pixelviewFollowsMouseBox
@@ -273,6 +283,8 @@ private slots:
     void prevImage();                  ///< View previous image in sequence
     void nextImage();                  ///< View next image in sequence
     void toggleImage();                ///< View most recently viewed image
+    void toggleDataWindow();           ///< Toggle data window overlay
+    void toggleDisplayWindow();        ///< Toggle display window overlay
     void exposureMinusOneTenthStop();  ///< Decrease exposure 1/10 stop
     void exposureMinusOneHalfStop();   ///< Decrease exposure 1/2 stop
     void exposurePlusOneTenthStop();   ///< Increase exposure 1/10 stop
@@ -374,6 +386,8 @@ private:
     QAction* showInfoWindowAct;
     QAction* editPreferencesAct;
     QAction* showPixelviewWindowAct;
+    QAction* showDataWindowAct;
+    QAction* showDisplayWindowAct;
     QMenu *fileMenu, *editMenu, /**imageMenu,*/ *viewMenu, *toolsMenu,
         *helpMenu;
     QMenu* openRecentMenu;

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -223,14 +223,9 @@ public:
         return showPixelviewWindowAct && showPixelviewWindowAct->isChecked();
     }
 
-    bool datawindowOn(void) const
+    bool windowguidesOn(void) const
     {
-        return showDataWindowAct && showDataWindowAct->isChecked();
-    }
-
-    bool displaywindowOn(void) const
-    {
-        return showDisplayWindowAct && showDisplayWindowAct->isChecked();
+        return toggleWindowGuidesAct && toggleWindowGuidesAct->isChecked();
     }
 
     bool pixelviewFollowsMouse(void) const
@@ -283,8 +278,7 @@ private slots:
     void prevImage();                  ///< View previous image in sequence
     void nextImage();                  ///< View next image in sequence
     void toggleImage();                ///< View most recently viewed image
-    void toggleDataWindow();           ///< Toggle data window overlay
-    void toggleDisplayWindow();        ///< Toggle display window overlay
+    void toggleWindowGuides();         ///< Toggle data and display window overlay
     void exposureMinusOneTenthStop();  ///< Decrease exposure 1/10 stop
     void exposureMinusOneHalfStop();   ///< Decrease exposure 1/2 stop
     void exposurePlusOneTenthStop();   ///< Increase exposure 1/10 stop
@@ -386,8 +380,7 @@ private:
     QAction* showInfoWindowAct;
     QAction* editPreferencesAct;
     QAction* showPixelviewWindowAct;
-    QAction* showDataWindowAct;
-    QAction* showDisplayWindowAct;
+    QAction* toggleWindowGuidesAct;
     QMenu *fileMenu, *editMenu, /**imageMenu,*/ *viewMenu, *toolsMenu,
         *helpMenu;
     QMenu* openRecentMenu;

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -273,12 +273,12 @@ private slots:
     /// change the zoom, even to fit on screen. If minsize is true, do not
     /// resize smaller than default_width x default_height.
     void fitWindowToImage(bool zoomok = true, bool minsize = false);
-    void fullScreenToggle();           ///< Toggle full screen mode
-    void about();                      ///< Show "about iv" dialog
-    void prevImage();                  ///< View previous image in sequence
-    void nextImage();                  ///< View next image in sequence
-    void toggleImage();                ///< View most recently viewed image
-    void toggleWindowGuides();         ///< Toggle data and display window overlay
+    void fullScreenToggle();    ///< Toggle full screen mode
+    void about();               ///< Show "about iv" dialog
+    void prevImage();           ///< View previous image in sequence
+    void nextImage();           ///< View next image in sequence
+    void toggleImage();         ///< View most recently viewed image
+    void toggleWindowGuides();  ///< Toggle data and display window overlay
     void exposureMinusOneTenthStop();  ///< Decrease exposure 1/10 stop
     void exposureMinusOneHalfStop();   ///< Decrease exposure 1/2 stop
     void exposurePlusOneTenthStop();   ///< Increase exposure 1/10 stop

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -655,12 +655,8 @@ IvGL::paintGL()
         }
     }
 
-    if (m_viewer.datawindowOn()) {
-        paint_datawindow();
-    }
-
-    if (m_viewer.displaywindowOn()) {
-        paint_displaywindow();
+    if (m_viewer.windowguidesOn()) {
+        paint_windowguides();
     }
 
     glPopMatrix();
@@ -938,44 +934,35 @@ IvGL::paint_pixelview()
 
 
 void
-IvGL::paint_datawindow()
+IvGL::paint_windowguides()
 {
     IvImage* img = m_current_image;
     const ImageSpec& spec(img->spec());
 
     glDisable(GL_TEXTURE_2D);
     glUseProgram(0);
-
-    const float xmin = spec.x;
-    const float xmax = spec.x + spec.width;
-    const float ymin = spec.y;
-    const float ymax = spec.y + spec.height;
     glPushAttrib(GL_ENABLE_BIT);
     glEnable(GL_COLOR_LOGIC_OP);
     glLogicOp(GL_XOR);
-    gl_rect_border(xmin, ymin, xmax, ymax);
-    glPopAttrib();
-}
 
+    // Data window
+    {
+        const float xmin = spec.x;
+        const float xmax = spec.x + spec.width;
+        const float ymin = spec.y;
+        const float ymax = spec.y + spec.height;
+        gl_rect_border(xmin, ymin, xmax, ymax);
+    }
 
+    // Display window
+    {
+        const float xmin = spec.full_x;
+        const float xmax = spec.full_x + spec.full_width;
+        const float ymin = spec.full_y;
+        const float ymax = spec.full_y + spec.full_height;
+        gl_rect_dotted_border(xmin, ymin, xmax, ymax);
+    }
 
-void
-IvGL::paint_displaywindow()
-{
-    IvImage* img = m_current_image;
-    const ImageSpec& spec(img->spec());
-
-    glDisable(GL_TEXTURE_2D);
-    glUseProgram(0);
-
-    const float xmin = spec.full_x;
-    const float xmax = spec.full_x + spec.full_width;
-    const float ymin = spec.full_y;
-    const float ymax = spec.full_y + spec.full_height;
-    glPushAttrib(GL_ENABLE_BIT);
-    glEnable(GL_COLOR_LOGIC_OP);
-    glLogicOp(GL_XOR);
-    gl_rect_dotted_border(xmin, ymin, xmax, ymax);
     glPopAttrib();
 }
 

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -468,6 +468,32 @@ gl_rect(float xmin, float ymin, float xmax, float ymax, float z = 0,
 
 
 static void
+gl_rect_border(float xmin, float ymin, float xmax, float ymax, float z = 0)
+{
+    glBegin(GL_LINE_LOOP);
+    glVertex3f(xmin, ymin, z);
+    glVertex3f(xmax, ymin, z);
+    glVertex3f(xmax, ymax, z);
+    glVertex3f(xmin, ymax, z);
+    glEnd();
+}
+
+
+
+static void
+gl_rect_dotted_border(float xmin, float ymin, float xmax, float ymax,
+                      float z = 0)
+{
+    glPushAttrib(GL_ENABLE_BIT);
+    glLineStipple(1, 0xF0F0);
+    glEnable(GL_LINE_STIPPLE);
+    gl_rect_border(xmin, ymin, xmax, ymax, z);
+    glPopAttrib();
+}
+
+
+
+static void
 handle_orientation(int orientation, int width, int height, float& scale_x,
                    float& scale_y, float& rotate_z, float& point_x,
                    float& point_y, bool pixel = false)
@@ -627,6 +653,14 @@ IvGL::paintGL()
             gl_rect(xstart, ystart, xstart + tile_width, ystart + tile_height,
                     0, smin, tmin, smax, tmax);
         }
+    }
+
+    if (m_viewer.datawindowOn()) {
+        paint_datawindow();
+    }
+
+    if (m_viewer.displaywindowOn()) {
+        paint_displaywindow();
     }
 
     glPopMatrix();
@@ -899,6 +933,44 @@ IvGL::paint_pixelview()
 
     glPopAttrib();
     glPopMatrix();
+}
+
+
+
+void
+IvGL::paint_datawindow()
+{
+    IvImage* img = m_current_image;
+    const ImageSpec& spec(img->spec());
+
+    glDisable(GL_TEXTURE_2D);
+    glUseProgram(0);
+
+    glColor4f(0.5f, 0.5f, 0.5f, 1.f);
+    const float xmin = spec.x;
+    const float xmax = spec.x + spec.width;
+    const float ymin = spec.y;
+    const float ymax = spec.y + spec.height;
+    gl_rect_border(xmin, ymin, xmax, ymax);
+}
+
+
+
+void
+IvGL::paint_displaywindow()
+{
+    IvImage* img = m_current_image;
+    const ImageSpec& spec(img->spec());
+
+    glDisable(GL_TEXTURE_2D);
+    glUseProgram(0);
+
+    glColor4f(0.5f, 0.5f, 0.5f, 1.f);
+    const float xmin = spec.full_x;
+    const float xmax = spec.full_x + spec.full_width;
+    const float ymin = spec.full_y;
+    const float ymax = spec.full_y + spec.full_height;
+    gl_rect_dotted_border(xmin, ymin, xmax, ymax);
 }
 
 

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -946,12 +946,15 @@ IvGL::paint_datawindow()
     glDisable(GL_TEXTURE_2D);
     glUseProgram(0);
 
-    glColor4f(0.5f, 0.5f, 0.5f, 1.f);
     const float xmin = spec.x;
     const float xmax = spec.x + spec.width;
     const float ymin = spec.y;
     const float ymax = spec.y + spec.height;
+    glPushAttrib(GL_ENABLE_BIT);
+    glEnable(GL_COLOR_LOGIC_OP);
+    glLogicOp(GL_XOR);
     gl_rect_border(xmin, ymin, xmax, ymax);
+    glPopAttrib();
 }
 
 
@@ -965,12 +968,15 @@ IvGL::paint_displaywindow()
     glDisable(GL_TEXTURE_2D);
     glUseProgram(0);
 
-    glColor4f(0.5f, 0.5f, 0.5f, 1.f);
     const float xmin = spec.full_x;
     const float xmax = spec.full_x + spec.full_width;
     const float ymin = spec.full_y;
     const float ymax = spec.full_y + spec.full_height;
+    glPushAttrib(GL_ENABLE_BIT);
+    glEnable(GL_COLOR_LOGIC_OP);
+    glLogicOp(GL_XOR);
     gl_rect_dotted_border(xmin, ymin, xmax, ymax);
+    glPopAttrib();
 }
 
 

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -151,8 +151,7 @@ protected:
     void focusOutEvent(QFocusEvent* event) override;
 
     void paint_pixelview();
-    void paint_datawindow();
-    void paint_displaywindow();
+    void paint_windowguides();
     void glSquare(float xmin, float ymin, float xmax, float ymax, float z = 0);
 
     virtual void create_shaders(void);

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -151,6 +151,8 @@ protected:
     void focusOutEvent(QFocusEvent* event) override;
 
     void paint_pixelview();
+    void paint_datawindow();
+    void paint_displaywindow();
     void glSquare(float xmin, float ymin, float xmax, float ymax, float z = 0);
 
     virtual void create_shaders(void);


### PR DESCRIPTION
Adding data and display window overlay in iv.
Dashed line: Display window
Solid line: Data window

<img width="624" alt="Screenshot 2024-09-25 at 15 07 13" src="https://github.com/user-attachments/assets/11727d24-b13d-4342-960d-4b953fc4c784">

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
