### PR TITLE
Added check_open for PNG, JPEG, and EXR readers

### DIFF
--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -253,6 +253,9 @@ JpgInput::open(const std::string& name, ImageSpec& newspec)
     m_spec = ImageSpec(m_cinfo.output_width, m_cinfo.output_height, nchannels,
                        TypeDesc::UINT8);
 
+    if (!check_open(m_spec, { 0, 1 << 16, 0, 1 << 16, 0, 1, 0, 3 }))
+        return false;
+
     // Assume JPEG is in sRGB unless the Exif or XMP tags say otherwise.
     m_spec.attribute("oiio:ColorSpace", "sRGB");
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1024,7 +1024,7 @@ OpenEXRInput::seek_subimage(int subimage, int miplevel)
     m_miplevel = miplevel;
     m_spec     = part.spec;
 
-    if (!check_open(m_spec, { 0, 1 << 30, 0, 1 << 30, 0, 1 << 16, 0, 1 << 16 }))
+    if (!check_open(m_spec, { 0, 1 << 20, 0, 1 << 20, 0, 1 << 16, 0, 1 << 12 }))
         return false;
 
     if (miplevel == 0 && part.levelmode == Imf::ONE_LEVEL) {

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1024,6 +1024,9 @@ OpenEXRInput::seek_subimage(int subimage, int miplevel)
     m_miplevel = miplevel;
     m_spec     = part.spec;
 
+    if (!check_open(m_spec, { 0, 1 << 30, 0, 1 << 30, 0, 1 << 16, 0, 1 << 16 }))
+        return false;
+
     if (miplevel == 0 && part.levelmode == Imf::ONE_LEVEL) {
         return true;
     }

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -162,7 +162,8 @@ PNGInput::open(const std::string& name, ImageSpec& newspec)
     bool ok = PNG_pvt::read_info(m_png, m_info, m_bit_depth, m_color_type,
                                  m_interlace_type, m_bg, m_spec,
                                  m_keep_unassociated_alpha);
-    if (!ok || m_err) {
+    if (!ok || m_err
+        || check_open(m_spec, { 0, 1 << 30, 0, 1 << 30, 0, 1, 0, 4 })) {
         close();
         return false;
     }

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -163,7 +163,7 @@ PNGInput::open(const std::string& name, ImageSpec& newspec)
                                  m_interlace_type, m_bg, m_spec,
                                  m_keep_unassociated_alpha);
     if (!ok || m_err
-        || check_open(m_spec, { 0, 1 << 30, 0, 1 << 30, 0, 1, 0, 4 })) {
+        || !check_open(m_spec, { 0, 1 << 16, 0, 1 << 16, 0, 1, 0, 4 })) {
         close();
         return false;
     }


### PR DESCRIPTION
## Description
This PR is ment to address this feature request: https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/3974

I added `check_open` for these file format's ImageInput while following each file specfication:
- PNG: https://www.w3.org/TR/png/#11IHDR
- JPEG: https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format#JFIF_APP0_marker_segment
- EXR: https://openexr.com/en/latest/OpenEXRFileLayout.html#header-attributes-all-files

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.