### PR TITLE
docs: convert to test for ImageBufAlgo Partial Image Arithmetic

### DIFF
--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -56,7 +56,7 @@ Most ImageBufAlgo functions that produce image data come in two forms:
 
 
 2. Pass a destination ImageBuf reference as the first parameter.
-   
+
    The function is passed a *destination* ImageBuf where the results will
    be stored, and the return value is a `bool` that is `true` if the
    function succeeds or `false` if the function fails. Upon failure, the
@@ -268,7 +268,7 @@ checker() -- make a checker pattern
   Examples:
 
     .. tabs::
-  
+
        .. tab:: C++
              .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
               :language: c++
@@ -454,7 +454,7 @@ Drawing shapes: points, lines, boxes
   Examples:
 
     .. tabs::
-  
+
        .. tab:: C++
              .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
               :language: c++
@@ -491,7 +491,7 @@ Drawing text
   Examples:
 
     .. tabs::
-  
+
        .. tab:: C++
              .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
               :language: c++
@@ -536,7 +536,7 @@ Drawing text
   Examples:
 
     .. tabs::
-  
+
        .. tab:: C++
              .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
               :language: c++
@@ -587,7 +587,7 @@ Shuffling channels
               :start-after: BEGIN-imagebufalgo-channels
               :end-before: END-imagebufalgo-channels
               :dedent: 4
-      
+
        .. tab:: oiiotool
          .. code-block:: bash
 
@@ -911,7 +911,7 @@ Shuffling channels
   Examples:
 
     .. tabs::
-  
+
        .. tab:: C++
 
           .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
@@ -1199,26 +1199,24 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
-          // Add images A and B
-          ImageBuf A ("a.exr");
-          ImageBuf B ("b.exr");
-          ImageBuf Sum = ImageBufAlgo::add (A, B);
-      
-          // Add 0.2 to channels 0-2, but not to channel 3
-          ImageBuf Sum = ImageBufAlgo::add (A, { 0.2f, 0.2f, 0.2f, 0.0f });
+       .. tab:: C++
+             .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+              :language: c++
+              :start-after: BEGIN-imagebufalgo-add
+              :end-before: END-imagebufalgo-add
+              :dedent: 4
 
        .. code-tab:: py
 
-          # Add images A and B
-          A = ImageBuf("a.exr")
-          B = ImageBuf("b.exr")
-          sum = ImageBufAlgo.add (A, B)
-
-          # Add 0.2 to channels 0-2, but not to channel 3
-          Sum = ImageBufAlgo.add (A, (0.2, 0.2, 0.2, 0.0))
+       .. tab:: Python
+          .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+              :language: py
+              :start-after: BEGIN-imagebufalgo-add
+              :end-before: END-imagebufalgo-add
+              :dedent: 4
 
        .. code-tab:: bash oiiotool
 
@@ -1240,18 +1238,22 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
-       .. code-tab:: c++
 
-          ImageBuf A ("a.exr");
-          ImageBuf B ("b.exr");
-          ImageBuf Diff = ImageBufAlgo::sub (A, B);
+       .. tab:: C++
+             .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+              :language: c++
+              :start-after: BEGIN-imagebufalgo-sub
+              :end-before: END-imagebufalgo-sub
+              :dedent: 4
 
        .. code-tab:: py
 
-          A = ImageBuf("a.exr")
-          B = ImageBuf("b.exr")
-          Diff = ImageBufAlgo.sub (A, B)
+       .. tab:: Python
+          .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+              :language: py
+              :start-after: BEGIN-imagebufalgo-sub
+              :end-before: END-imagebufalgo-sub
+              :dedent: 4
 
        .. code-tab:: bash oiiotool
 
@@ -1269,18 +1271,23 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
-       .. code-tab:: c++
 
-          ImageBuf A ("a.exr");
-          ImageBuf B ("b.exr");
-          ImageBuf Diff = ImageBufAlgo::absdiff (A, B);
+       .. tab:: C++
+             .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+              :language: c++
+              :start-after: BEGIN-imagebufalgo-absdiff
+              :end-before: END-imagebufalgo-absdiff
+              :dedent: 4
 
        .. code-tab:: py
 
-          A = ImageBuf("a.exr")
-          B = ImageBuf("b.exr")
-          Diff = ImageBufAlgo.absdiff (A, B)
+       .. tab:: Python
+          .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+              :language: py
+              :start-after: BEGIN-imagebufalgo-absdiff
+              :end-before: END-imagebufalgo-absdiff
+              :dedent: 4
+
 
        .. code-tab:: bash oiiotool
 
@@ -1298,16 +1305,22 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
-       .. code-tab:: c++
 
-          ImageBuf A ("a.exr");
-          ImageBuf Abs = ImageBufAlgo::abs (A);
+       .. tab:: C++
+             .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+              :language: c++
+              :start-after: BEGIN-imagebufalgo-abs
+              :end-before: END-imagebufalgo-abs
+              :dedent: 4
 
        .. code-tab:: py
 
-          A = ImageBuf("a.exr")
-          Abs = ImageBufAlgo.abs (A)
+       .. tab:: Python
+          .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+              :language: py
+              :start-after: BEGIN-imagebufalgo-abs
+              :end-before: END-imagebufalgo-abs
+              :dedent: 4
 
        .. code-tab:: bash oiiotool
 
@@ -1325,26 +1338,22 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
-       .. code-tab:: c++
 
