### PR TITLE
ci: Test against OpenEXR 3.3 and deal with its 4.0 bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: latest releases gcc13 C++20 py3.12 avx2 exr3.2 ocio2.3
+          - desc: latest releases gcc13 C++20 py3.12 avx2 exr3.3 ocio2.3
             nametag: linux-latest-releases
             runner: ubuntu-24.04
             cc_compiler: gcc-13
@@ -325,7 +325,7 @@ jobs:
             cxx_std: 20
             fmt_ver: 11.0.2
             opencolorio_ver: v2.3.2
-            openexr_ver: v3.2.4
+            openexr_ver: v3.3.0
             pybind11_ver: v2.13.5
             python_ver: "3.12"
             simd: avx2,f16c

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,11 +12,13 @@ on:
       - '**/analysis.yml'
       - '**.properties'
       - '**.cpp'
+      - '**.cmake'
   pull_request:
     paths-ignore:
       - '**/analysis.yml'
       - '**.properties'
       - '**.cpp'
+      - '**.cmake'
   schedule:
     # Full nightly build
     - cron: "0 8 * * *"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,9 +19,9 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=20`, etc.
  * Compilers: **gcc 9.3** - 14.1, **clang 5** - 18, MSVS 2017 - 2019 (**v19.14
    and up**), **Intel icc 19+**, Intel OneAPI C++ compiler 2022+.
- * **CMake >= 3.15** (tested through 3.29)
+ * **CMake >= 3.15** (tested through 3.30)
  * **Imath >= 3.1** (tested through 3.1.x and main)
- * **OpenEXR >= 3.1** (tested through 3.2 and main)
+ * **OpenEXR >= 3.1** (tested through 3.3 and main)
  * **libTIFF >= 4.0** (tested through 4.7)
  * **OpenColorIO >= 2.2** (tested through 2.3 and main)
  * libjpeg >= 8 (tested through jpeg9e), or **libjpeg-turbo >= 2.1** (tested
@@ -49,7 +49,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * OpenJpeg >= 2.0 (tested through 2.5; we recommend 2.4 or higher
        for multithreading support)
  * If you want support for OpenVDB files:
-     * OpenVDB >= 5.0 (tested through 11.0). Note that using OpenVDB >= 10.0
+     * OpenVDB >= 9.0 (tested through 11.0). Note that using OpenVDB >= 10.0
        requires that you compile OIIO with C++17 or higher.
  * If you want to use TBB as the thread pool:
      * TBB >= 2018 (tested through 2021 and OneTBB)

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -60,6 +60,7 @@ popd
 
 # Set up paths. These will only affect the caller if this script is
 # run with 'source' rather than in a separate shell.
+export OpenEXR_ROOT=$OPENEXR_INSTALL_DIR
 export OPENEXR_ROOT=$OPENEXR_INSTALL_DIR
 export OPENEXR_LIBRARY_DIR=$OPENEXR_INSTALL_DIR/lib
 export LD_LIBRARY_PATH=$OPENEXR_ROOT/lib:$LD_LIBRARY_PATH

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -57,6 +57,7 @@ checked_find_package (Imath REQUIRED
 
 checked_find_package (OpenEXR REQUIRED
     VERSION_MIN 3.1
+    NO_FP_RANGE_CHECK
     PRINT IMATH_INCLUDES OPENEXR_INCLUDES Imath_VERSION
     )
 


### PR DESCRIPTION
OpenEXR 3.3 was just released and its main branch has bumped its advertised version to 4.0 (the latter breaking our "bleeding edge" CI test).

Raise our "latest releases" test to use 3.3.

Our "bleeding edge" test picking up the now-called-4.0 OpenEXR main branch required some minor logic changes to not reject the version as too new to be compatible.
