### PR TITLE
Initialize m_pfm_flip before use to avoid UB.

### DIFF
--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -372,6 +372,7 @@ PNMInput::open(const std::string& name, ImageSpec& newspec)
     m_file_contents.resize(m_io->size());
     m_io->pread(m_file_contents.data(), m_file_contents.size(), 0);
     m_remaining = string_view(m_file_contents.data(), m_file_contents.size());
+    m_pfm_flip  = false;
 
     if (!read_file_header())
         return false;


### PR DESCRIPTION
Fixes #4445

## Description

This avoids UB by initializing a variable.

## Tests

I ran valgrind after the fix: no longer issues error.

```
==77256== 
==77256== HEAP SUMMARY:
==77256==     in use at exit: 25,167,390 bytes in 8,232 blocks
==77256==   total heap usage: 183,524 allocs, 175,292 frees, 4,415,783,216 bytes allocated
==77256== 
==77256== LEAK SUMMARY:
==77256==    definitely lost: 0 bytes in 0 blocks
==77256==    indirectly lost: 0 bytes in 0 blocks
==77256==      possibly lost: 0 bytes in 0 blocks
==77256==    still reachable: 25,167,390 bytes in 8,232 blocks
==77256==         suppressed: 0 bytes in 0 blocks
==77256== Rerun with --leak-check=full to see details of leaked memory
==77256== 
==77256== For lists of detected and suppressed errors, rerun with: -s
==77256== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
