### PR TITLE
testing: Fixup after directory refactor of OpenImageIO-images

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -193,7 +193,7 @@ macro (oiio_add_all_tests)
                     texture-filtersize
                     texture-filtersize-stochastic
                     texture-res texture-maxres
-                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images"
+                    IMAGEDIR oiio-images URL "Recent checkout of OpenImageIO-images"
                    )
 
     # Add tests that require the Python bindings.
@@ -234,20 +234,20 @@ macro (oiio_add_all_tests)
                     IMAGEDIR oiio-images/bmpsuite)
     oiio_add_tests (cineon
                     ENABLEVAR ENABLE_CINEON
-                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
+                    IMAGEDIR oiio-images URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (dpx
                     ENABLEVAR ENABLE_DPX
-                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
+                    IMAGEDIR oiio-images/dpx URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (dds
                     ENABLEVAR ENABLE_DDS
-                    IMAGEDIR oiio-images/dds URL "Recent checkout of oiio-images")
+                    IMAGEDIR oiio-images/dds URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (fits
                     ENABLEVAR ENABLE_FITS
                     IMAGEDIR fits-images
                     URL http://www.cv.nrao.edu/fits/data/tests/)
     oiio_add_tests (gif
                     FOUNDVAR GIF_FOUND ENABLEVAR ENABLE_GIF
-                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
+                    IMAGEDIR oiio-images/gif URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (hdr
                     ENABLEVAR ENABLE_HDR
                     IMAGEDIR openexr-images
@@ -259,13 +259,13 @@ macro (oiio_add_all_tests)
                     URL http://github.com/AcademySoftwareFoundation/openexr-images)
     oiio_add_tests (ico
                     ENABLEVAR ENABLE_ICO
-                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
+                    IMAGEDIR oiio-images/ico URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (iff
                     ENABLEVAR ENABLE_IFF
-                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
+                    IMAGEDIR oiio-images URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (jpeg2000
                     FOUNDVAR OPENJPEG_FOUND
-                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
+                    IMAGEDIR oiio-images URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (jpeg2000-j2kp4files
                     FOUNDVAR OPENJPEG_FOUND
                     IMAGEDIR j2kp4files_v1_5
@@ -307,13 +307,13 @@ macro (oiio_add_all_tests)
                     FOUNDVAR OpenVDB_FOUND ENABLEVAR ENABLE_OpenVDB)
     oiio_add_tests (png png-damaged
                     ENABLEVAR ENABLE_PNG
-                    IMAGEDIR oiio-images)
+                    IMAGEDIR oiio-images/png)
     oiio_add_tests (pnm
                     ENABLEVAR ENABLE_PNM
                     IMAGEDIR oiio-images)
     oiio_add_tests (psd psd-colormodes
                     ENABLEVAR ENABLE_PSD
-                    IMAGEDIR oiio-images)
+                    IMAGEDIR oiio-images/psd)
     oiio_add_tests (ptex
                     FOUNDVAR PTEX_FOUND ENABLEVAR ENABLE_PTEX)
     oiio_add_tests (raw
@@ -321,7 +321,7 @@ macro (oiio_add_all_tests)
                     IMAGEDIR oiio-images/raw)
     oiio_add_tests (rla
                     ENABLEVAR ENABLE_RLA
-                    IMAGEDIR oiio-images)
+                    IMAGEDIR oiio-images/rla)
     oiio_add_tests (sgi
                     ENABLEVAR ENABLE_SGI
                     IMAGEDIR oiio-images)
@@ -406,7 +406,8 @@ endfunction()
 
 function (oiio_setup_test_data)
     oiio_get_test_data (oiio-images
-                        REPO https://github.com/AcademySoftwareFoundation/OpenImageIO-images.git)
+                        REPO https://github.com/AcademySoftwareFoundation/OpenImageIO-images.git
+                        BRANCH dev-${OpenImageIO_VERSION_MAJOR}.${OpenImageIO_VERSION_MINOR})
     oiio_get_test_data (openexr-images
                         REPO https://github.com/AcademySoftwareFoundation/openexr-images.git
                         BRANCH main)

--- a/testsuite/dpx/ref/out.txt
+++ b/testsuite/dpx/ref/out.txt
@@ -1,5 +1,5 @@
-Reading ../oiio-images/dpx_nuke_10bits_rgb.dpx
-../oiio-images/dpx_nuke_10bits_rgb.dpx :  512 x  512, 3 channel, uint10 dpx
+Reading ../oiio-images/dpx/dpx_nuke_10bits_rgb.dpx
+../oiio-images/dpx/dpx_nuke_10bits_rgb.dpx :  512 x  512, 3 channel, uint10 dpx
     SHA-1: D63D2EC8C60AB41B1C0F72A65AE8FF27DA8A620E
     channel list: R, G, B
     DateTime: "2011:03:08 14:47:25"
@@ -38,10 +38,10 @@ Reading ../oiio-images/dpx_nuke_10bits_rgb.dpx
     oiio:BitsPerSample: 10
     oiio:subimages: 1
     smpte:TimeCode: 00:00:00:00
-Comparing "../oiio-images/dpx_nuke_10bits_rgb.dpx" and "dpx_nuke_10bits_rgb.dpx"
+Comparing "../oiio-images/dpx/dpx_nuke_10bits_rgb.dpx" and "dpx_nuke_10bits_rgb.dpx"
 PASS
-Reading ../oiio-images/dpx_nuke_16bits_rgba.dpx
-../oiio-images/dpx_nuke_16bits_rgba.dpx :  512 x  512, 4 channel, uint10 dpx
+Reading ../oiio-images/dpx/dpx_nuke_16bits_rgba.dpx
+../oiio-images/dpx/dpx_nuke_16bits_rgba.dpx :  512 x  512, 4 channel, uint10 dpx
     SHA-1: E9FECE70CD875C5654F58DA9EC576399F089D855
     channel list: R, G, B, A
     DateTime: "2011:03:08 14:47:01"
@@ -80,7 +80,7 @@ Reading ../oiio-images/dpx_nuke_16bits_rgba.dpx
     oiio:BitsPerSample: 10
     oiio:subimages: 1
     smpte:TimeCode: 00:00:00:00
-Comparing "../oiio-images/dpx_nuke_16bits_rgba.dpx" and "dpx_nuke_16bits_rgba.dpx"
+Comparing "../oiio-images/dpx/dpx_nuke_16bits_rgba.dpx" and "dpx_nuke_16bits_rgba.dpx"
 PASS
 Comparing "src/input_rgb_mattes.tif" and "output_rgb_mattes.dpx"
 PASS

--- a/testsuite/gif/ref/out.txt
+++ b/testsuite/gif/ref/out.txt
@@ -1,5 +1,5 @@
-Reading ../oiio-images/gif_animation.gif
-../oiio-images/gif_animation.gif :   30 x   30, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_animation.gif
+../oiio-images/gif/gif_animation.gif :   30 x   30, 4 channel, uint8 gif
     3 subimages: 30x30 [u8,u8,u8,u8]
  subimage  0:   30 x   30, 4 channel, uint8 gif
     SHA-1: DDECBD8686D4C2BCB43C2AA05F75C5BDB1CAF54B
@@ -22,45 +22,45 @@ Reading ../oiio-images/gif_animation.gif
     gif:Interlacing: 0
     oiio:ColorSpace: "sRGB"
     oiio:Movie: 1
-Reading ../oiio-images/gif_oiio_logo_with_alpha.gif
-../oiio-images/gif_oiio_logo_with_alpha.gif :  135 x  135, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_oiio_logo_with_alpha.gif
+../oiio-images/gif/gif_oiio_logo_with_alpha.gif :  135 x  135, 4 channel, uint8 gif
     SHA-1: 8EDEB5C51B7C376D2526BAC0E3CFE2BE500F4115
     channel list: R, G, B, A
     ImageDescription: "oiio logo with alpha"
     gif:Interlacing: 0
     oiio:ColorSpace: "sRGB"
-Reading ../oiio-images/gif_tahoe.gif
-../oiio-images/gif_tahoe.gif : 2048 x 1536, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_tahoe.gif
+../oiio-images/gif/gif_tahoe.gif : 2048 x 1536, 4 channel, uint8 gif
     SHA-1: 4E76899178CDAA94690E52CD18E07B810E40A273
     channel list: R, G, B, A
     gif:Interlacing: 0
     oiio:ColorSpace: "sRGB"
-Reading ../oiio-images/gif_tahoe_interlaced.gif
-../oiio-images/gif_tahoe_interlaced.gif : 2048 x 1536, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_tahoe_interlaced.gif
+../oiio-images/gif/gif_tahoe_interlaced.gif : 2048 x 1536, 4 channel, uint8 gif
     SHA-1: 4E76899178CDAA94690E52CD18E07B810E40A273
     channel list: R, G, B, A
     gif:Interlacing: 1
     oiio:ColorSpace: "sRGB"
-Reading ../oiio-images/gif_bluedot.gif
-../oiio-images/gif_bluedot.gif :    1 x    1, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_bluedot.gif
+../oiio-images/gif/gif_bluedot.gif :    1 x    1, 4 channel, uint8 gif
     SHA-1: EE0202803A0133BDA7BC40AC63091DCC58A4225B
     channel list: R, G, B, A
     gif:Interlacing: 0
     oiio:ColorSpace: "sRGB"
-Reading ../oiio-images/gif_diagonal_interlaced.gif
-../oiio-images/gif_diagonal_interlaced.gif :  200 x  200, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_diagonal_interlaced.gif
+../oiio-images/gif/gif_diagonal_interlaced.gif :  200 x  200, 4 channel, uint8 gif
     SHA-1: CE1C613BB8B7EE80673B640CA3E392345C8C9FF4
     channel list: R, G, B, A
     gif:Interlacing: 1
     oiio:ColorSpace: "sRGB"
-Reading ../oiio-images/gif_triangle_interlaced.gif
-../oiio-images/gif_triangle_interlaced.gif :  200 x  200, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_triangle_interlaced.gif
+../oiio-images/gif/gif_triangle_interlaced.gif :  200 x  200, 4 channel, uint8 gif
     SHA-1: 44F8A0F4F39AB3ED532268B9EB45E09548925345
     channel list: R, G, B, A
     gif:Interlacing: 1
     oiio:ColorSpace: "sRGB"
-Reading ../oiio-images/gif_test_disposal_method.gif
-../oiio-images/gif_test_disposal_method.gif :   50 x   50, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_test_disposal_method.gif
+../oiio-images/gif/gif_test_disposal_method.gif :   50 x   50, 4 channel, uint8 gif
     4 subimages: 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8]
  subimage  0:   50 x   50, 4 channel, uint8 gif
     SHA-1: 30839F361083DA6893F6A29B4F4628DCFBF9F1B5
@@ -82,8 +82,8 @@ Reading ../oiio-images/gif_test_disposal_method.gif
     channel list: R, G, B, A
     gif:Interlacing: 0
     oiio:ColorSpace: "sRGB"
-Reading ../oiio-images/gif_test_loop_count.gif
-../oiio-images/gif_test_loop_count.gif :   20 x   20, 4 channel, uint8 gif
+Reading ../oiio-images/gif/gif_test_loop_count.gif
+../oiio-images/gif/gif_test_loop_count.gif :   20 x   20, 4 channel, uint8 gif
     SHA-1: C4AA837A5833B05CFCA50BD090D42AEB033069E1
     channel list: R, G, B, A
     gif:Interlacing: 0

--- a/testsuite/ico/ref/out.txt
+++ b/testsuite/ico/ref/out.txt
@@ -1,5 +1,5 @@
-Reading ../oiio-images/oiio.ico
-../oiio-images/oiio.ico :   16 x   16, 4 channel, uint1 ico
+Reading ../oiio-images/ico/oiio.ico
+../oiio-images/ico/oiio.ico :   16 x   16, 4 channel, uint1 ico
     10 subimages: 16x16 [u1,u1,u1,u1], 32x32 [u2,u2,u2,u2], 16x16 [u2,u2,u2,u2], 48x48 [u3,u3,u3,u3], 32x32 [u3,u3,u3,u3], 16x16 [u3,u3,u3,u3], 256x256 [u2,u2,u2,u2], 48x48 [u8,u8,u8,u8], 32x32 [u8,u8,u8,u8], 16x16 [u8,u8,u8,u8]
  subimage  0:   16 x   16, 4 channel, uint1 ico
     SHA-1: 563F978D0860CB8791716CA694AB94EEA83E6E03
@@ -43,5 +43,5 @@ Reading ../oiio-images/oiio.ico
     SHA-1: 0196F151853CC595AF7504196C8CCC5B3A3CE446
     channel list: R, G, B, A
     oiio:BitsPerSample: 8
-Comparing "../oiio-images/oiio.ico" and "oiio.ico"
+Comparing "../oiio-images/ico/oiio.ico" and "oiio.ico"
 PASS

--- a/testsuite/png-damaged/run.py
+++ b/testsuite/png-damaged/run.py
@@ -9,6 +9,6 @@
 redirect = " >> out.txt 2>&1 "
 failureok = 1
 
-command += rw_command (OIIO_TESTSUITE_IMAGEDIR + "/png/broken",
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR + "/broken",
                        "invalid_gray_alpha_sbit.png",
                        printinfo=False)

--- a/testsuite/png/ref/out-libpng15.txt
+++ b/testsuite/png/ref/out-libpng15.txt
@@ -1,5 +1,5 @@
-Reading ../oiio-images/oiio-logo-no-alpha.png
-../oiio-images/oiio-logo-no-alpha.png :  135 x  135, 4 channel, uint8 png
+Reading ../oiio-images/png/oiio-logo-no-alpha.png
+../oiio-images/png/oiio-logo-no-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 75ED9B183E083ECF0A4881EEE0B553457B698CF4
     channel list: R, G, B, A
     Comment: "Created with GIMP"
@@ -8,10 +8,10 @@ Reading ../oiio-images/oiio-logo-no-alpha.png
     XResolution: 72
     YResolution: 72
     oiio:ColorSpace: "sRGB"
-Comparing "../oiio-images/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
+Comparing "../oiio-images/png/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
 PASS
-Reading ../oiio-images/oiio-logo-with-alpha.png
-../oiio-images/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
+Reading ../oiio-images/png/oiio-logo-with-alpha.png
+../oiio-images/png/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 8AED04DCCE8F83B068C537DC0982A42EFBE431B6
     channel list: R, G, B, A
     Comment: "Created with GIMP"
@@ -20,7 +20,7 @@ Reading ../oiio-images/oiio-logo-with-alpha.png
     XResolution: 72
     YResolution: 72
     oiio:ColorSpace: "sRGB"
-Comparing "../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
+Comparing "../oiio-images/png/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
 Reading exif.png
 exif.png             :   64 x   64, 3 channel, uint8 png

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -1,5 +1,5 @@
-Reading ../oiio-images/oiio-logo-no-alpha.png
-../oiio-images/oiio-logo-no-alpha.png :  135 x  135, 4 channel, uint8 png
+Reading ../oiio-images/png/oiio-logo-no-alpha.png
+../oiio-images/png/oiio-logo-no-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 75ED9B183E083ECF0A4881EEE0B553457B698CF4
     channel list: R, G, B, A
     Comment: "Created with GIMP"
@@ -8,10 +8,10 @@ Reading ../oiio-images/oiio-logo-no-alpha.png
     XResolution: 72
     YResolution: 72
     oiio:ColorSpace: "sRGB"
-Comparing "../oiio-images/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
+Comparing "../oiio-images/png/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
 PASS
-Reading ../oiio-images/oiio-logo-with-alpha.png
-../oiio-images/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
+Reading ../oiio-images/png/oiio-logo-with-alpha.png
+../oiio-images/png/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 8AED04DCCE8F83B068C537DC0982A42EFBE431B6
     channel list: R, G, B, A
     Comment: "Created with GIMP"
@@ -20,7 +20,7 @@ Reading ../oiio-images/oiio-logo-with-alpha.png
     XResolution: 72
     YResolution: 72
     oiio:ColorSpace: "sRGB"
-Comparing "../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
+Comparing "../oiio-images/png/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
 Reading exif.png
 exif.png             :   64 x   64, 3 channel, uint8 png

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -1,5 +1,5 @@
-Reading ../oiio-images/psd_123.psd
-../oiio-images/psd_123.psd :  257 x  126, 4 channel, uint8 psd
+Reading ../oiio-images/psd/psd_123.psd
+../oiio-images/psd/psd_123.psd :  257 x  126, 4 channel, uint8 psd
     4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 4 channel, uint8 psd
     SHA-1: D48458E9AEDB9C8618DE4B7DAA25BD4D7421778A
@@ -183,8 +183,8 @@ Reading ../oiio-images/psd_123.psd
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:when: "2011-08-22T22:14:43-04:00"
-Reading ../oiio-images/psd_123_nomaxcompat.psd
-../oiio-images/psd_123_nomaxcompat.psd :  257 x  126, 3 channel, uint8 psd
+Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
+../oiio-images/psd/psd_123_nomaxcompat.psd :  257 x  126, 3 channel, uint8 psd
     4 subimages: 257x126 [u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 3 channel, uint8 psd
     SHA-1: 5A7BDC7A11A9E4BDCBEC968375EE466DE74D0481
@@ -372,8 +372,8 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:F4BDDC0457D2E011BF419187EAB8EBB9; xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:when: "2011-08-22T22:14:43-04:00; 2011-08-29T12:10:28-04:00"
-Reading ../oiio-images/psd_bitmap.psd
-../oiio-images/psd_bitmap.psd :  320 x  240, 3 channel, uint8 psd
+Reading ../oiio-images/psd/psd_bitmap.psd
+../oiio-images/psd/psd_bitmap.psd :  320 x  240, 3 channel, uint8 psd
     SHA-1: F23185BC048E31BAC6BB4B319E5E5AC570CC7B89
     channel list: R, G, B
     Artist: "Daniel Wyatt"
@@ -440,8 +440,8 @@ Reading ../oiio-images/psd_bitmap.psd
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
     stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-Reading ../oiio-images/psd_indexed_trans.psd
-../oiio-images/psd_indexed_trans.psd :  320 x  240, 4 channel, uint8 psd
+Reading ../oiio-images/psd/psd_indexed_trans.psd
+../oiio-images/psd/psd_indexed_trans.psd :  320 x  240, 4 channel, uint8 psd
     SHA-1: 5B548EAE1F69EC4B65D762F52D8C542CF18515D5
     channel list: R, G, B, A
     Artist: "Daniel Wyatt"
@@ -511,8 +511,8 @@ Reading ../oiio-images/psd_indexed_trans.psd
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
     stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-Reading ../oiio-images/psd_rgb_8.psd
-../oiio-images/psd_rgb_8.psd :  320 x  240, 3 channel, uint8 psd
+Reading ../oiio-images/psd/psd_rgb_8.psd
+../oiio-images/psd/psd_rgb_8.psd :  320 x  240, 3 channel, uint8 psd
     SHA-1: 44362B2D9E51C40DF8ABF87CC749B77F2D0D9F4F
     channel list: R, G, B
     Artist: "Daniel Wyatt"
@@ -582,8 +582,8 @@ Reading ../oiio-images/psd_rgb_8.psd
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
     stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-Reading ../oiio-images/psd_rgb_16.psd
-../oiio-images/psd_rgb_16.psd :  320 x  240, 3 channel, uint16 psd
+Reading ../oiio-images/psd/psd_rgb_16.psd
+../oiio-images/psd/psd_rgb_16.psd :  320 x  240, 3 channel, uint16 psd
     SHA-1: E42334B0F0684E3C3BF9125F2920B07C44C17B11
     channel list: R, G, B
     Artist: "Daniel Wyatt"
@@ -653,8 +653,8 @@ Reading ../oiio-images/psd_rgb_16.psd
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
     stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-Reading ../oiio-images/psd_rgb_32.psd
-../oiio-images/psd_rgb_32.psd :  320 x  240, 3 channel, float psd
+Reading ../oiio-images/psd/psd_rgb_32.psd
+../oiio-images/psd/psd_rgb_32.psd :  320 x  240, 3 channel, float psd
     SHA-1: 63CF8F7B010D24EFD3C41F51C16D8D285FE07313
     channel list: R, G, B
     Artist: "Daniel Wyatt"
@@ -723,8 +723,8 @@ Reading ../oiio-images/psd_rgb_32.psd
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
     stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-Reading ../oiio-images/psd_rgba_8.psd
-../oiio-images/psd_rgba_8.psd :  320 x  240, 4 channel, uint8 psd
+Reading ../oiio-images/psd/psd_rgba_8.psd
+../oiio-images/psd/psd_rgba_8.psd :  320 x  240, 4 channel, uint8 psd
     2 subimages: 320x240 [u8,u8,u8,u8], 320x240 [u8,u8,u8,u8]
  subimage  0:  320 x  240, 4 channel, uint8 psd
     SHA-1: 81C22E59537BCDB081C12BF93E14DB2B5DDEEC13
@@ -805,8 +805,8 @@ Reading ../oiio-images/psd_rgba_8.psd
     stEvt:instanceID: "xmp.iid:037A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:when: "2011-08-22T22:07:44-04:00; 2011-08-25T17:39:28-04:00"
-Reading ../oiio-images/psd_123.psd
-../oiio-images/psd_123.psd :  257 x  126, 4 channel, uint8 psd
+Reading ../oiio-images/psd/psd_123.psd
+../oiio-images/psd/psd_123.psd :  257 x  126, 4 channel, uint8 psd
     4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 4 channel, uint8 psd
     SHA-1: B229DA843AD0DA7C6FF92ABC78C737E81FEB6CF2

--- a/testsuite/rla/ref/out.txt
+++ b/testsuite/rla/ref/out.txt
@@ -1,5 +1,5 @@
-Reading ../oiio-images/ginsu_a_nc10.rla
-../oiio-images/ginsu_a_nc10.rla :  512 x  512, 4 channel, uint10 rla
+Reading ../oiio-images/rla/ginsu_a_nc10.rla
+../oiio-images/rla/ginsu_a_nc10.rla :  512 x  512, 4 channel, uint10 rla
     SHA-1: 2732EF8B7515349C6FB6C8D9B678D9968E304AE3
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -17,10 +17,10 @@ Reading ../oiio-images/ginsu_a_nc10.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_a_nc10.rla" and "ginsu_a_nc10.rla"
+Comparing "../oiio-images/rla/ginsu_a_nc10.rla" and "ginsu_a_nc10.rla"
 PASS
-Reading ../oiio-images/ginsu_a_ncf.rla
-../oiio-images/ginsu_a_ncf.rla :  512 x  512, 4 channel, float rla
+Reading ../oiio-images/rla/ginsu_a_ncf.rla
+../oiio-images/rla/ginsu_a_ncf.rla :  512 x  512, 4 channel, float rla
     SHA-1: 10419E1D3AFFDE7F351BFA9ABF96F8C18527BE5D
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -38,10 +38,10 @@ Reading ../oiio-images/ginsu_a_ncf.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_a_ncf.rla" and "ginsu_a_ncf.rla"
+Comparing "../oiio-images/rla/ginsu_a_ncf.rla" and "ginsu_a_ncf.rla"
 PASS
-Reading ../oiio-images/ginsu_rgba_nc8.rla
-../oiio-images/ginsu_rgba_nc8.rla :  512 x  512, 4 channel, uint8 rla
+Reading ../oiio-images/rla/ginsu_rgba_nc8.rla
+../oiio-images/rla/ginsu_rgba_nc8.rla :  512 x  512, 4 channel, uint8 rla
     SHA-1: 030CF1F960E9585D2F6A1173B86034BC15C26C41
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -59,10 +59,10 @@ Reading ../oiio-images/ginsu_rgba_nc8.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgba_nc8.rla" and "ginsu_rgba_nc8.rla"
+Comparing "../oiio-images/rla/ginsu_rgba_nc8.rla" and "ginsu_rgba_nc8.rla"
 PASS
-Reading ../oiio-images/ginsu_rgb_nc16.rla
-../oiio-images/ginsu_rgb_nc16.rla :  512 x  512, 3 channel, uint16 rla
+Reading ../oiio-images/rla/ginsu_rgb_nc16.rla
+../oiio-images/rla/ginsu_rgb_nc16.rla :  512 x  512, 3 channel, uint16 rla
     SHA-1: B31B6515AA9BD09C8CFFCB242C1E7D5D130CA923
     channel list: R, G, B
     Artist: "jeremys"
@@ -80,10 +80,10 @@ Reading ../oiio-images/ginsu_rgb_nc16.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgb_nc16.rla" and "ginsu_rgb_nc16.rla"
+Comparing "../oiio-images/rla/ginsu_rgb_nc16.rla" and "ginsu_rgb_nc16.rla"
 PASS
-Reading ../oiio-images/imgmake_rgba_nc10.rla
-../oiio-images/imgmake_rgba_nc10.rla :  512 x  512, 4 channel, uint10 rla
+Reading ../oiio-images/rla/imgmake_rgba_nc10.rla
+../oiio-images/rla/imgmake_rgba_nc10.rla :  512 x  512, 4 channel, uint10 rla
     SHA-1: 12F22B420DDB3D330092A38AF48F9A225467EC6E
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -99,10 +99,10 @@ Reading ../oiio-images/imgmake_rgba_nc10.rla
     rla:GreenChroma: 0.21, 0.21, 0.71
     rla:RedChroma: 0.67, 0.67, 0.33
     rla:WhitePoint: 0.31, 0.31, 0.316
-Comparing "../oiio-images/imgmake_rgba_nc10.rla" and "imgmake_rgba_nc10.rla"
+Comparing "../oiio-images/rla/imgmake_rgba_nc10.rla" and "imgmake_rgba_nc10.rla"
 PASS
-Reading ../oiio-images/ginsu_a_nc16.rla
-../oiio-images/ginsu_a_nc16.rla :  512 x  512, 4 channel, uint16 rla
+Reading ../oiio-images/rla/ginsu_a_nc16.rla
+../oiio-images/rla/ginsu_a_nc16.rla :  512 x  512, 4 channel, uint16 rla
     SHA-1: 476760230A4F7540072865C0E01CC6417EA9EC3E
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -120,10 +120,10 @@ Reading ../oiio-images/ginsu_a_nc16.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_a_nc16.rla" and "ginsu_a_nc16.rla"
+Comparing "../oiio-images/rla/ginsu_a_nc16.rla" and "ginsu_a_nc16.rla"
 PASS
-Reading ../oiio-images/ginsu_rgba_nc10.rla
-../oiio-images/ginsu_rgba_nc10.rla :  512 x  512, 4 channel, uint10 rla
+Reading ../oiio-images/rla/ginsu_rgba_nc10.rla
+../oiio-images/rla/ginsu_rgba_nc10.rla :  512 x  512, 4 channel, uint10 rla
     SHA-1: 12F22B420DDB3D330092A38AF48F9A225467EC6E
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -141,10 +141,10 @@ Reading ../oiio-images/ginsu_rgba_nc10.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgba_nc10.rla" and "ginsu_rgba_nc10.rla"
+Comparing "../oiio-images/rla/ginsu_rgba_nc10.rla" and "ginsu_rgba_nc10.rla"
 PASS
-Reading ../oiio-images/ginsu_rgba_ncf.rla
-../oiio-images/ginsu_rgba_ncf.rla :  512 x  512, 4 channel, float rla
+Reading ../oiio-images/rla/ginsu_rgba_ncf.rla
+../oiio-images/rla/ginsu_rgba_ncf.rla :  512 x  512, 4 channel, float rla
     SHA-1: 43EB1CE263C8FC4630AEE68E34139C02A13F506D
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -162,10 +162,10 @@ Reading ../oiio-images/ginsu_rgba_ncf.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgba_ncf.rla" and "ginsu_rgba_ncf.rla"
+Comparing "../oiio-images/rla/ginsu_rgba_ncf.rla" and "ginsu_rgba_ncf.rla"
 PASS
-Reading ../oiio-images/ginsu_rgb_nc8.rla
-../oiio-images/ginsu_rgb_nc8.rla :  512 x  512, 3 channel, uint8 rla
+Reading ../oiio-images/rla/ginsu_rgb_nc8.rla
+../oiio-images/rla/ginsu_rgb_nc8.rla :  512 x  512, 3 channel, uint8 rla
     SHA-1: CB23AB13150BBD29947E65434E174D76C0324E7D
     channel list: R, G, B
     Artist: "jeremys"
@@ -183,10 +183,10 @@ Reading ../oiio-images/ginsu_rgb_nc8.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgb_nc8.rla" and "ginsu_rgb_nc8.rla"
+Comparing "../oiio-images/rla/ginsu_rgb_nc8.rla" and "ginsu_rgb_nc8.rla"
 PASS
-Reading ../oiio-images/imgmake_rgba_nc16.rla
-../oiio-images/imgmake_rgba_nc16.rla :  512 x  512, 4 channel, uint16 rla
+Reading ../oiio-images/rla/imgmake_rgba_nc16.rla
+../oiio-images/rla/imgmake_rgba_nc16.rla :  512 x  512, 4 channel, uint16 rla
     SHA-1: C1E653EAAFABEE98913D9B485CADAA50EF5731B2
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -202,10 +202,10 @@ Reading ../oiio-images/imgmake_rgba_nc16.rla
     rla:GreenChroma: 0.21, 0.21, 0.71
     rla:RedChroma: 0.67, 0.67, 0.33
     rla:WhitePoint: 0.31, 0.31, 0.316
-Comparing "../oiio-images/imgmake_rgba_nc16.rla" and "imgmake_rgba_nc16.rla"
+Comparing "../oiio-images/rla/imgmake_rgba_nc16.rla" and "imgmake_rgba_nc16.rla"
 PASS
-Reading ../oiio-images/ginsu_a_nc8.rla
-../oiio-images/ginsu_a_nc8.rla :  512 x  512, 4 channel, uint8 rla
+Reading ../oiio-images/rla/ginsu_a_nc8.rla
+../oiio-images/rla/ginsu_a_nc8.rla :  512 x  512, 4 channel, uint8 rla
     SHA-1: B96EF7B8A3B5328312BE6EA090A408681C423A00
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -223,10 +223,10 @@ Reading ../oiio-images/ginsu_a_nc8.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_a_nc8.rla" and "ginsu_a_nc8.rla"
+Comparing "../oiio-images/rla/ginsu_a_nc8.rla" and "ginsu_a_nc8.rla"
 PASS
-Reading ../oiio-images/ginsu_rgba_nc16.rla
-../oiio-images/ginsu_rgba_nc16.rla :  512 x  512, 4 channel, uint16 rla
+Reading ../oiio-images/rla/ginsu_rgba_nc16.rla
+../oiio-images/rla/ginsu_rgba_nc16.rla :  512 x  512, 4 channel, uint16 rla
     SHA-1: C1E653EAAFABEE98913D9B485CADAA50EF5731B2
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -244,10 +244,10 @@ Reading ../oiio-images/ginsu_rgba_nc16.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgba_nc16.rla" and "ginsu_rgba_nc16.rla"
+Comparing "../oiio-images/rla/ginsu_rgba_nc16.rla" and "ginsu_rgba_nc16.rla"
 PASS
-Reading ../oiio-images/ginsu_rgb_nc10.rla
-../oiio-images/ginsu_rgb_nc10.rla :  512 x  512, 3 channel, uint10 rla
+Reading ../oiio-images/rla/ginsu_rgb_nc10.rla
+../oiio-images/rla/ginsu_rgb_nc10.rla :  512 x  512, 3 channel, uint10 rla
     SHA-1: CF6AE7239E7F8FEE3D44BD6D6FE907642938B471
     channel list: R, G, B
     Artist: "jeremys"
@@ -265,10 +265,10 @@ Reading ../oiio-images/ginsu_rgb_nc10.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgb_nc10.rla" and "ginsu_rgb_nc10.rla"
+Comparing "../oiio-images/rla/ginsu_rgb_nc10.rla" and "ginsu_rgb_nc10.rla"
 PASS
-Reading ../oiio-images/ginsu_rgb_ncf.rla
-../oiio-images/ginsu_rgb_ncf.rla :  512 x  512, 3 channel, float rla
+Reading ../oiio-images/rla/ginsu_rgb_ncf.rla
+../oiio-images/rla/ginsu_rgb_ncf.rla :  512 x  512, 3 channel, float rla
     SHA-1: B5499846C3D45BF41351BC7A7338E9A31DD883AD
     channel list: R, G, B
     Artist: "jeremys"
@@ -286,10 +286,10 @@ Reading ../oiio-images/ginsu_rgb_ncf.rla
     rla:JobNumber: 1
     rla:RedChroma: 0.67, 0.33
     rla:WhitePoint: 0.31, 0.316
-Comparing "../oiio-images/ginsu_rgb_ncf.rla" and "ginsu_rgb_ncf.rla"
+Comparing "../oiio-images/rla/ginsu_rgb_ncf.rla" and "ginsu_rgb_ncf.rla"
 PASS
-Reading ../oiio-images/imgmake_rgba_nc8.rla
-../oiio-images/imgmake_rgba_nc8.rla :  512 x  512, 4 channel, uint8 rla
+Reading ../oiio-images/rla/imgmake_rgba_nc8.rla
+../oiio-images/rla/imgmake_rgba_nc8.rla :  512 x  512, 4 channel, uint8 rla
     SHA-1: 030CF1F960E9585D2F6A1173B86034BC15C26C41
     channel list: R, G, B, A
     Artist: "jeremys"
@@ -305,7 +305,7 @@ Reading ../oiio-images/imgmake_rgba_nc8.rla
     rla:GreenChroma: 0.21, 0.21, 0.71
     rla:RedChroma: 0.67, 0.67, 0.33
     rla:WhitePoint: 0.31, 0.31, 0.316
-Comparing "../oiio-images/imgmake_rgba_nc8.rla" and "imgmake_rgba_nc8.rla"
+Comparing "../oiio-images/rla/imgmake_rgba_nc8.rla" and "imgmake_rgba_nc8.rla"
 PASS
 oiiotool ERROR: read : "../oiio-images/rla/crash1.rla": Read error: malformed RLE record
 Full command line was:

--- a/testsuite/rla/run.py
+++ b/testsuite/rla/run.py
@@ -18,8 +18,8 @@ for f in files:
 command += oiiotool (OIIO_TESTSUITE_IMAGEDIR +
                      "/ginsu_rgb_nc8.rla -crop 100x100+100+100 -o rlacrop.rla")
 # Test corrupted files
-command += oiiotool(OIIO_TESTSUITE_IMAGEDIR + "/rla/crash1.rla -o crash1.exr", failureok = True)
-command += oiiotool(OIIO_TESTSUITE_IMAGEDIR + "/rla/crash2.rla -o crash2.exr", failureok = True)
+command += oiiotool(OIIO_TESTSUITE_IMAGEDIR + "/crash1.rla -o crash1.exr", failureok = True)
+command += oiiotool(OIIO_TESTSUITE_IMAGEDIR + "/crash2.rla -o crash2.exr", failureok = True)
 command += oiiotool("src/crash-1629.rla -o crash3.exr", failureok = True)
 command += oiiotool("src/crash-3951.rla -o crash4.exr", failureok = True)
 


### PR DESCRIPTION
I refactored the companion project full of testing images, putting all the clutter in the main directory into a subdirectory for each file type. These are the main OpenImageIO changes needed as a result.