-          // Pixel-by-pixel, channel-by-channel multiplication of A and B
-          ImageBuf A ("a.exr");
-          ImageBuf B ("b.exr");
-          ImageBuf Product = ImageBufAlgo::mul (A, B);
-
-          // In-place reduce intensity of A's channels 0-2 by 50%
-          ImageBufAlgo::mul (A, A, { 0.5f, 0.5f, 0.5f, 1.0f });
+       .. tab:: C++
+             .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+              :language: c++
+              :start-after: BEGIN-imagebufalgo-mul
+              :end-before: END-imagebufalgo-mul
+              :dedent: 4
 
        .. code-tab:: py
 
-          # Pixel-by-pixel, channel-by-channel multiplication of A and B
-          A = ImageBuf("a.exr")
-          B = ImageBuf("b.exr")
-          Product = ImageBufAlgo.mul (A, B)
-
-          # In-place reduce intensity of A's channels 0-2 by 50%
-          ImageBufAlgo.mul (A, A, (0.5, 0.5, 0.5, 1.0))
+       .. tab:: Python
+          .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+              :language: py
+              :start-after: BEGIN-imagebufalgo-mul
+              :end-before: END-imagebufalgo-mul
+              :dedent: 4
 
        .. code-tab:: bash oiiotool
 
@@ -1366,26 +1375,24 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
-          // Pixel-by-pixel, channel-by-channel division of A by B
-          ImageBuf A ("a.exr");
-          ImageBuf B ("b.exr");
-          ImageBuf Ratio = ImageBufAlgo::div (A, B);
-
-          // In-place reduce intensity of A's channels 0-2 by 50%
-          ImageBufAlgo::div (A, A, { 2.0f, 2.0f, 2.0f, 1.0f });
+       .. tab:: C++
+             .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+              :language: c++
+              :start-after: BEGIN-imagebufalgo-div
+              :end-before: END-imagebufalgo-div
+              :dedent: 4
 
        .. code-tab:: py
 
-          # Pixel-by-pixel, channel-by-channel division of A by B
-          A = ImageBuf("a.exr")
-          B = ImageBuf("b.exr")
-          Ratio = ImageBufAlgo.div (A, B)
-
-          # In-place reduce intensity of A's channels 0-2 by 50%
-          ImageBufAlgo.div (A, A, (2.0, 2.0, 2.0, 1.0))
+       .. tab:: Python
+          .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+              :language: py
+              :start-after: BEGIN-imagebufalgo-div
+              :end-before: END-imagebufalgo-div
+              :dedent: 4
 
        .. code-tab:: bash oiiotool
 
@@ -1407,7 +1414,7 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           // Pixel-by-pixel, channel-by-channel A * B + C
@@ -1452,7 +1459,7 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf A ("a.exr");
@@ -1481,7 +1488,7 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf A ("a.exr");
@@ -1510,7 +1517,7 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           // Invert all channels of A
@@ -1575,7 +1582,7 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           // Gamma-correct by 2.2 channels 0-2 of the image, in-place
@@ -1610,7 +1617,7 @@ Image arithmetic
     (assuming Rec709 primaries and a linear scale):
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           // Compute luminance via a weighted sum of R,G,B
@@ -1642,25 +1649,25 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           // min of images A and B, assign to MinImage
           ImageBuf A ("a.exr");
           ImageBuf B ("b.exr");
           ImageBuf MinImage = ImageBufAlgo::min (Sum, A, B);
-      
+
           // Squash negative values in A by taking max(A, 0.0) for all channels
           ImageBuf A ("a.exr");
           ImageBufAlgo::max (A, A, 0.0f);
 
           // Clamp image buffer A in-place to the [0,1] range for all pixels.
           ImageBufAlgo::clamp (A, A, 0.0f, 1.0f);
-      
+
           // Just clamp alpha to [0,1] in-place
           ImageBufAlgo::clamp (A, A, -std::numeric_limits<float>::max(),
                                std::numeric_limits<float>::max(), true);
-      
+
           // Clamp R & G to [0,0.5], leave other channels alone
           std::vector<float> min (A.nchannels(), -std::numeric_limits<float>::max());
           std::vector<float> max (A.nchannels(), std::numeric_limits<float>::max());
@@ -1674,17 +1681,17 @@ Image arithmetic
           A = ImageBuf("a.exr")
           B = ImageBuf("b.exr")
           MinImage = ImageBufAlgo.min (Sum, A, B)
-      
+
           # Squash negative values in A by taking max(A, 0.0) for all channels
           A = ImageBuf("a.exr")
           ImageBufAlgo.max (A, A, 0.0)
 
           # Clamp image buffer A in-place to the [0,1] range for all pixels.
           ImageBufAlgo.clamp (A, A, 0.0, 1.0)
-      
+
           # Just clamp alpha to [0,1] in-place
           ImageBufAlgo.clamp (A, A, -1.0e30, 1.0e30, True)
-      
+
           # Clamp R & G to [0,0.5], leave other channels alone
           ImageBufAlgo.clamp (A, A, (0, 0, -1.0e30, -1.0e30),
                               (0.5, 0.5, 1.0e30, 1.0e30), False)
@@ -1693,16 +1700,16 @@ Image arithmetic
 
           # min of images A and B, assign to MinImage
           oiiotool a.exr b.exr --min -o minimage.exr
-      
+
           # Squash negative values in A by taking max(A, 0.0) for all channels
           oiiotool.exr a.exr --maxc 0 -o a.exr
 
           # Clamp image buffer A in-place to the [0,1] range for all pixels.
           oiiotool.exr a.exr --clamp:min=0:max=1 -o a.exr
-      
+
           # Just clamp alpha to [0,1] in-place
           oiiotool.exr a.exr --clamp:min=,,,0:max=,,,1 -o a.exr
-      
+
           # Clamp R & G to [0,0.5], leave other channels alone
           oiiotool.exr a.exr --clamp:min=0,0,,,:max=1,1,,, -o a.exr
 
