### PR TITLE
ci: Streamline the old MacOS-12 CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,8 +512,9 @@ jobs:
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
-            python_ver: "3.10"
+            python_ver: "3.11"
             aclang: 13
+            setenvs: export INSTALL_QT=0 INSTALL_OPENCV=0
           - desc: MacOS-13
             runner: macos-13
             nametag: macos13-py311
@@ -525,11 +526,11 @@ jobs:
             simd: sse4.2,avx2
           - desc: MacOS-14-ARM
             runner: macos-14
-            nametag: macos14-arm-py311
+            nametag: macos14-arm-py312
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 20
-            python_ver: "3.11"
+            python_ver: "3.12"
             aclang: 15
     runs-on: ${{ matrix.runner }}
     env:

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -44,10 +44,10 @@ brew install --display-times -q freetype libraw dcmtk pybind11 numpy || true
 brew install --display-times -q ffmpeg libheif ptex || true
 brew install --display-times -q tbb || true
 brew install --display-times -q openvdb || true
-if [[ "${USE_OPENCV}" != "0" ]] ; then
+if [[ "${USE_OPENCV}" != "0" ]] && [[ "${INSTALL_OPENCV:=1}" != "0" ]] ; then
     brew install --display-times -q opencv || true
 fi
-if [[ "${USE_QT}" != "0" ]] ; then
+if [[ "${USE_QT:=1}" != "0" ]] && [[ "${INSTALL_QT:=1}" != "0" ]] ; then
     brew install --display-times -q qt${QT_VERSION}
 fi
 if [[ "${USE_LLVM:=0}" != "0" ]] || [[ "${LLVMBREWVER}" != "" ]]; then


### PR DESCRIPTION
It's an old flavor not well supported by homebrew any longer, so what's happening is that most of the dependency packages we ask to install have to build from source, which means it takes a long long time.

By disabling OpenCV and Qt homebrew installation for it, we can make it fast again. Neither the minimal OpenCV interop, nor osltoy (the only thing that needs Qt) are exercised by the automated testsuite anyway, so I don't think there's any loss of testing functionality in practice.
