### PR TITLE
docs:imageinput-errorchecking

### DIFF
--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -1043,61 +1043,18 @@ Section :ref:`sec-imageinput-made-simple`, but this time it is fully
 elaborated with error checking and reporting:
 
 .. tabs::
-    
-   .. code-tab:: c++
-    
-        #include <OpenImageIO/imageio.h>
-        using namespace OIIO;
-        ...
 
-        const char *filename = "foo.jpg";
-        auto inp = ImageInput::open (filename);
-        if (! inp) {
-            std::cerr << "Could not open " << filename
-                      << ", error = " << OIIO::geterror() << "\n";
-            return;
-        }
-        const ImageSpec &spec = inp->spec();
-        int xres = spec.width;
-        int yres = spec.height;
-        int nchannels = spec.nchannels;
-        auto pixels = std::unique_ptr<unsigned char[]>(new unsigned char[xres * yres * nchannels]);
+    .. tab:: C++
+        .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
+            :language: c++
+            :start-after: BEGIN-imageinput-errorchecking
+            :end-before: END-imageinput-errorchecking
 
-        if (! inp->read_image(0, 0, 0, nchannels, TypeDesc::UINT8, &pixels[0])) {
-            std::cerr << "Could not read pixels from " << filename
-                      << ", error = " << inp->geterror() << "\n";
-            return;
-        }
-
-        if (! inp->close ()) {
-            std::cerr << "Error closing " << filename
-                      << ", error = " << inp->geterror() << "\n";
-            return;
-        }
-
-   .. code-tab:: py
-    
-        import OpenImageIO as oiio
-        import numpy as np
-
-        filename = "foo.jpg"
-        inp = ImageInput::open(filename)
-        if inp is None :
-            print("Could not open", filename, ", error =", oiio.geterror())
-            return
-        spec = inp.spec()
-        xres = spec.width
-        yres = spec.height
-        nchannels = spec.nchannels
-
-        pixels = inp.read_image(0, 0, 0, nchannels, "uint8")
-        if pixels is None :
-            print("Could not read pixels from", filename, ", error =", inp.geterror())
-            return
-
-        if not inp.close() :
-            print("Error closing", filename, ", error =", inp.geterror())
-            return
+    .. tab:: Python
+        .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imageinput.py
+            :language: py
+            :start-after: BEGIN-imageinput-errorchecking
+            :end-before: END-imageinput-errorchecking
 
 
 .. _sec-imageinput-class-reference:

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
@@ -73,11 +73,47 @@ void scanlines_read()
 // END-imageinput-scanlines
 }
 
+
+// BEGIN-imageinput-errorchecking
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void error_checking()
+{
+    const char *filename = "tahoe.tif";
+    auto inp = ImageInput::open (filename);
+    if (! inp) {
+        std::cerr << "Could not open " << filename
+                  << ", error = " << OIIO::geterror() << "\n";
+        return;
+    }
+    const ImageSpec &spec = inp->spec();
+    int xres = spec.width;
+    int yres = spec.height;
+    int nchannels = spec.nchannels;
+    auto pixels = std::unique_ptr<unsigned char[]>(new unsigned char[xres * yres * nchannels]);
+
+    if (! inp->read_image(0, 0, 0, nchannels, TypeDesc::UINT8, &pixels[0])) {
+        std::cerr << "Could not read pixels from " << filename
+                  << ", error = " << inp->geterror() << "\n";
+        return;
+    }
+
+    if (! inp->close ()) {
+        std::cerr << "Error closing " << filename
+                  << ", error = " << inp->geterror() << "\n";
+        return;
+    }
+}
+// END-imageinput-errorchecking
+
+
 int main(int /*argc*/, char** /*argv*/)
 {
     // Each example function needs to get called here, or it won't execute
     // as part of the test.
     simple_read();
     scanlines_read();
+    error_checking();
     return 0;
 }

--- a/testsuite/docs-examples-python/src/docs-examples-imageinput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageinput.py
@@ -66,8 +66,34 @@ def scanlines_read() :
     inp.close ()
     # END-imageinput-scanlines
 
+def error_checking():
+# BEGIN-imageinput-errorchecking
+    import OpenImageIO as oiio
+    import numpy as np
+
+    filename = "tahoe.tif"
+    inp = oiio.ImageInput.open(filename)
+    if inp is None :
+        print("Could not open", filename, ", error =", oiio.geterror())
+        return
+    spec = inp.spec()
+    xres = spec.width
+    yres = spec.height
+    nchannels = spec.nchannels
+
+    pixels = inp.read_image(0, 0, 0, nchannels, "uint8")
+    if pixels is None :
+        print("Could not read pixels from", filename, ", error =", inp.geterror())
+        return
+
+    if not inp.close() :
+        print("Error closing", filename, ", error =", inp.geterror())
+        return
+# END-imageinput-errorchecking
+
 if __name__ == '__main__':
     # Each example function needs to get called here, or it won't execute
     # as part of the test.
     simple_read()
     scanlines_read()
+    error_checking()


### PR DESCRIPTION
## Description

Convert error checking C++ and Python examples from the "imageinput" chapter into tests within the "docs-examples" testsuites (https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/3992).


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