@@ -1715,7 +1722,7 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           // Computes the maximum of R, G, B.
@@ -1746,7 +1753,7 @@ Image arithmetic
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf A ("tahoe.tif");
@@ -1869,7 +1876,7 @@ Image arithmetic
        // scale) and map to a spectrum-like palette:
        ImageBuf A ("a.exr");
        ImageBuf B = ImageBufAlgo::color_map (A, -1, "turbo");
-   
+
        // Use a custom color map
        float mymap[] = { 0.25, 0.25, 0.25,  0, 0.5, 0,  1, 0, 0 };
        B = ImageBufAlgo::color_map (A, -1 /* use luminance */,
@@ -1882,7 +1889,7 @@ Image arithmetic
        # scale) and map to a spectrum-like palette:
        A = ImageBuf("a.exr")
        B = ImageBufAlgo.color_map (A, -1, "turbo")
-   
+
        # Use a custom color map
        B = ImageBufAlgo.color_map (A, -1, (0.25, 0.25, 0.25,  0, 0.5, 0,  1, 0, 0))
 
@@ -1891,7 +1898,7 @@ Image arithmetic
        # Use luminance of a.exr (assuming Rec709 primaries and a linear
        # scale) and map to a spectrum-like palette:
        oiiotool a.exr --colormap turbo -o b.exr
-   
+
        # Use a custom color map
        oiiotool a.exr --colormap turbo 0.25,0.25,0.25,0,0.5,0,1,0,0 -o b.exr
 
@@ -1927,36 +1934,36 @@ Image arithmetic
     resize, then re-expand the range.
 
     .. tabs::
-  
+
        .. code-tab:: c++
-      
+
           // 1. Read the original image
           ImageBuf Src ("tahoeHDR.exr");
-      
+
           // 2. Range compress to a logarithmic scale
           ImageBuf Compressed = ImageBufAlgo::rangecompress (Src);
-      
+
           // 3. Now do the resize
           ImageBuf Dst = ImageBufAlgo::resize (Compressed,
                                                { { "filtername", "lanczos3" }
                                                  { "filterwidth", 6.0f } },
                                                ROI(0, 640, 0, 480));
-      
+
           // 4. Expand range to be linear again (operate in-place)
           ImageBufAlgo::rangeexpand (Dst, Dst);
 
        .. code-tab:: py
-      
+
           # 1. Read the original image
           Src = ImageBuf("tahoeHDR.exr")
-      
+
           # 2. Range compress to a logarithmic scale
           Compressed = ImageBufAlgo.rangecompress (Src)
-      
+
           # 3. Now do the resize
           Dst = ImageBufAlgo.resize (Compressed, filtername="lanczos3",
                                      filterwidth=6.0, ROI(0, 640, 0, 480))
-      
+
           # 4. Expand range to be linear again (operate in-place)
           ImageBufAlgo.rangeexpand (Dst, Dst)
 
@@ -2062,8 +2069,8 @@ Image comparison and statistics
            std::cout << "Average error was " << comp.meanerror << "\n";
            std::cout << "RMS error was " << comp.rms_error << "\n";
            std::cout << "PSNR was " << comp.PSNR << "\n";
-           std::cout << "largest error was " << comp.maxerror 
-                     << " on pixel (" << comp.maxx << "," << comp.maxy 
+           std::cout << "largest error was " << comp.maxerror
+                     << " on pixel (" << comp.maxx << "," << comp.maxy
                      << "," << comp.maxz << "), channel " << comp.maxc << "\n";
        }
 
@@ -2221,10 +2228,10 @@ Image comparison and statistics
         ImageBuf A ("a.exr");
         ROI roi = get_roi (A.spec());
         roi.chend = std::min (roi.chend, 4);  // only compare RGBA
-    
+
         float low[] = {0, 0, 0, 0};
         float high[] = {1, 1, 1, 1};
-    
+
         imagesize_t lowcount, highcount, inrangecount;
         ImageBufAlgo::color_range_check (A, &lowcount, &highcount, &inrangecount,
                                          low, high, roi);
@@ -2237,10 +2244,10 @@ Image comparison and statistics
         A = ImageBuf("a.exr")
         roi = A.roi.copy()
         roi.chend = min (roi.chend, 4)  # only compare RGBA
-    
+
         low = (0, 0, 0, 0)
         high = (1, 1, 1, 1)
-    
+
         lowcount, highcount, inrangecount = ImageBufAlgo.color_range_check (A, low, high, roi)
         print(lowcount, "pixels had components < 0")
         print(highcount, "pixels had components > 1")
@@ -2537,7 +2544,7 @@ Image Enhancement / Restoration
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.exr");
@@ -2566,7 +2573,7 @@ Image Enhancement / Restoration
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("holes.exr");
@@ -2578,7 +2585,7 @@ Image Enhancement / Restoration
           Filled = ImageBufAlgo.fillholes_pushpull (Src)
 
        .. code-tab:: bash oiiotool
-                 
+
           oiiotool holes.exr --fillholes -o filled.exr
 
 |
@@ -2592,7 +2599,7 @@ Image Enhancement / Restoration
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Noisy ("tahoe.exr");
@@ -2635,7 +2642,7 @@ Image Enhancement / Restoration
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Blurry ("tahoe.exr");
@@ -2690,14 +2697,14 @@ are often constructed from them:
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Source ("source.tif");
-      
+
           ImageBuf Dilated = ImageBufAlgo::dilate (Source, 3, 3);
           ImageBuf Eroded  = ImageBufAlgo::erode (Source, 3, 3);
-      
+
           // Morphological "open" is dilate(erode((source))
           ImageBuf Opened = ImageBufAlgo::dilate (Eroded, 3, 3);
           // Morphological "close" is erode(dilate(source))
