### PR TITLE
feat(raw): raw reader - exposing max_raw_memory_mb

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2181,7 +2181,8 @@ options are supported:
        (Default: 0)
    * - ``raw:max_raw_memory_mb``
      - int
-     - Max memory allocation for processing of raw images. This exposes max_raw_memory_mb in libraw.
+     - Maximum memory allocation for processing of raw buffer. Stop processing if
+       raw buffer size grows larger than that value (in megabytes).
        (Default: 2048)
 
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2181,7 +2181,7 @@ options are supported:
        (Default: 0)
    * - ``raw:max_raw_memory_mb``
      - int
-     - Maximum memory allocation for processing of raw buffer. Stop processing if
+     - Maximum memory allocation for processing of raw images. Stop processing if
        raw buffer size grows larger than that value (in megabytes).
        (Default: 2048)
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2179,6 +2179,10 @@ options are supported:
        0 - do not use FBDD noise reduction, 1 - light FBDD reduction,
        2 (and more) - full FBDD reduction
        (Default: 0)
+   * - ``raw:max_raw_memory_mb``
+     - int
+     - Max memory allocation for processing of raw images. This exposes max_raw_memory_mb in libraw.
+       (Default: 2048)
 
 
 |

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -453,12 +453,9 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // Output 16 bit images
     m_processor->imgdata.params.output_bps = 16;
 
-    // exposing max_raw_memory_mb setting
-    static_assert(sizeof(m_processor->imgdata.rawparams.max_raw_memory_mb)
-                      == sizeof(int),
-                  "Sizes must match");
-    config.getattribute("raw:max_raw_memory_mb", TypeDesc::INT,
-                        &m_processor->imgdata.rawparams.max_raw_memory_mb);
+    // Exposing max_raw_memory_mb setting. Default max is 2048.
+    m_processor->imgdata.rawparams.max_raw_memory_mb
+        = config.get_int_attribute("raw:max_raw_memory_mb", 2048);
 
 
     // Disable exposure correction (unless config "raw:auto_bright" == 1)

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -453,6 +453,14 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // Output 16 bit images
     m_processor->imgdata.params.output_bps = 16;
 
+    // exposing max_raw_memory_mb setting
+    static_assert(sizeof(m_processor->imgdata.rawparams.max_raw_memory_mb)
+                      == sizeof(int),
+                  "Sizes must match");
+    config.getattribute("raw:max_raw_memory_mb", TypeDesc::INT,
+                        &m_processor->imgdata.rawparams.max_raw_memory_mb);
+
+
     // Disable exposure correction (unless config "raw:auto_bright" == 1)
     m_processor->imgdata.params.no_auto_bright
         = !config.get_int_attribute("raw:auto_bright", 0);


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

PR is to address https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/3881 feature request. The reported wanted to expose `imgdata.rawparams.max_raw_memory_mb` as `raw:max_raw_memory_mb`

## Tests

I was able to compile my code successfully, no new test were added for this.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
