### PR TITLE
docs: Convert ImageInput tiles examples from docs to tests

### DIFF
--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -196,39 +196,19 @@ scanline image and you should read pixels using ``read_scanline()``, not
 
 .. tabs::
 
-    .. code-tab:: c++
+   .. tab:: C++
+      .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
+          :language: c++
+          :start-after: BEGIN-imageinput-tiles
+          :end-before: END-imageinput-tiles
+          :dedent: 4
 
-        auto inp = ImageInput::open(filename);
-        const ImageSpec &spec = inp->spec();
-        if (spec.tile_width == 0) {
-            // ... read scanline by scanline ...
-        } else {
-            // Tiles
-            int tilesize = spec.tile_width * spec.tile_height;
-            auto tile = std::unique_ptr<unsigned char[]>(new unsigned char[tilesize * spec.nchannels]);
-            for (int y = 0;  y < yres;  y += spec.tile_height) {
-                for (int x = 0;  x < xres;  x += spec.tile_width) {
-                    inp->read_tile(x, y, 0, TypeDesc::UINT8, &tile[0]);
-                    // ... process the pixels in tile[] ..
-                }
-            }
-        }
-        inp->close ();
-
-    .. code-tab:: py
-
-        inp = ImageInput.open(filename)
-        spec = inp.spec()
-        if spec.tile_width == 0 :
-            # ... read scanline by scanline ...
-        else :
-            # Tiles
-            tilesize = spec.tile_width * spec.tile_height;
-            for y in range(0, yres, spec.tile_height) :
-                for x in range(0, xres, spec.tile_width) :
-                    tile = inp.read_tile (x, y, 0, "uint8")
-                    # ... process the pixels in tile[][] ..
-        inp.close ();
+   .. tab:: Python
+      .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imageinput.py
+          :language: py
+          :start-after: BEGIN-imageinput-tiles
+          :end-before: END-imageinput-tiles
+          :dedent: 8
 
 The first three arguments to ``read_tile()`` specify which tile is
 being read by the pixel coordinates of any pixel contained in the

--- a/testsuite/docs-examples-cpp/run.py
+++ b/testsuite/docs-examples-cpp/run.py
@@ -14,6 +14,11 @@ else :
 command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr grid.exr")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/tahoe-small.tif tahoe.tif")
 
+# Copy the grid to both a tiled and scanline version
+command += oiio_app("iconvert") + "../common/grid.tif --scanline scanline.tif > out.txt ;" 
+command += oiio_app("iconvert") + "../common/grid.tif --tile 64 64 tiled.tif > out.txt ;" 
+
+
 # Build
 command += run_app("cmake -S " + test_source_dir + " -B build -DCMAKE_BUILD_TYPE=Release >> build.txt 2>&1", silent=True)
 command += run_app("cmake --build build --config Release >> build.txt 2>&1", silent=True)

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
@@ -74,6 +74,32 @@ void scanlines_read()
 }
 
 
+
+void tiles_read()
+{
+    const char* filename = "tiled.tif";
+
+// BEGIN-imageinput-tiles
+    auto inp = ImageInput::open(filename);
+    const ImageSpec &spec = inp->spec();
+    if (spec.tile_width == 0) {
+        // ... read scanline by scanline ...
+    } else {
+        // Tiles
+        int tilesize = spec.tile_width * spec.tile_height;
+        auto tile = std::unique_ptr<unsigned char[]>(new unsigned char[tilesize * spec.nchannels]);
+        for (int y = 0;  y < spec.height;  y += spec.tile_height) {
+            for (int x = 0;  x < spec.width;  x += spec.tile_width) {
+                inp->read_tile(x, y, 0, TypeDesc::UINT8, &tile[0]);
+                // ... process the pixels in tile[] ..
+            }
+        }
+    }
+    inp->close ();
+// END-imageinput-tiles
+}
+
+
 // BEGIN-imageinput-errorchecking
 #include <OpenImageIO/imageio.h>
 using namespace OIIO;