@@ -2712,10 +2719,10 @@ are often constructed from them:
        .. code-tab:: py
 
           Source = ImageBuf("source.tif")
-      
+
           Dilated = ImageBufAlgo.dilate (Source, 3, 3)
           Eroded  = ImageBufAlgo.erode (Source, 3, 3)
-      
+
           # Morphological "open" is dilate(erode((source))
           Opened = ImageBufAlgo.dilate (Eroded, 3, 3)
           # Morphological "close" is erode(dilate(source))
@@ -2731,7 +2738,7 @@ are often constructed from them:
 
           oiiotool source.tif --dilate 3x3 -o dilated.tif
           oiiotool source.tif --erode 3x3 -o eroded.tif
-      
+
           # Morphological "open" is dilate(erode((source))
           oiiotool source.tif --erode 3x3 --dilate 3x3 -o opened.tif
           # Morphological "close" is erode(dilate(source))
@@ -2789,7 +2796,7 @@ Color space conversion
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.jpg");
@@ -2815,7 +2822,7 @@ Color space conversion
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.exr");
@@ -2835,8 +2842,8 @@ Color space conversion
           dst = ImageBufAlgo.colormatrixtransform (Src, M)
 
        .. code-tab:: bash oiiotool
-              
-          oiiotool tahoe.exr --colormatrixtransform 0.8047379,0.5058794,-0.3106172,0,-0.3106172,0.8047379,0.5058794,0.5058794,-0.3106172,0,0,0,0,1,0 -o tahoe_matrix.exr 
+
+          oiiotool tahoe.exr --colormatrixtransform 0.8047379,0.5058794,-0.3106172,0,-0.3106172,0.8047379,0.5058794,0.5058794,-0.3106172,0,0,0,0,1,0 -o tahoe_matrix.exr
 
 
 .. |ccmat1| image:: figures/tahoe-small.jpg
@@ -2862,7 +2869,7 @@ Color space conversion
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.jpg");
@@ -2890,7 +2897,7 @@ Color space conversion
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.exr");
@@ -2918,7 +2925,7 @@ Color space conversion
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.exr");
@@ -2941,19 +2948,19 @@ Color space conversion
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           // Convert from unassociated alpha to associated alpha by
           // straightforward multiplication of color by alpha.
           ImageBuf Unassoc;  // Assume somehow this has unassociated alpha
           ImageBuf Assoc = ImageBufAlgo::premult (Unassoc);
-      
+
           // Convert in-place from associated alpha to unassociated alpha,
           // preserving the color of alpha==0 pixels.
           ImageBuf A;
           ImageBufAlgo::unpremult (A, A);
-      
+
           // Finish the round-trip back to associated, still preserving the
           // color of alpha==0 pixels. This should result in exactly the same
           // pixel values we started with (within precision limits).
@@ -2965,12 +2972,12 @@ Color space conversion
           # straightforward multiplication of color by alpha.
           Unassoc = ImageBuf(...)  # Assume somehow this has unassociated alpha
           Assoc = ImageBufAlgo.premult (Unassoc)
-      
+
           # Convert in-place from associated alpha to unassociated alpha,
           # preserving the color of alpha==0 pixels.
           A = ImageBuf(...)
           ImageBufAlgo.unpremult (A, A)
-      
+
           # Finish the round-trip back to associated, still preserving the
           # color of alpha==0 pixels. This should result in exactly the same
           # pixel values we started with (within precision limits).
@@ -2981,11 +2988,11 @@ Color space conversion
           # Convert from unassociated alpha to associated alpha by
           # straightforward multiplication of color by alpha.
           oiiotool unassoc.tif --premult -o assoc.tif
-      
+
           # Convert in-place from associated alpha to unassociated alpha,
           # preserving the color of alpha==0 pixels.
           oiiotool A.tif --unpremult -o A.tif
-      
+
           # Finish the round-trip back to associated, still preserving the
           # color of alpha==0 pixels. This should result in exactly the same
           # pixel values we started with (within precision limits).
@@ -3021,14 +3028,14 @@ Import / export
 
       .. tab:: oiiotool
          .. sourcecode:: bash
-         
+
             oiiotool in.exr -otex:hilightcomp=1:filtername=lanczos3:opaque_detect=1 texture.exr
 
       .. tab:: maketx
          .. sourcecode:: bash
 
             maketx in.exr --hicomp --filter lanczos3 --opaque-detect -o texture.exr
-      
+
 |
 
 OpenCV interoperability is performed by the `from_OpenCV()` and
@@ -3071,7 +3078,7 @@ Functions specific to deep images
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Flat ("RGBAZ.exr");
@@ -3097,7 +3104,7 @@ Functions specific to deep images
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Deep ("deepalpha.exr");
@@ -3123,7 +3130,7 @@ Functions specific to deep images
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf DeepA ("hardsurf.exr");
@@ -3151,7 +3158,7 @@ Functions specific to deep images
   Examples:
 
     .. tabs::
-  
+
        .. code-tab:: c++
 
           ImageBuf Src ("image.exr");

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -1307,15 +1307,15 @@ Image arithmetic
        .. tab:: C++
              .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
               :language: c++
-              :start-after: BEGIN-imagebufalgo-abs
-              :end-before: END-imagebufalgo-abs
+              :start-after: BEGIN-imagebufalgo-absolute
+              :end-before: END-imagebufalgo-absolute
               :dedent: 4
 
        .. tab:: Python
           .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
               :language: py
