### PR TITLE
fix(raw) check for nullptr in raw input plugin

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -1516,6 +1516,13 @@ RawInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (!m_process) {
         // The user has selected not to apply any debayering.
 
+        if (m_processor->imgdata.rawdata.raw_image == nullptr) {
+            errorfmt(
+                "Raw undebayered data is not available for this file \"{}\"",
+                m_filename);
+            return false;
+        }
+
         // The raw_image buffer might contain junk pixels that are usually trimmed off
         // we must index into the raw buffer, taking these into account
         auto& sizes        = m_processor->imgdata.sizes;


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

This adds a null pointer check in the raw input plugin when the user requested raw bayer data for a file format which doesn't have it. With this fix OIIO shows an error instead of crashing in such case.

This fixes the issue mentioned in the comments of #4361. The title issue of #4361 has been resolved in LibRaw 0.22.0, so we can close that issue, I guess.

This also fixes the crash on 5 out of 6 examples in #3115. The last one is unrelated, and I don't have a good fix for that at this time (crash due to the raw buffer having half resolution, with the pixel aspect ratio of 0.5). Perhaps we could create a separate issue and close #3115. 

## Tests

I have not added any tests for this change specifically, as it is fairly trivial. 
I have started working on a more comprehensive test suite for the raw plugin / rawtoaces, but it's not ready yet, and I'm not sure where it should live at this stage.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