@@ -108,12 +134,14 @@ void error_checking()
 // END-imageinput-errorchecking
 
 
+
 int main(int /*argc*/, char** /*argv*/)
 {
     // Each example function needs to get called here, or it won't execute
     // as part of the test.
     simple_read();
     scanlines_read();
+    tiles_read();
     error_checking();
     return 0;
 }

--- a/testsuite/docs-examples-python/run.py
+++ b/testsuite/docs-examples-python/run.py
@@ -14,6 +14,10 @@ refdirlist += [ "../docs-examples-cpp/ref" ]
 command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr grid.exr")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/tahoe-small.tif tahoe.tif")
 
+# Copy the grid to both a tiled and scanline version
+command += oiio_app("iconvert") + "../common/grid.tif --scanline scanline.tif > out.txt ;" 
+command += oiio_app("iconvert") + "../common/grid.tif --tile 64 64 tiled.tif > out.txt ;" 
+
 # Run the examples for each chapter
 for chapter in [ "imageioapi", "imageoutput", "imageinput", "writingplugins",
                  "imagecache", "texturesys", "imagebuf", "imagebufalgo" ] :

--- a/testsuite/docs-examples-python/src/docs-examples-imageinput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageinput.py
@@ -70,15 +70,16 @@ def tiles_read() :
     filename = "tiled.tif"
 
      # BEGIN-imageinput-tiles
-    inp = ImageInput.open(filename)
+    inp = oiio.ImageInput.open(filename)
     spec = inp.spec()
     if spec.tile_width == 0 :
         # ... read scanline by scanline ...
+        pass
     else :
         # Tiles
         tilesize = spec.tile_width * spec.tile_height;
-        for y in range(0, yres, spec.tile_height) :
-            for x in range(0, xres, spec.tile_width) :
+        for y in range(0, spec.height, spec.tile_height) :
+            for x in range(0, spec.width, spec.tile_width) :
                 tile = inp.read_tile (x, y, 0, "uint8")
                 # ... process the pixels in tile[][] ..
     inp.close ();

--- a/testsuite/docs-examples-python/src/docs-examples-imageinput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageinput.py
@@ -66,6 +66,25 @@ def scanlines_read() :
     inp.close ()
     # END-imageinput-scanlines
 
+def tiles_read() :
+    filename = "tiled.tif"
+
+     # BEGIN-imageinput-tiles
+    inp = ImageInput.open(filename)
+    spec = inp.spec()
+    if spec.tile_width == 0 :
+        # ... read scanline by scanline ...
+    else :
+        # Tiles
+        tilesize = spec.tile_width * spec.tile_height;
+        for y in range(0, yres, spec.tile_height) :
+            for x in range(0, xres, spec.tile_width) :
+                tile = inp.read_tile (x, y, 0, "uint8")
+                # ... process the pixels in tile[][] ..
+    inp.close ();
+    # END-imageinput-tiles
+
+
 def error_checking():
 # BEGIN-imageinput-errorchecking
     import OpenImageIO as oiio
@@ -91,9 +110,12 @@ def error_checking():
         return
 # END-imageinput-errorchecking
 
+
+
 if __name__ == '__main__':
     # Each example function needs to get called here, or it won't execute
     # as part of the test.
     simple_read()
     scanlines_read()
+    tiles_read()
     error_checking()

--- a/testsuite/docs-examples-python/src/docs-examples-imageinput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageinput.py
@@ -77,12 +77,12 @@ def tiles_read() :
         pass
     else :
         # Tiles
-        tilesize = spec.tile_width * spec.tile_height;
+        tilesize = spec.tile_width * spec.tile_height
         for y in range(0, spec.height, spec.tile_height) :
             for x in range(0, spec.width, spec.tile_width) :
                 tile = inp.read_tile (x, y, 0, "uint8")
                 # ... process the pixels in tile[][] ..
-    inp.close ();
+    inp.close ()
     # END-imageinput-tiles
 
 


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Convert tiles C++ and Python examples from the "imageinput" chapter into tests within the "docs-examples" testsuites (https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/3992).


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