-              :start-after: BEGIN-imagebufalgo-abs
-              :end-before: END-imagebufalgo-abs
+              :start-after: BEGIN-imagebufalgo-absolute
+              :end-before: END-imagebufalgo-absolute
               :dedent: 4
 
        .. code-tab:: bash oiiotool

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -1279,8 +1279,6 @@ Image arithmetic
               :end-before: END-imagebufalgo-absdiff
               :dedent: 4
 
-       .. code-tab:: py
-
        .. tab:: Python
           .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
               :language: py
@@ -1313,8 +1311,6 @@ Image arithmetic
               :end-before: END-imagebufalgo-abs
               :dedent: 4
 
-       .. code-tab:: py
-
        .. tab:: Python
           .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
               :language: py
@@ -1345,8 +1341,6 @@ Image arithmetic
               :start-after: BEGIN-imagebufalgo-mul
               :end-before: END-imagebufalgo-mul
               :dedent: 4
-
-       .. code-tab:: py
 
        .. tab:: Python
           .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -1384,8 +1378,6 @@ Image arithmetic
               :start-after: BEGIN-imagebufalgo-div
               :end-before: END-imagebufalgo-div
               :dedent: 4
-
-       .. code-tab:: py
 
        .. tab:: Python
           .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py

--- a/testsuite/docs-examples-cpp/ref/out-arm.txt
+++ b/testsuite/docs-examples-cpp/ref/out-arm.txt
@@ -27,6 +27,12 @@ example_resize
 example_resample
 example_fit
 example_warp
+example_add
+example_sub
+example_absdiff
+example_abs
+example_mul
+example_div
 example_make_texture
 zero1.exr            :  512 x  512, 3 channel, half openexr
     SHA-1: 95823C334FCE55968E8D2827CCD1CF77CEE19ABD
@@ -106,6 +112,20 @@ cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
 texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
     SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+add.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: EA465A4FEA171DDF7D382931AE1FF1E37C4977F8
+add-cspan.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: 3E8E6F104951D3D156891708478193AAE6C5859F
+sub.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+absdiff.exr          :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+abs.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: A670546F9AB515ABEC009BFE4C4FF6AF4D628FBA
+mul.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: ECCDBBBF088912F0B77B887D6B8B480C3F93615E
+div.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A85C923DB82C893C0D88028386F1C58604A4757
 Comparing "simple.tif" and "ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "ref/scanlines.tif"

--- a/testsuite/docs-examples-cpp/ref/out.txt
+++ b/testsuite/docs-examples-cpp/ref/out.txt
@@ -27,6 +27,12 @@ example_resize
 example_resample
 example_fit
 example_warp
+example_add
+example_sub
+example_absdiff
+example_abs
+example_mul
+example_div
 example_make_texture
 zero1.exr            :  512 x  512, 3 channel, half openexr
     SHA-1: 95823C334FCE55968E8D2827CCD1CF77CEE19ABD
@@ -106,6 +112,20 @@ cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
 texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
     SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+add.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: EA465A4FEA171DDF7D382931AE1FF1E37C4977F8
+add-cspan.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: 3E8E6F104951D3D156891708478193AAE6C5859F
+sub.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+absdiff.exr          :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+abs.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: A670546F9AB515ABEC009BFE4C4FF6AF4D628FBA
+mul.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: ECCDBBBF088912F0B77B887D6B8B480C3F93615E
+div.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A85C923DB82C893C0D88028386F1C58604A4757
 Comparing "simple.tif" and "ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "ref/scanlines.tif"

--- a/testsuite/docs-examples-cpp/run.py
+++ b/testsuite/docs-examples-cpp/run.py
@@ -68,7 +68,14 @@ hashes = [
     "transpose.exr",
     "reorient.exr",
     "cshift.exr",
-    "texture.exr"
+    "texture.exr",
+    "add.exr",
+    "add-cspan.exr",
+    "sub.exr",
+    "absdiff.exr",
+    "abs.exr",
+    "mul.exr",
+    "div.exr"
 ]
 for file in hashes :
     command += info_command(file, verbose=False)

--- a/testsuite/docs-examples-cpp/run.py
+++ b/testsuite/docs-examples-cpp/run.py
@@ -13,6 +13,9 @@ else :
 # Prep:
 command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr grid.exr")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/tahoe-small.tif tahoe.tif")
+command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr A.exr")
+command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr B.exr")
+
 
 # Build
 command += run_app("cmake -S " + test_source_dir + " -B build -DCMAKE_BUILD_TYPE=Release >> build.txt 2>&1", silent=True)

--- a/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
@@ -494,7 +494,86 @@ void example_warp()
 
 
 // Section: Image Arithmetic
+void example_add()
+{
+    print("example_add\n");
+    // BEGIN-imagebufalgo-add
+    // Add images A and B
+    ImageBuf A ("grid.exr");
+    ImageBuf B ("grid.exr");
+    ImageBuf Sum = ImageBufAlgo::add(A, B);
 
+    // Add 0.2 to channels 0-2, but not to channel 3
+    ImageBuf SumCspan = ImageBufAlgo::add(A, { 0.2f, 0.2f, 0.2f, 0.0f });
+    // END-imagebufalgo-add
+    Sum.write("add.exr");
+    SumCspan.write("add-cspan.exr");
+}
+
+void example_sub()
+{
+    print("example_sub\n");
+    // BEGIN-imagebufalgo-sub
+    ImageBuf A ("grid.exr");
+    ImageBuf B ("grid.exr");
+    ImageBuf Diff = ImageBufAlgo::sub(A, B);
+    // END-imagebufalgo-sub
+    Diff.write("sub.exr");
+}
+
+void example_absdiff()
+{
+    print("example_absdiff\n");
+    // BEGIN-imagebufalgo-absdiff
+    ImageBuf A ("grid.exr");
+    ImageBuf B ("grid.exr");
+    ImageBuf Diff = ImageBufAlgo::absdiff (A, B);
+    // END-imagebufalgo-absdiff
+    Diff.write("absdiff.exr");
+}
+
+void example_abs()
+{
+    print("example_abs\n");
+    // BEGIN-imagebufalgo-abs
+    ImageBuf A("grid.exr");
+    ImageBuf Abs = ImageBufAlgo::abs(A);
+    // END-imagebufalgo-abs
+    Abs.write("abs.exr");
+}
+
+void example_mul()
+{
+    print("example_mul\n");
+    // BEGIN-imagebufalgo-mul
+    // Pixel-by-pixel, channel-by-channel multiplication of A and B
+    ImageBuf A ("grid.exr");
+    ImageBuf B ("grid.exr");
+    ImageBuf Product = ImageBufAlgo::mul (A, B);
+
+    // In-place reduce intensity of A's channels 0-2 by 50%
+    ImageBufAlgo::mul (A, A, { 0.5f, 0.5f, 0.5f, 1.0f });
+    // END-imagebufalgo-mul
+    Product.write("mul.exr");
+}
+
+
+void example_div()
+{
+    print("example_div\n");
+    // BEGIN-imagebufalgo-div
+    // Pixel-by-pixel, channel-by-channel division of A by B
+    ImageBuf A ("grid.exr");
+    ImageBuf B ("grid.exr");
+    ImageBuf Ratio = ImageBufAlgo::div (A, B);
+
+    // In-place reduce intensity of A's channels 0-2 by 50%
+    ImageBufAlgo::div (A, A, { 2.0f, 2.0f, 2.0f, 1.0f });
+    // END-imagebufalgo-div
+    Ratio.write("div.exr");
+}
+
+//TODO: mad and onwards
 
 // Section: Image comparison and statistics
 
@@ -572,6 +651,12 @@ int main(int /*argc*/, char** /*argv*/)
     example_warp();
 
     // Section: Image Arithmetic
+    example_add();
+    example_sub();
+    example_absdiff();
+    example_abs();
+    example_mul();
+    example_div();
 
     // Section: Image comparison and statistics
 

--- a/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
@@ -499,8 +499,8 @@ void example_add()
     print("example_add\n");
     // BEGIN-imagebufalgo-add
     // Add images A and B
-    ImageBuf A ("grid.exr");
-    ImageBuf B ("grid.exr");
+    ImageBuf A ("A.exr");
+    ImageBuf B ("B.exr");
     ImageBuf Sum = ImageBufAlgo::add(A, B);
 
     // Add 0.2 to channels 0-2, but not to channel 3
@@ -514,8 +514,8 @@ void example_sub()
 {
     print("example_sub\n");
     // BEGIN-imagebufalgo-sub
-    ImageBuf A ("grid.exr");
-    ImageBuf B ("grid.exr");
+    ImageBuf A ("A.exr");
+    ImageBuf B ("B.exr");
     ImageBuf Diff = ImageBufAlgo::sub(A, B);
     // END-imagebufalgo-sub
     Diff.write("sub.exr");
@@ -525,8 +525,8 @@ void example_absdiff()
 {
     print("example_absdiff\n");
     // BEGIN-imagebufalgo-absdiff
-    ImageBuf A ("grid.exr");
-    ImageBuf B ("grid.exr");
+    ImageBuf A ("A.exr");
+    ImageBuf B ("B.exr");
     ImageBuf Diff = ImageBufAlgo::absdiff (A, B);
     // END-imagebufalgo-absdiff
     Diff.write("absdiff.exr");
@@ -547,8 +547,8 @@ void example_mul()
     print("example_mul\n");
     // BEGIN-imagebufalgo-mul
     // Pixel-by-pixel, channel-by-channel multiplication of A and B
-    ImageBuf A ("grid.exr");
-    ImageBuf B ("grid.exr");
+    ImageBuf A ("A.exr");
+    ImageBuf B ("B.exr");
     ImageBuf Product = ImageBufAlgo::mul (A, B);
 
     // In-place reduce intensity of A's channels 0-2 by 50%
@@ -563,8 +563,8 @@ void example_div()
     print("example_div\n");
     // BEGIN-imagebufalgo-div
     // Pixel-by-pixel, channel-by-channel division of A by B
-    ImageBuf A ("grid.exr");
-    ImageBuf B ("grid.exr");
+    ImageBuf A ("A.exr");
+    ImageBuf B ("B.exr");
     ImageBuf Ratio = ImageBufAlgo::div (A, B);
 
     // In-place reduce intensity of A's channels 0-2 by 50%

--- a/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
@@ -535,10 +535,10 @@ void example_absdiff()
 void example_abs()
 {
     print("example_abs\n");
-    // BEGIN-imagebufalgo-abs
+    // BEGIN-imagebufalgo-absolute
     ImageBuf A("grid.exr");
     ImageBuf Abs = ImageBufAlgo::abs(A);
-    // END-imagebufalgo-abs
+    // END-imagebufalgo-absolute
     Abs.write("abs.exr");
 }
 

--- a/testsuite/docs-examples-python/ref/out-arm.txt
+++ b/testsuite/docs-examples-python/ref/out-arm.txt
@@ -28,6 +28,12 @@ example_resize
 example_resample
 example_fit
 example_warp
+example_add
+example_sub
+example_absdiff
+example_abs
+example_mul
+example_div
 example_make_texture
 zero1.exr            :  512 x  512, 3 channel, half openexr
     SHA-1: 95823C334FCE55968E8D2827CCD1CF77CEE19ABD
@@ -107,6 +113,20 @@ cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
 texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
     SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+add.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: EA465A4FEA171DDF7D382931AE1FF1E37C4977F8
+add-cspan.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: 3E8E6F104951D3D156891708478193AAE6C5859F
+sub.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+absdiff.exr          :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+abs.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: A670546F9AB515ABEC009BFE4C4FF6AF4D628FBA
+mul.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: ECCDBBBF088912F0B77B887D6B8B480C3F93615E
+div.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A85C923DB82C893C0D88028386F1C58604A4757
 Comparing "simple.tif" and "../docs-examples-cpp/ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "../docs-examples-cpp/ref/scanlines.tif"

--- a/testsuite/docs-examples-python/ref/out-arm.txt
+++ b/testsuite/docs-examples-python/ref/out-arm.txt
@@ -115,7 +115,7 @@ texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
     SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
 add.exr              :  256 x  256, 4 channel, half openexr
     SHA-1: EA465A4FEA171DDF7D382931AE1FF1E37C4977F8
-add-cspan.exr        :  256 x  256, 4 channel, half openexr
+add_cspan.exr        :  256 x  256, 4 channel, half openexr
     SHA-1: 3E8E6F104951D3D156891708478193AAE6C5859F
 sub.exr              :  256 x  256, 4 channel, half openexr
     SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C

--- a/testsuite/docs-examples-python/ref/out.txt
+++ b/testsuite/docs-examples-python/ref/out.txt
@@ -28,6 +28,12 @@ example_resize
 example_resample
 example_fit
 example_warp
+example_add
+example_sub
+example_absdiff
+example_abs
+example_mul
+example_div
 example_make_texture
 zero1.exr            :  512 x  512, 3 channel, half openexr
     SHA-1: 95823C334FCE55968E8D2827CCD1CF77CEE19ABD
@@ -107,6 +113,20 @@ cshift.exr           :  256 x  256, 4 channel, half openexr
     SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
 texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
     SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+add.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: EA465A4FEA171DDF7D382931AE1FF1E37C4977F8
+add_cspan.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: 3E8E6F104951D3D156891708478193AAE6C5859F
+sub.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+absdiff.exr          :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+abs.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: A670546F9AB515ABEC009BFE4C4FF6AF4D628FBA
+mul.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: ECCDBBBF088912F0B77B887D6B8B480C3F93615E
+div.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A85C923DB82C893C0D88028386F1C58604A4757
 Comparing "simple.tif" and "../docs-examples-cpp/ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "../docs-examples-cpp/ref/scanlines.tif"

--- a/testsuite/docs-examples-python/run.py
+++ b/testsuite/docs-examples-python/run.py
@@ -13,6 +13,8 @@ refdirlist += [ "../docs-examples-cpp/ref" ]
 # Prep:
 command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr grid.exr")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/tahoe-small.tif tahoe.tif")
+command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr A.exr")
+command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr B.exr")
 
 # Run the examples for each chapter
 for chapter in [ "imageioapi", "imageoutput", "imageinput", "writingplugins",

--- a/testsuite/docs-examples-python/run.py
+++ b/testsuite/docs-examples-python/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
@@ -64,7 +64,15 @@ hashes = [
     "transpose.exr",
     "reorient.exr",
     "cshift.exr",
-    "texture.exr"
+    "texture.exr",
+    "add.exr",
+    "add_cspan.exr",
+    "sub.exr",
+    "absdiff.exr",
+    "abs.exr",
+    "mul.exr",
+    "div.exr"
+
 ]
 for file in hashes :
     command += info_command(file, verbose=False)

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -436,7 +436,73 @@ def example_warp():
 
 
 # Section: Image Arithmetic
+def example_add():
+    print("example_add")
+    # BEGIN-imagebufalgo-add
+    # Add images A and B
+    A = ImageBuf("grid.exr")
+    B = ImageBuf("grid.exr")
+    Sum = ImageBufAlgo.add (A, B)
 
+    # Add 0.2 to channels 0-2, but not to channel 3
+    Sum_cspan = ImageBufAlgo.add (A, (0.2, 0.2, 0.2, 0.0))
+    # END-imagebufalgo-add
+    Sum.write("add.exr", "half")
+    Sum_cspan.write("add_cspan.exr", "half")
+
+def example_sub():
+    print("example_sub")
+    # BEGIN-imagebufalgo-sub
+    A = ImageBuf("grid.exr")
+    B = ImageBuf("grid.exr")
+    Diff = ImageBufAlgo.sub (A, B)
+    # END-imagebufalgo-sub
+    Diff.write("sub.exr", "half")
+
+def example_absdiff():
+    print("example_absdiff")
+    # BEGIN-imagebufalgo-absdiff
+    A = ImageBuf("grid.exr")
+    B = ImageBuf("grid.exr")
+    Diff = ImageBufAlgo.absdiff (A, B)
+    # END--imagebufalgo-absdiff
+    Diff.write("absdiff.exr", "half")
+
+def example_abs():
+    print("example_abs")
+    # BEGIN-imagebufalgo-abs
+    A = ImageBuf("grid.exr")
+    Abs = ImageBufAlgo.abs (A)
+    # END--imagebufalgo-abs
+    Abs.write("abs.exr", "half")
+
+def example_mul():
+    print("example_mul")
+    # BEGIN-imagebufalgo-mul
+    # Pixel-by-pixel, channel-by-channel multiplication of A and B
+    A = ImageBuf("grid.exr")
+    B = ImageBuf("grid.exr")
+    Product = ImageBufAlgo.mul (A, B)
+
+    # In-place reduce intensity of A's channels 0-2 by 50%
+    ImageBufAlgo.mul (A, A, (0.5, 0.5, 0.5, 1.0))
+    # END--imagebufalgo-mul
+    Product.write("mul.exr", "half")
+
+def example_div():
+    print("example_div")
+    # BEGIN-imagebufalgo-div
+    # Pixel-by-pixel, channel-by-channel division of A by B
+    A = ImageBuf("grid.exr")
+    B = ImageBuf("grid.exr")
+    Ratio = ImageBufAlgo.div (A, B)
+
+    # In-place reduce intensity of A's channels 0-2 by 50%
+    ImageBufAlgo.div (A, A, (2.0, 2.0, 2.0, 1.0))
+    # END--imagebufalgo-div
+    Ratio.write("div.exr", "half")
+
+#TODO: mad and onwards
 
 # Section: Image comparison and statistics
 
@@ -511,6 +577,12 @@ if __name__ == '__main__':
     example_warp()
 
     # Section: Image Arithmetic
+    example_add()
+    example_sub()
+    example_absdiff()
+    example_abs()
+    example_mul()
+    example_div()
 
     # Section: Image comparison and statistics
 

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -440,8 +440,8 @@ def example_add():
     print("example_add")
     # BEGIN-imagebufalgo-add
     # Add images A and B
-    A = ImageBuf("grid.exr")
-    B = ImageBuf("grid.exr")
+    A = ImageBuf("A.exr")
+    B = ImageBuf("B.exr")
     Sum = ImageBufAlgo.add (A, B)
 
     # Add 0.2 to channels 0-2, but not to channel 3
@@ -453,8 +453,8 @@ def example_add():
 def example_sub():
     print("example_sub")
     # BEGIN-imagebufalgo-sub
-    A = ImageBuf("grid.exr")
-    B = ImageBuf("grid.exr")
+    A = ImageBuf("A.exr")
+    B = ImageBuf("B.exr")
     Diff = ImageBufAlgo.sub (A, B)
     # END-imagebufalgo-sub
     Diff.write("sub.exr", "half")
@@ -462,8 +462,8 @@ def example_sub():
 def example_absdiff():
     print("example_absdiff")
     # BEGIN-imagebufalgo-absdiff
-    A = ImageBuf("grid.exr")
-    B = ImageBuf("grid.exr")
+    A = ImageBuf("A.exr")
+    B = ImageBuf("B.exr")
     Diff = ImageBufAlgo.absdiff (A, B)
     # END--imagebufalgo-absdiff
     Diff.write("absdiff.exr", "half")
@@ -480,8 +480,8 @@ def example_mul():
     print("example_mul")
     # BEGIN-imagebufalgo-mul
     # Pixel-by-pixel, channel-by-channel multiplication of A and B
-    A = ImageBuf("grid.exr")
-    B = ImageBuf("grid.exr")
+    A = ImageBuf("A.exr")
+    B = ImageBuf("B.exr")
     Product = ImageBufAlgo.mul (A, B)
 
     # In-place reduce intensity of A's channels 0-2 by 50%
@@ -493,8 +493,8 @@ def example_div():
     print("example_div")
     # BEGIN-imagebufalgo-div
     # Pixel-by-pixel, channel-by-channel division of A by B
-    A = ImageBuf("grid.exr")
-    B = ImageBuf("grid.exr")
+    A = ImageBuf("A.exr")
+    B = ImageBuf("B.exr")
     Ratio = ImageBufAlgo.div (A, B)
 
     # In-place reduce intensity of A's channels 0-2 by 50%

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -465,7 +465,7 @@ def example_absdiff():
     A = ImageBuf("A.exr")
     B = ImageBuf("B.exr")
     Diff = ImageBufAlgo.absdiff (A, B)
-    # END--imagebufalgo-absdiff
+    # END-imagebufalgo-absdiff
     Diff.write("absdiff.exr", "half")
 
 def example_abs():
@@ -473,7 +473,7 @@ def example_abs():
     # BEGIN-imagebufalgo-absolute
     A = ImageBuf("grid.exr")
     Abs = ImageBufAlgo.abs (A)
-    # END--imagebufalgo-absolute
+    # END-imagebufalgo-absolute
     Abs.write("abs.exr", "half")
 
 def example_mul():
@@ -486,7 +486,7 @@ def example_mul():
 
     # In-place reduce intensity of A's channels 0-2 by 50%
     ImageBufAlgo.mul (A, A, (0.5, 0.5, 0.5, 1.0))
-    # END--imagebufalgo-mul
+    # END-imagebufalgo-mul
     Product.write("mul.exr", "half")
 
 def example_div():
@@ -499,7 +499,7 @@ def example_div():
 
     # In-place reduce intensity of A's channels 0-2 by 50%
     ImageBufAlgo.div (A, A, (2.0, 2.0, 2.0, 1.0))
-    # END--imagebufalgo-div
+    # END-imagebufalgo-div
     Ratio.write("div.exr", "half")
 
 #TODO: mad and onwards

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -470,10 +470,10 @@ def example_absdiff():
 
 def example_abs():
     print("example_abs")
-    # BEGIN-imagebufalgo-abs
+    # BEGIN-imagebufalgo-absolute
     A = ImageBuf("grid.exr")
     Abs = ImageBufAlgo.abs (A)
-    # END--imagebufalgo-abs
+    # END--imagebufalgo-absolute
     Abs.write("abs.exr", "half")
 
 def example_mul():


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->
This a documentation to testsuite conversion for cpp and python for the ImageBufAlgo Chapter, Section: Image Arithmetic up to the div function.

The PR also fixes a python testing image file reference in ..docs-examples-python/ref/out.txt, where reference images "simple.tif" and "scanlines.tif" should have the docs-examples-cpp prefix (see ..docs-examples-python/run.py line 11 for details).

## Tests
Verified in SPI build environment that existing tests are working.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
