### PR TITLE
Color management nomenclature improvements

### DIFF
--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -169,7 +169,7 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
     // This is not very smart, but it seems that as a practical matter,
     // all Cineon files are log. So ignore the gamma field and just set
     // the color space to KodakLog.
-    m_spec.attribute("oiio:ColorSpace", "KodakLog");
+    m_spec.set_colorspace("KodakLog");
 #else
     // image linearity
     // FIXME: making this more robust would require the per-channel transfer
@@ -177,19 +177,18 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
     switch (m_cin.header.ImageDescriptor(0)) {
     case cineon::kRec709Red:
     case cineon::kRec709Green:
-    case cineon::kRec709Blue: m_spec.attribute("oiio:ColorSpace", "Rec709");
+    case cineon::kRec709Blue: m_spec.set_colorspace("Rec709");
     default:
         // either grayscale or printing density
         if (!std::isinf(m_cin.header.Gamma()) && m_cin.header.Gamma() != 0.0f)
             // actual gamma value is read later on
-            m_spec.attribute("oiio:ColorSpace",
-                             Strutil::fmt::format("Gamma{:.2g}", g));
+            set_colorspace_rec709_gamma(m_spec, float(m_cin.header.Gamma()));
         break;
     }
 
     // gamma exponent
     if (!std::isinf(m_cin.header.Gamma()) && m_cin.header.Gamma() != 0.0f)
-        m_spec.attribute("oiio:Gamma", (float)m_cin.header.Gamma());
+        set_colorspace_rec709_gamma(m_spec, float(m_cin.header.Gamma()));
 #endif
 
     // general metadata

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -845,7 +845,7 @@ DDSInput::seek_subimage(int subimage, int miplevel)
     // linear color space for HDR-ish images
     if (colorspace == nullptr
         && (basetype == TypeDesc::HALF || basetype == TypeDesc::FLOAT))
-        colorspace = "linear";
+        colorspace = "lin_rec709";
 
     m_spec.set_colorspace(colorspace);
 

--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -285,6 +285,12 @@ just exist in the OIIO namespace as general utilities. (See
 
 .. doxygenfunction:: get_extension_map
 
+.. doxygenfunction:: OIIO::set_colorspace
+
+.. doxygenfunction:: OIIO::set_colorspace_rec709_gamma
+
+.. doxygenfunction:: OIIO::equivalent_colorspace
+
 |
 
  .. _sec-startupshutdown:

--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -888,12 +888,12 @@ color space:
    .. code-tab:: c++
 
       ImageSpec spec (width, length, channels, format);
-      spec.attribute ("oiio:ColorSpace", "scene_linear");
+      spec.set_colorspace("scene_linear");
 
    .. code-tab:: py
 
       spec = ImageSpec(width, length, channels, format)
-      spec.attribute ("oiio:ColorSpace", "scene_linear")
+      spec.set_colorspace("scene_linear")
 
 If a particular ``ImageOutput`` implementation is required (by the rules of
 the file format it writes) to have pixels in a fixed color space,

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -732,7 +732,6 @@ Section :ref:`sec-ImageSpec`, is replicated for Python.
         spec.set_colorspace ("sRGB")
 
 
-
 .. py:method:: ImageSpec.undefined ()
 
     Returns `True` for a newly initialized (undefined) ImageSpec.
@@ -3883,6 +3882,53 @@ details.
     .. code-block:: python
 
         formats = oiio.get_string_attribute ("format_list")
+
+
+.. py:method:: set_colorspace (spec, name)
+
+    Set the metadata of the `spec` to presume that color space is `name` (or
+    to assume nothing about the color space if `name` is empty).
+
+    Example:
+
+    .. code-block:: python
+
+        spec = oiio.ImageSpec()
+        oiio.set_colorspace (spec, "lin_rec709")
+
+    This function was added in OpenImageIO 3.0.
+
+
+.. py:method:: set_colorspace_rec709_gamma (spec, name)
+
+    Set the metadata of the `spec` to reflect Rec709 color primaries and the
+    given gamma.
+
+    Example:
+
+    .. code-block:: python
+
+        spec = oiio.ImageSpec()
+        oiio.set_colorspace_rec709_gamma (spec, 2.2)
+
+    This function was added in OpenImageIO 3.0.
+
+
+.. py:method:: equivalent_colorspace (a, b)
+
+    Return `True` if the color spaces `a` and `b` are equivalent in the
+    default active color config.
+
+    Example:
+
+    .. code-block:: python
+
+        # ib is an ImageBuf
+        cs = ib.spec().get_string_attribute("oiio:ColorSpace")
+        if oiio.equivalent_colorspace(cs, "sRGB") :
+            print ("The image is sRGB")
+
+    This function was added in OpenImageIO 3.0.
 
 
 .. py:method:: is_imageio_format_name (name)

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -143,18 +143,19 @@ Color information
     
     - `"scene_linear"` :  Color pixel values are known to be scene-linear and
       using facility-default color primaries as defined by the OpenColorIO
-      configuration. Note that `"linear"` is treated as a synonym. (Note: when
-      no color config is found, this are presumed to use sRGB/Rec709 color
-      primaries when built against OpenColorIO 2.1 or earlier, or when no OCIO
-      support is available, but is presumed to be ACEScg when built against
-      OCIO 2.2 or higher and using its built-in config.)
-    - `"lin_srgb"` :  Color pixel values are known to be linear and
-      using sRGB/Rec709 color primaries.
+      configuration.
+    - `"lin_srgb"`, `"lin_rec709"` :  Color pixel values are known to be
+      linear and using sRGB/Rec709 color primaries. Note that `"linear"` is
+      treated as a synonym.
     - `"sRGB"` :  Using standard sRGB response and primaries.
     - `"Rec709"` :  Using standard Rec709 response and primaries.
     - `"ACEScg"` :  ACEScg color space encoding.
     - `"AdobeRGB"` :  Adobe RGB color space.
     - `"KodakLog"` :  Kodak logarithmic color space.
+    - `"g22_rec709"` : Rec709/sRGB primaries, but using a response curve
+      corresponding to gamma 2.2.
+    - `"g18_rec709"` : Rec709/sRGB primaries, but using a response curve
+      corresponding to gamma 1.8.
     - `"GammaX.Y"` :  Color values have been gamma corrected
       (raised to the power :math:`1/\gamma`). The `X.Y` is the numeric value
       of the gamma exponent.
@@ -230,7 +231,7 @@ Disk file format info/hints
     `piz`, `pxr24`, `b44`, `b44a`, `dwaa`, or `dwab`.
 
     he compression name is permitted to have a quality value to be appended
-    fter a colon, for example `dwaa:60`.  The exact meaning and range of
+    after a colon, for example `dwaa:60`.  The exact meaning and range of
     he quality value can vary between different file formats and compression
     odes, and some don't support quality values at all (it will be ignored if
     ot supported, or if out of range).

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -312,17 +312,12 @@ DPXInput::seek_subimage(int subimage, int miplevel)
 
     // image linearity
     switch (m_dpx.header.Transfer(subimage)) {
-    case dpx::kLinear: m_spec.attribute("oiio:ColorSpace", "Linear"); break;
-    case dpx::kLogarithmic:
-        m_spec.attribute("oiio:ColorSpace", "KodakLog");
-        break;
-    case dpx::kITUR709: m_spec.attribute("oiio:ColorSpace", "Rec709"); break;
+    case dpx::kLinear: m_spec.set_colorspace("Linear"); break;
+    case dpx::kLogarithmic: m_spec.set_colorspace("KodakLog"); break;
+    case dpx::kITUR709: m_spec.set_colorspace("Rec709"); break;
     case dpx::kUserDefined:
         if (!std::isnan(m_dpx.header.Gamma()) && m_dpx.header.Gamma() != 0) {
-            float g = float(m_dpx.header.Gamma());
-            m_spec.attribute("oiio:ColorSpace",
-                             Strutil::fmt::format("Gamma{:.2}", g));
-            m_spec.attribute("oiio:Gamma", g);
+            set_colorspace_rec709_gamma(m_spec, float(m_dpx.header.Gamma()));
             break;
         }
         // intentional fall-through

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -259,7 +259,7 @@ GIFInput::read_subimage_metadata(ImageSpec& newspec)
     newspec.nchannels = 4;
     newspec.default_channel_names();
     newspec.alpha_channel = 4;
-    newspec.attribute("oiio:ColorSpace", "sRGB");
+    newspec.set_colorspace("sRGB");
 
     m_previous_disposal_method = m_disposal_method;
     m_disposal_method          = DISPOSAL_UNSPECIFIED;

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -291,7 +291,7 @@ HdrInput::RGBE_ReadHeader()
     if (!line.size())
         return false;
 
-    m_spec.attribute("oiio:ColorSpace", "lin_srgb");
+    m_spec.set_colorspace("lin_rec709");
     // presume linear w/ srgb primaries -- seems like the safest assumption
     // for this old file format.
 
@@ -310,13 +310,7 @@ HdrInput::RGBE_ReadHeader()
             // 2.2, not 2.19998.
             float g = float(1.0 / tempf);
             g       = roundf(100.0 * g) / 100.0f;
-            m_spec.attribute("oiio:Gamma", g);
-            if (g == 1.0f)
-                m_spec.attribute("oiio:ColorSpace", "linear");
-            else
-                m_spec.attribute("oiio:ColorSpace",
-                                 Strutil::fmt::format("Gamma{:.2g}", g));
-
+            set_colorspace_rec709_gamma(m_spec, g);
         } else if (Strutil::parse_values(line,
                                          "EXPOSURE=", span<float>(tempf))) {
             m_spec.attribute("hdr:exposure", tempf);

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -243,7 +243,7 @@ HeifInput::seek_subimage(int subimage, int miplevel)
                          m_himage.get_height(heif_channel_interleaved), bits / 8,
                          TypeUInt8);
 
-    m_spec.attribute("oiio:ColorSpace", "sRGB");
+    m_spec.set_colorspace("sRGB");
 
 #if LIBHEIF_HAVE_VERSION(1, 12, 0)
     // Libheif >= 1.12 added API call to find out if the image is associated

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -224,7 +224,7 @@ adjust_spec(ImageInput* in, ImageOutput* out, const ImageSpec& inspec,
 
     outspec.attribute("oiio:Gamma", gammaval);
     if (sRGB) {
-        outspec.attribute("oiio:ColorSpace", "sRGB");
+        outspec.set_colorspace("sRGB");
         if (!strcmp(in->format_name(), "jpeg")
             || outspec.find_attribute("Exif:ColorSpace"))
             outspec.attribute("Exif:ColorSpace", 1);

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -371,6 +371,23 @@ public:
     /// Return a filename or other identifier for the config we're using.
     std::string configname() const;
 
+    /// Set the spec's metadata to presume that color space is `name` (or to
+    /// assume nothing about the color space if `name` is empty). The core
+    /// operation is to set the "oiio:ColorSpace" attribute, but it also removes
+    /// or alters several other attributes that may hint color space in ways that
+    /// might be contradictory or no longer true.
+    ///
+    /// @version 3.0
+    void set_colorspace(ImageSpec& spec, string_view name) const;
+
+    /// Set the spec's metadata to reflect Rec709 color primaries and the given
+    /// gamma. The core operation is to set the "oiio:ColorSpace" attribute, but
+    /// it also removes or alters several other attributes that may hint color
+    /// space in ways that might be contradictory or no longer true.
+    ///
+    /// @version 3.0
+    void set_colorspace_rec709_gamma(ImageSpec& spec, float gamma) const;
+
     /// Return if OpenImageIO was built with OCIO support
     static bool supportsOpenColorIO();
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1817,12 +1817,9 @@ bool OIIO_API erode (ImageBuf &dst, const ImageBuf &src,
 /// transformed, and the fourth channel (if it exists) is presumed to be
 /// alpha. Any additional channels will be simply copied unaltered.
 ///
-/// If OIIO was built with OpenColorIO support enabled, then the
-/// transformation may be between any two spaces supported by the active
+/// The transformation may be between any two spaces supported by the active
 /// OCIO configuration, or may be a "look" transformation created by
-/// `ColorConfig::createLookTransform`.  If OIIO was not built with
-/// OpenColorIO support enabled, then the only transformations available are
-/// from "sRGB" to "linear" and vice versa.
+/// `ColorConfig::createLookTransform`.
 ///
 /// @param  fromspace/tospace
 ///             For the varieties of `colorconvert()` that use named color
@@ -1927,7 +1924,8 @@ bool OIIO_API colormatrixtransform (ImageBuf &dst, const ImageBuf &src,
 ///             The looks to apply (comma-separated).
 /// @param  fromspace/tospace
 ///             For the varieties of `colorconvert()` that use named color
-///             spaces, these specify the color spaces by name.
+///             spaces, these specify the color spaces by name.  If either
+///             is the empty string, it will use `"scene_linear"`.
 /// @param  unpremult
 ///             If true, unpremultiply the image (divide the RGB channels by
 ///             alpha if it exists and is nonzero) before color conversion,
@@ -1979,7 +1977,7 @@ bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src, string_view looks,
 ///             If `fromspace` is not supplied, it will assume that the
 ///             source color space is whatever is indicated by the source
 ///             image's metadata or filename, and if that cannot be deduced,
-///             it will be assumed to be scene linear.
+///             it will be assumed to be `"scene_linear"`.
 /// @param  looks
 ///             The looks to apply (comma-separated). This may be empty,
 ///             in which case no "look" is used. Note: this parameter value

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3254,6 +3254,33 @@ inline string_view get_string_attribute (string_view name,
 }
 
 
+/// Set the metadata of the `spec` to presume that color space is `name` (or
+/// to assume nothing about the color space if `name` is empty). The core
+/// operation is to set the "oiio:ColorSpace" attribute, but it also removes
+/// or alters several other attributes that may hint color space in ways that
+/// might be contradictory or no longer true. This uses the current default
+/// color config to adjudicate color space name equivalencies.
+///
+/// @version 3.0
+OIIO_API void set_colorspace(ImageSpec& spec, string_view name);
+
+/// Set the metadata of the `spec` to reflect Rec709 color primaries and the
+/// given gamma. The core operation is to set the "oiio:ColorSpace" attribute,
+/// but it also removes or alters several other attributes that may hint color
+/// space in ways that might be contradictory or no longer true. This uses the
+/// current default color config to adjudicate color space name equivalencies.
+///
+/// @version 3.0
+OIIO_API void set_colorspace_rec709_gamma(ImageSpec& spec, float gamma);
+
+
+/// Are the two named color spaces equivalent, based on the default color
+/// config in effect?
+///
+/// @version 3.0
+OIIO_API bool equivalent_colorspace(string_view a, string_view b);
+
+
 /// Register the input and output 'create' routines and list of file
 /// extensions for a particular format.
 OIIO_API void declare_imageio_format (const std::string &format_name,

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -257,7 +257,7 @@ JpgInput::open(const std::string& name, ImageSpec& newspec)
         return false;
 
     // Assume JPEG is in sRGB unless the Exif or XMP tags say otherwise.
-    m_spec.attribute("oiio:ColorSpace", "sRGB");
+    m_spec.set_colorspace("sRGB");
 
     if (m_cinfo.jpeg_color_space == JCS_CMYK)
         m_spec.attribute("jpeg:ColorSpace", "CMYK");

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -229,7 +229,8 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
                           comment.size() + 1);
     }
 
-    if (Strutil::iequals(m_spec.get_string_attribute("oiio:ColorSpace"), "sRGB"))
+    if (equivalent_colorspace(m_spec.get_string_attribute("oiio:ColorSpace"),
+                              "sRGB"))
         m_spec.attribute("Exif:ColorSpace", 1);
 
     // Write EXIF info

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -330,7 +330,7 @@ Jpeg2000Input::open(const std::string& name, ImageSpec& p_spec)
     m_spec.full_height = m_image->y1;
 
     m_spec.attribute("oiio:BitsPerSample", maxPrecision);
-    m_spec.attribute("oiio:ColorSpace", "sRGB");
+    m_spec.set_colorspace("sRGB");
 
     if (m_image->icc_profile_len && m_image->icc_profile_buf) {
         m_spec.attribute("ICCProfile",

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -1216,7 +1216,7 @@ decode_exif(cspan<uint8_t> exif, ImageSpec& spec)
         // Exif spec says that anything other than 0xffff==uncalibrated
         // should be interpreted to be sRGB.
         if (cs != 0xffff)
-            spec.attribute("oiio:ColorSpace", "sRGB");
+            spec.set_colorspace("sRGB");
     }
 
     // Look for a maker note offset, now that we have seen all the metadata

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -9,6 +9,7 @@
 
 #include <OpenImageIO/half.h>
 
+#include <OpenImageIO/color.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagebuf.h>
@@ -1229,25 +1230,7 @@ pvt::check_texture_metadata_sanity(ImageSpec& spec)
 void
 ImageSpec::set_colorspace(string_view colorspace)
 {
-    // If we're not changing color space, don't mess with anything
-    string_view oldspace = get_string_attribute("oiio:ColorSpace");
-    if (oldspace.size() && colorspace.size() && oldspace == colorspace)
-        return;
-
-    // Set or clear the main "oiio:ColorSpace" attribute
-    if (colorspace.empty()) {
-        erase_attribute("oiio:ColorSpace");
-    } else {
-        attribute("oiio:ColorSpace", colorspace);
-    }
-
-    // Clear a bunch of other metadata that might contradict the colorspace,
-    // including some format-specific things that we don't want to propagate
-    // from input to output if we know that color space transformations have
-    // occurred.
-    erase_attribute("Exif:ColorSpace");
-    erase_attribute("tiff:ColorSpace");
-    erase_attribute("tiff:PhotometricInterpretation");
+    ColorConfig::default_colorconfig().set_colorspace(*this, colorspace);
 }
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5195,7 +5195,7 @@ input_file(Oiiotool& ot, cspan<const char*> argv)
                     print("  Metadata of {} indicates color space \"{}\"\n",
                           colorspace, filename);
             }
-            std::string linearspace = ot.colorconfig().resolve("linear");
+            std::string linearspace = ot.colorconfig().resolve("scene_linear");
             if (colorspace.size()
                 && !ot.colorconfig().equivalent(colorspace, linearspace)) {
                 std::string cmd = "colorconvert:strict=0";
@@ -5504,7 +5504,7 @@ output_file(Oiiotool& ot, cspan<const char*> argv)
         }
     }
     if (autocc) {
-        string_view linearspace = ot.colorconfig().resolve("linear");
+        string_view linearspace = ot.colorconfig().resolve("scene_linear");
         std::string currentspace
             = ir->spec()->get_string_attribute("oiio:ColorSpace", linearspace);
         // Special cases where we know formats should be particular color
@@ -6008,12 +6008,16 @@ print_ocio_info(Oiiotool& ot, std::ostream& out)
         out << "No OpenColorIO";
     out << "\nColor config: " << colorconfig.configname() << "\n";
     out << "Known color spaces: \n";
-    const char* linear = colorconfig.getColorSpaceNameByRole("linear");
+    const char* linear       = colorconfig.getColorSpaceNameByRole("linear");
+    const char* scene_linear = colorconfig.getColorSpaceNameByRole(
+        "scene_linear");
     for (int i = 0, e = colorconfig.getNumColorSpaces(); i < e; ++i) {
         const char* n = colorconfig.getColorSpaceNameByIndex(i);
         out << "    - " << quote_if_spaces(n);
-        if ((linear && !colorconfig.equivalent(n, "linear")
-             && colorconfig.equivalent(n, linear))
+        if ((scene_linear && !colorconfig.equivalent(n, "scene_linear")
+             && colorconfig.equivalent(n, scene_linear))
+            || (linear && !colorconfig.equivalent(n, "linear")
+                && colorconfig.equivalent(n, linear))
             || colorconfig.isColorSpaceLinear(n))
             out << " (linear)";
         out << "\n";

--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -44,20 +44,17 @@ static bool exrdebug = Strutil::stoi(Sysutil::getenv("OIIO_DEBUG_OPENEXR"))
 #endif
 
 
+namespace pvt {
+
 // Split a full channel name into layer and suffix.
-inline void
-split_name(string_view fullname, string_view& layer, string_view& suffix)
-{
-    size_t dot = fullname.find_last_of('.');
-    if (dot == string_view::npos) {
-        suffix = fullname;
-        layer  = string_view();
-    } else {
-        layer  = string_view(fullname.data(), dot + 1);
-        suffix = string_view(fullname.data() + dot + 1,
-                             fullname.size() - dot - 1);
-    }
-}
+void
+split_name(string_view fullname, string_view& layer, string_view& suffix);
+
+// Do the channels appear to be R, G, B (or known common aliases)?
+bool
+channels_are_rgb(const ImageSpec& spec);
+
+}  // namespace pvt
 
 
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -337,7 +337,7 @@ PNMInput::read_file_header()
         m_spec.attribute("pnm:bigendian", m_scaling_factor < 0 ? 0 : 1);
         m_spec.attribute("pnm:binary", 1);
     }
-    m_spec.attribute("oiio:ColorSpace", "Rec709");
+    m_spec.set_colorspace("Rec709");
     return true;
 }
 

--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -136,7 +136,10 @@ declare_colorconfig(py::module& m)
                 return self.equivalent(color_space, other_color_space);
             },
             "color_space"_a, "other_color_space"_a)
-        .def("configname", &ColorConfig::configname);
+        .def("configname", &ColorConfig::configname)
+        .def_static("default_colorconfig", []() -> const ColorConfig& {
+            return ColorConfig::default_colorconfig();
+        });
 
     m.attr("supportsOpenColorIO")     = ColorConfig::supportsOpenColorIO();
     m.attr("OpenColorIO_version_hex") = ColorConfig::OpenColorIO_version_hex();

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -338,6 +338,19 @@ OIIO_DECLARE_PYMODULE(PYMODULE_NAME)
         py::arg("name"), py::arg("defaultval") = "");
     m.def("getattribute", &oiio_getattribute_typed);
     m.def(
+        "set_colorspace",
+        [](ImageSpec& spec, const std::string& name) {
+            set_colorspace(spec, name);
+        },
+        py::arg("spec"), py::arg("name"));
+    m.def("set_colorspace_rec709_gamma", [](ImageSpec& spec, float gamma) {
+        set_colorspace_rec709_gamma(spec, gamma);
+    });
+    m.def("equivalent_colorspace",
+          [](const std::string& a, const std::string& b) {
+              return equivalent_colorspace(a, b);
+          });
+    m.def(
         "is_imageio_format_name",
         [](const std::string& name) {
             return OIIO::is_imageio_format_name(name);

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -570,11 +570,14 @@ RawInput::open_raw(bool unpack, const std::string& name,
         m_processor->imgdata.params.gamm[0]      = 1.0 / 2.4;
         m_processor->imgdata.params.gamm[1]      = 12.92;
     } else if (Strutil::iequals(cs, "sRGB-linear")
+               || Strutil::iequals(cs, "lin_srgb")
+               || Strutil::iequals(cs, "lin_rec709")
                || Strutil::iequals(cs, "linear") /* DEPRECATED */) {
         // Request "sRGB" primaries, linear response
         m_processor->imgdata.params.output_color = 1;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
+        cs                                       = "lin_rec709";
     } else if (Strutil::iequals(cs, "Adobe")) {
         // Request Adobe color space with 2.2 gamma (no linear toe)
         m_processor->imgdata.params.output_color = 2;
@@ -613,7 +616,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
 #endif
     } else if (Strutil::iequals(cs, "Rec2020")) {
 #if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
-        // ACES linear
+        // Rec2020
         m_processor->imgdata.params.output_color = 8;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
@@ -626,7 +629,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
         errorfmt("raw:ColorSpace set to unknown value \"{}\"", cs);
         return false;
     }
-    m_spec.attribute("oiio:ColorSpace", cs);
+    m_spec.set_colorspace(cs);
 
     // Exposure adjustment
     float exposure = config.get_float_attribute("raw:Exposure", -1.0f);

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -402,13 +402,7 @@ RLAInput::seek_subimage(int subimage, int miplevel)
         // decisions based on known gamma values. For example, you want
         // 2.2, not 2.19998.
         gamma = roundf(100.0 * gamma) / 100.0f;
-        if (gamma == 1.f)
-            m_spec.attribute("oiio:ColorSpace", "Linear");
-        else {
-            m_spec.attribute("oiio:ColorSpace",
-                             Strutil::fmt::format("Gamma{:.2g}", gamma));
-            m_spec.attribute("oiio:Gamma", gamma);
-        }
+        set_colorspace_rec709_gamma(m_spec, gamma);
     }
 
     float aspect = Strutil::stof(m_rla.AspectRatio);

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -440,14 +440,7 @@ TGAInput::read_tga2_header()
             // decisions based on known gamma values. For example, you want
             // 2.2, not 2.19998.
             gamma = roundf(100.0 * gamma) / 100.0f;
-            if (gamma == 1.f) {
-                m_spec.attribute("oiio:ColorSpace", "lin_srgb");
-                // Presume that Targa files are sRGB primaries
-            } else {
-                m_spec.attribute("oiio:ColorSpace",
-                                 Strutil::fmt::format("Gamma{:.2g}", gamma));
-                m_spec.attribute("oiio:Gamma", gamma);
-            }
+            set_colorspace_rec709_gamma(m_spec, gamma);
         }
 
         // offset to colour correction table
@@ -531,7 +524,7 @@ TGAInput::get_thumbnail(ImageBuf& thumb, int subimage)
         // the thumbnail is in the same format as the main image but
         // uncompressed.
         ImageSpec thumbspec(res[0], res[1], m_spec.nchannels, TypeUInt8);
-        thumbspec.attribute("oiio:ColorSpace", "sRGB");
+        thumbspec.set_colorspace("sRGB");
         thumb.reset(thumbspec);
         int bytespp    = (m_tga.bpp == 15) ? 2 : (m_tga.bpp / 8);
         int palbytespp = (m_tga.cmap_size == 15) ? 2 : (m_tga.cmap_size / 8);

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1254,6 +1254,9 @@ TIFFInput::readspec(bool read_meta)
             // should be interpreted to be sRGB.
             if (m_spec.get_int_attribute("Exif:ColorSpace") != 0xffff)
                 m_spec.attribute("oiio:ColorSpace", "sRGB");
+            // NOTE: We must set "oiio:ColorSpace" explicitly, not call
+            // set_colorspace, or it will erase several other TIFF attribs we
+            // need to preserve.
         }
         // TIFFReadEXIFDirectory seems to do something to the internal state
         // that requires a TIFFSetDirectory to set things straight again.

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -873,7 +873,8 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
             TIFFSetField(m_tif, TIFFTAG_ICCPROFILE, length, icc_profile);
     }
 
-    if (Strutil::iequals(m_spec.get_string_attribute("oiio:ColorSpace"), "sRGB"))
+    if (equivalent_colorspace(m_spec.get_string_attribute("oiio:ColorSpace"),
+                              "sRGB"))
         m_spec.attribute("Exif:ColorSpace", 1);
 
     // Deal with missing XResolution or YResolution, or a PixelAspectRatio

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -161,7 +161,7 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
 
     m_spec = ImageSpec(w, h, (m_demux_flags & ALPHA_FLAG) ? 4 : 3, TypeUInt8);
     m_scanline_size = m_spec.scanline_bytes();
-    m_spec.attribute("oiio:ColorSpace", "sRGB");  // webp is always sRGB
+    m_spec.set_colorspace("sRGB");  // webp is always sRGB
     if (m_demux_flags & ANIMATION_FLAG) {
         m_spec.attribute("oiio:Movie", 1);
         m_frame_count       = (int)WebPDemuxGetI(m_demux, WEBP_FF_FRAME_COUNT);

--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -41,14 +41,14 @@ Reading ../oiio-images/dds/dds_bc6hu.dds
     channel list: R, G, B
     compression: "BC6HU"
     textureformat: "Plain Texture"
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
 Reading ../oiio-images/dds/dds_bc6hu_hdr.dds
 ../oiio-images/dds/dds_bc6hu_hdr.dds :  128 x   64, 3 channel, half dds
     SHA-1: 86FE86288649F5375DB51CDF19C91C3651992726
     channel list: R, G, B
     compression: "BC6HU"
     textureformat: "Plain Texture"
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
 Reading ../oiio-images/dds/dds_bc7.dds
 ../oiio-images/dds/dds_bc7.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 18D1977AD74C3C19E5B30459D212EBC8C7F8BC54

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -6,7 +6,7 @@ out.exr              :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading out2.exr
 out2.exr             :   64 x   64, 6 channel, half openexr
@@ -17,7 +17,7 @@ out2.exr             :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "Aimg"
     oiio:subimages: 1
     openexr:chunkCount: 4

--- a/testsuite/hdr/ref/out.txt
+++ b/testsuite/hdr/ref/out.txt
@@ -2,7 +2,7 @@ Reading MtTamWest.hdr
 MtTamWest.hdr        : 1214 x  732, 3 channel, float hdr
     channel list: R, G, B
     Orientation: 1 (normal)
-    oiio:ColorSpace: "lin_srgb"
+    oiio:ColorSpace: "lin_rec709"
     Stats Min: 0.000183 0.000240 0.000000 (float)
     Stats Max: 3.875000 3.875000 4.875000 (float)
     Stats Avg: 0.220837 0.352995 0.493945 (float)

--- a/testsuite/iinfo/ref/out-fmt6.txt
+++ b/testsuite/iinfo/ref/out-fmt6.txt
@@ -146,7 +146,7 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-src/tiny-az.exr :     oiio:ColorSpace: "Linear"
+src/tiny-az.exr :     oiio:ColorSpace: "lin_rec709"
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
     Stats Max: 0.250000 0.500000 0.750000 (float)
@@ -173,7 +173,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000
     Pixel (3, 2): 0.250000000 0.500000000 0.750000000
@@ -212,7 +212,6 @@ src/tinydeep.exr :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 4
     Stats Min: 1.000000 10.000000 (float)
@@ -247,7 +246,6 @@ src/tinydeep.exr     :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 4
     Pixel (0, 0): 0 samples 

--- a/testsuite/iinfo/ref/out.txt
+++ b/testsuite/iinfo/ref/out.txt
@@ -146,7 +146,7 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-src/tiny-az.exr :     oiio:ColorSpace: "Linear"
+src/tiny-az.exr :     oiio:ColorSpace: "lin_rec709"
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
     Stats Max: 0.250000 0.500000 0.750000 (float)
@@ -173,7 +173,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000
     Pixel (3, 2): 0.250000000 0.500000000 0.750000000
@@ -212,7 +212,6 @@ src/tinydeep.exr :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 4
     Stats Min: 1.000000 10.000000 (float)
@@ -247,7 +246,6 @@ src/tinydeep.exr     :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 4
     Pixel (0, 0): 0 samples 

--- a/testsuite/maketx/ref/out-macarm.txt
+++ b/testsuite/maketx/ref/out-macarm.txt
@@ -315,7 +315,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -343,7 +343,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -435,7 +435,6 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -456,7 +455,6 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -488,7 +486,6 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -315,7 +315,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -343,7 +343,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -435,7 +435,6 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -456,7 +455,6 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -488,7 +486,6 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -68,7 +68,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -81,7 +81,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -96,7 +96,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -108,7 +108,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -68,7 +68,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -81,7 +81,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -96,7 +96,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -108,7 +108,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -13,7 +13,7 @@ allhalf.exr          :   38 x   38, 5 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading rgbahalf-zfloat.exr
 rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
@@ -26,7 +26,7 @@ rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 explicit -d uint save result: 
 uint8.tif            :  128 x  128, 3 channel, uint8 tiff
@@ -66,7 +66,7 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading green.exr
 green.exr            :   64 x   64, 3 channel, half openexr
@@ -76,7 +76,7 @@ green.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading greenmeta.exr
 greenmeta.exr        :   64 x   64, 3 channel, half openexr
@@ -89,7 +89,7 @@ greenmeta.exr        :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     weight: 20.5
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading nometamerge.exr
 nometamerge.exr      :   64 x   64, 6 channel, float openexr
@@ -100,7 +100,7 @@ nometamerge.exr      :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading metamerge.exr
 metamerge.exr        :   64 x   64, 6 channel, float openexr
@@ -112,7 +112,7 @@ metamerge.exr        :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Testing -o with no image
 oiiotool WARNING: -o : out.tif did not have any current image to output.

--- a/testsuite/oiiotool-deep/ref/out-fmt6.txt
+++ b/testsuite/oiiotool-deep/ref/out-fmt6.txt
@@ -12,7 +12,6 @@ allhalf.exr          :  160 x  120, 2 channel, deep half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 6
     Stats Min: 0.011902 3.031250 (float)
@@ -56,7 +55,6 @@ swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 6
     Stats Min: 0.011902 3.031250 (float)
@@ -95,7 +93,6 @@ tinydeep.exr         :    4 x    4, 2 channel, deep float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     version: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 4
     Pixel (0, 0): 0 samples 

--- a/testsuite/oiiotool-deep/ref/out.txt
+++ b/testsuite/oiiotool-deep/ref/out.txt
@@ -12,7 +12,6 @@ allhalf.exr          :  160 x  120, 2 channel, deep half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 6
     Stats Min: 0.011902 3.031250 (float)
@@ -56,7 +55,6 @@ swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 6
     Stats Min: 0.011902 3.031250 (float)
@@ -95,7 +93,6 @@ tinydeep.exr         :    4 x    4, 2 channel, deep float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     version: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
     openexr:chunkCount: 4
     Pixel (0, 0): 0 samples 

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -9,7 +9,7 @@ src/bad.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
@@ -28,7 +28,7 @@ black.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
@@ -47,7 +47,7 @@ box3.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/oiiotool-maketx/ref/out-macarm.txt
+++ b/testsuite/oiiotool-maketx/ref/out-macarm.txt
@@ -277,7 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -306,7 +306,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
@@ -349,7 +349,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -598,7 +598,6 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -277,7 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -305,7 +305,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     openexr:roundingmode: 0
 Reading grid.tx
@@ -553,7 +553,6 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out-win.txt
+++ b/testsuite/oiiotool-maketx/ref/out-win.txt
@@ -277,7 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -306,7 +306,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
@@ -349,7 +349,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -598,7 +598,6 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -277,7 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -306,7 +306,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
@@ -349,7 +349,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -598,7 +598,6 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-subimage/ref/out.txt
+++ b/testsuite/oiiotool-subimage/ref/out.txt
@@ -10,7 +10,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerA"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -23,7 +23,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerB"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -36,7 +36,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerC"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -49,7 +49,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerD"
     oiio:subimages: 4
     openexr:chunkCount: 4

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -40,7 +40,7 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 dumpdata:
 dump.exr             :    2 x    2, 3 channel, half openexr

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -7,7 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/Chromaticities/Rec709.exr" and "Rec709.exr"
 PASS
@@ -21,7 +21,7 @@ Reading ../openexr-images/Chromaticities/XYZ.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/Chromaticities/XYZ.exr" and "XYZ.exr"
 PASS
@@ -35,7 +35,6 @@ Reading ../openexr-images/LuminanceChroma/Garden.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
 Comparing "../openexr-images/LuminanceChroma/Garden.exr" and "Garden.exr"
 PASS

--- a/testsuite/openexr-decreasingy/ref/out.txt
+++ b/testsuite/openexr-decreasingy/ref/out.txt
@@ -9,7 +9,7 @@ increasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading increasingY-copy.exr
 increasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
@@ -22,7 +22,7 @@ increasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading decreasingY-resize.exr
 decreasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
@@ -35,7 +35,7 @@ decreasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Reading decreasingY-copy.exr
 decreasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
@@ -48,7 +48,7 @@ decreasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "increasingY-copy.exr" and "decreasingY-copy.exr"
 PASS

--- a/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
@@ -7,7 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/Rec709_YC.exr" and "Rec709_YC.exr"
@@ -22,7 +22,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/XYZ_YC.exr" and "XYZ_YC.exr"
@@ -37,7 +37,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/CrissyField.exr" and "CrissyField.exr"
@@ -51,7 +51,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/Flowers.exr" and "Flowers.exr"
@@ -65,7 +65,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/MtTamNorth.exr" and "MtTamNorth.exr"
@@ -79,7 +79,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/StarField.exr" and "StarField.exr"

--- a/testsuite/openexr-luminance-chroma/ref/out.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out.txt
@@ -7,7 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/Rec709_YC.exr" and "Rec709_YC.exr"
@@ -22,7 +22,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/XYZ_YC.exr" and "XYZ_YC.exr"
@@ -37,7 +37,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/CrissyField.exr" and "CrissyField.exr"
@@ -51,7 +51,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/Flowers.exr" and "Flowers.exr"
@@ -65,7 +65,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/MtTamNorth.exr" and "MtTamNorth.exr"
@@ -79,7 +79,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/StarField.exr" and "StarField.exr"

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -12,7 +12,7 @@ Reading ../openexr-images/MultiResolution/Bonita.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/Bonita.exr" and "Bonita.exr"
@@ -31,7 +31,7 @@ Reading ../openexr-images/MultiResolution/ColorCodedLevels.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/ColorCodedLevels.exr" and "ColorCodedLevels.exr"
@@ -50,7 +50,7 @@ Reading ../openexr-images/MultiResolution/KernerEnvCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -68,7 +68,7 @@ Reading ../openexr-images/MultiResolution/KernerEnvLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -88,7 +88,7 @@ Reading ../openexr-images/MultiResolution/MirrorPattern.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "mirror,mirror"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/MirrorPattern.exr" and "MirrorPattern.exr"
@@ -107,7 +107,7 @@ Reading ../openexr-images/MultiResolution/OrientationCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -125,7 +125,7 @@ Reading ../openexr-images/MultiResolution/OrientationLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -145,7 +145,7 @@ Reading ../openexr-images/MultiResolution/PeriodicPattern.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/PeriodicPattern.exr" and "PeriodicPattern.exr"
@@ -164,7 +164,7 @@ Reading ../openexr-images/MultiResolution/StageEnvCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -182,7 +182,7 @@ Reading ../openexr-images/MultiResolution/StageEnvLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -203,7 +203,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:roundingmode: 0
@@ -221,7 +221,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -237,7 +237,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesSphere.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"
 PASS
@@ -254,7 +254,7 @@ Reading ../openexr-images/MultiView/Adjuster.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/MultiView/Adjuster.exr" and "Adjuster.exr"
 PASS
@@ -270,7 +270,7 @@ Reading ../openexr-images/MultiView/Balls.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/MultiView/Balls.exr" and "Balls.exr"
 PASS
@@ -290,7 +290,6 @@ Reading ../openexr-images/MultiView/Fog.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
 Comparing "../openexr-images/MultiView/Fog.exr" and "Fog.exr"
 PASS
@@ -312,7 +311,7 @@ Reading ../openexr-images/MultiView/Impact.exr
     wrapmodes: "clamp,clamp"
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiView/Impact.exr" and "Impact.exr"
@@ -332,7 +331,7 @@ Reading ../openexr-images/MultiView/LosPadres.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/MultiView/LosPadres.exr" and "LosPadres.exr"
 PASS

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -14,7 +14,7 @@ Reading ../openexr-images/ScanLines/Blobbies.exr
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 50
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
 PASS
@@ -31,7 +31,7 @@ Reading ../openexr-images/ScanLines/CandleGlass.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/CandleGlass.exr" and "CandleGlass.exr"
 PASS
@@ -44,7 +44,7 @@ Reading ../openexr-images/ScanLines/Cannon.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
 PASS
@@ -56,7 +56,7 @@ Reading ../openexr-images/ScanLines/Desk.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/Desk.exr" and "Desk.exr"
 PASS
@@ -75,7 +75,7 @@ Reading ../openexr-images/ScanLines/MtTamWest.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     utcOffset: 25200
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/MtTamWest.exr" and "MtTamWest.exr"
 PASS
@@ -92,7 +92,7 @@ Reading ../openexr-images/ScanLines/PrismsLenses.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/PrismsLenses.exr" and "PrismsLenses.exr"
 PASS
@@ -107,7 +107,7 @@ Reading ../openexr-images/ScanLines/StillLife.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 0.45
     utcOffset: 25200
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/StillLife.exr" and "StillLife.exr"
 PASS
@@ -125,7 +125,7 @@ Reading ../openexr-images/ScanLines/Tree.exr
     screenWindowWidth: 0.48
     utcOffset: 25200
     whiteLuminance: 621
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/ScanLines/Tree.exr" and "Tree.exr"
 PASS
@@ -137,7 +137,7 @@ Reading ../openexr-images/TestImages/AllHalfValues.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/AllHalfValues.exr" and "AllHalfValues.exr"
 PASS
@@ -149,7 +149,7 @@ Reading ../openexr-images/TestImages/BrightRings.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/BrightRings.exr" and "BrightRings.exr"
 PASS
@@ -161,7 +161,7 @@ Reading ../openexr-images/TestImages/BrightRingsNanInf.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/BrightRingsNanInf.exr" and "BrightRingsNanInf.exr"
 PASS
@@ -173,7 +173,7 @@ Reading ../openexr-images/TestImages/GammaChart.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/GammaChart.exr" and "GammaChart.exr"
 PASS
@@ -185,7 +185,6 @@ Reading ../openexr-images/TestImages/GrayRampsDiagonal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/GrayRampsDiagonal.exr" and "GrayRampsDiagonal.exr"
 PASS
@@ -197,7 +196,6 @@ Reading ../openexr-images/TestImages/GrayRampsHorizontal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/GrayRampsHorizontal.exr" and "GrayRampsHorizontal.exr"
 PASS
@@ -209,7 +207,7 @@ Reading ../openexr-images/TestImages/RgbRampsDiagonal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/RgbRampsDiagonal.exr" and "RgbRampsDiagonal.exr"
 PASS
@@ -221,7 +219,7 @@ Reading ../openexr-images/TestImages/SquaresSwirls.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/SquaresSwirls.exr" and "SquaresSwirls.exr"
 PASS
@@ -234,7 +232,7 @@ Reading ../openexr-images/TestImages/WideColorGamut.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/WideColorGamut.exr" and "WideColorGamut.exr"
 PASS
@@ -246,7 +244,6 @@ Reading ../openexr-images/TestImages/WideFloatRange.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimages: 1
 Comparing "../openexr-images/TestImages/WideFloatRange.exr" and "WideFloatRange.exr"
 PASS
@@ -270,7 +267,7 @@ Reading ../openexr-images/Tiles/GoldenGate.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1.15
     utcOffset: 28800
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/Tiles/GoldenGate.exr" and "GoldenGate.exr"
 PASS
@@ -285,7 +282,7 @@ Reading ../openexr-images/Tiles/Ocean.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
 PASS
@@ -306,7 +303,7 @@ Reading ../openexr-images/Tiles/Spirals.exr
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 90
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
 PASS
@@ -323,7 +320,7 @@ Reading ../openexr-images/Beachball/singlepart.0001.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba"
     oiio:subimages: 1
 Comparing "../openexr-images/Beachball/singlepart.0001.exr" and "singlepart.0001.exr"

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -15,7 +15,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -32,7 +32,6 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth.left"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -49,7 +48,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -66,7 +65,6 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth.right"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -99,7 +97,7 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     screenWindowWidth: 1
     version: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 761
@@ -117,7 +115,7 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     screenWindowWidth: 1
     version: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 761
@@ -158,7 +156,7 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     screenWindowWidth: 1
     version: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 1080
@@ -173,7 +171,7 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     screenWindowWidth: 1
     version: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 1080
@@ -215,7 +213,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -231,7 +229,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -247,7 +244,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "forward_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -263,7 +259,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "whitebarmask_left"
     oiio:subimages: 10
     openexr:chunkCount: 769
@@ -279,7 +274,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -295,7 +290,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -311,7 +305,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "forward_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -326,7 +319,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "disparityL"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -341,7 +333,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "disparityR"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -357,7 +348,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "Linear"
     oiio:subimagename: "whitebarmask_right"
     oiio:subimages: 10
     openexr:chunkCount: 769

--- a/testsuite/openexr-window/ref/out.txt
+++ b/testsuite/openexr-window/ref/out.txt
@@ -6,7 +6,7 @@ Reading ../openexr-images/DisplayWindow/t01.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t01.exr" and "t01.exr"
 PASS
@@ -20,7 +20,7 @@ Reading ../openexr-images/DisplayWindow/t02.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t02.exr" and "t02.exr"
 PASS
@@ -34,7 +34,7 @@ Reading ../openexr-images/DisplayWindow/t03.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t03.exr" and "t03.exr"
 PASS
@@ -48,7 +48,7 @@ Reading ../openexr-images/DisplayWindow/t04.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t04.exr" and "t04.exr"
 PASS
@@ -62,7 +62,7 @@ Reading ../openexr-images/DisplayWindow/t05.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t05.exr" and "t05.exr"
 PASS
@@ -76,7 +76,7 @@ Reading ../openexr-images/DisplayWindow/t06.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t06.exr" and "t06.exr"
 PASS
@@ -90,7 +90,7 @@ Reading ../openexr-images/DisplayWindow/t07.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t07.exr" and "t07.exr"
 PASS
@@ -105,7 +105,7 @@ Reading ../openexr-images/DisplayWindow/t08.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t08.exr" and "t08.exr"
 PASS
@@ -119,7 +119,7 @@ Reading ../openexr-images/DisplayWindow/t09.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t09.exr" and "t09.exr"
 PASS
@@ -133,7 +133,7 @@ Reading ../openexr-images/DisplayWindow/t10.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t10.exr" and "t10.exr"
 PASS
@@ -147,7 +147,7 @@ Reading ../openexr-images/DisplayWindow/t11.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t11.exr" and "t11.exr"
 PASS
@@ -161,7 +161,7 @@ Reading ../openexr-images/DisplayWindow/t12.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t12.exr" and "t12.exr"
 PASS
@@ -175,7 +175,7 @@ Reading ../openexr-images/DisplayWindow/t13.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t13.exr" and "t13.exr"
 PASS
@@ -189,7 +189,7 @@ Reading ../openexr-images/DisplayWindow/t14.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t14.exr" and "t14.exr"
 PASS
@@ -203,7 +203,7 @@ Reading ../openexr-images/DisplayWindow/t15.exr
     PixelAspectRatio: 1.5
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t15.exr" and "t15.exr"
 PASS
@@ -217,7 +217,7 @@ Reading ../openexr-images/DisplayWindow/t16.exr
     PixelAspectRatio: 0.666667
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
 Comparing "../openexr-images/DisplayWindow/t16.exr" and "t16.exr"
 PASS

--- a/testsuite/python-colorconfig/ref/out-ocio23.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio23.txt
@@ -15,7 +15,7 @@ getNumRoles = 9
 getRoles = ['aces_interchange', 'cie_xyz_d65_interchange', 'color_picking', 'color_timing', 'compositing_log', 'data', 'matte_paint', 'scene_linear', 'texture_paint']
 aliases of 'scene_linear' are ['ACES - ACEScg', 'lin_ap1']
 resolve('foo'): foo
-resolve('linear'): ACEScg
+resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
 resolve('srgb'): sRGB - Texture

--- a/testsuite/python-colorconfig/ref/out-ocio24.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio24.txt
@@ -15,7 +15,7 @@ getNumRoles = 9
 getRoles = ['aces_interchange', 'cie_xyz_d65_interchange', 'color_picking', 'color_timing', 'compositing_log', 'data', 'matte_paint', 'scene_linear', 'texture_paint']
 aliases of 'scene_linear' are ['ACES - ACEScg', 'lin_ap1', 'lin_ap1_scene']
 resolve('foo'): foo
-resolve('linear'): ACEScg
+resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
 resolve('srgb'): sRGB Encoded Rec.709 (sRGB)

--- a/testsuite/python-colorconfig/ref/out.txt
+++ b/testsuite/python-colorconfig/ref/out.txt
@@ -15,7 +15,7 @@ getNumRoles = 9
 getRoles = ['aces_interchange', 'cie_xyz_d65_interchange', 'color_picking', 'color_timing', 'compositing_log', 'data', 'matte_paint', 'scene_linear', 'texture_paint']
 aliases of 'scene_linear' are ['ACES - ACEScg', 'lin_ap1']
 resolve('foo'): foo
-resolve('linear'): ACEScg
+resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
 resolve('srgb'): sRGB - Texture

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -62,7 +62,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     Software: "OpenImageIO 1.8.5dev : oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     timecodeRate: 24
     Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     smpte:TimeCode: 01:18:19:06
 Comparing "src/test.exr" and "test.exr"
@@ -76,5 +76,5 @@ rat2.exr             :   64 x   64, 3 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1

--- a/testsuite/raw/ref/out-libraw-0.20.2-gh.txt
+++ b/testsuite/raw/ref/out-libraw-0.20.2-gh.txt
@@ -52,7 +52,6 @@
     Canon:SpecularWhiteLevel: 12749
     Canon:SpotMeteringMode: 0 (center)
     Exif:ApertureValue: 2.97085 (f/2.8)
-    Exif:ColorSpace: 1
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2009:10:09 14:18:45"
     Exif:DateTimeOriginal: "2009:10:09 14:18:45"
@@ -77,7 +76,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 2076, 1024, 1584, 1024
     raw:cam_xyz: 0.6844, -0.0996, -0.0856, -0.3876, 1.1761, 0.2396, -0.0593, 0.1772, 0.6198, 0, 0, 0
@@ -167,7 +166,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -188,7 +187,6 @@
     Software: "Digital Camera FinePix F700  Ver2.00"
     Exif:ApertureValue: 3.69599 (f/3.6)
     Exif:BrightnessValue: 773/100 (7.73)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 30/10 (3)
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2007:01:06 14:20:22"
@@ -241,7 +239,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 131.532, 80, 97.3451, 80
     raw:cam_xyz: 1.0004, -0.3219, -0.1201, -0.7036, 1.5047, 0.2107, -0.1863, 0.2565, 0.7736, 0, 0, 0
@@ -331,7 +329,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -354,7 +352,6 @@
     PixelAspectRatio: 1
     Software: "Version 1.0                    "
     Exif:ApertureValue: 2 (f/2.0)
-    Exif:ColorSpace: 1
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 1 (yes)
     Exif:DateTimeDigitized: "2008:12:19 12:29:40"
@@ -378,7 +375,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 0
     Olympus:AFPoint: 0
@@ -447,7 +444,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -2
@@ -496,7 +493,6 @@
     Software: "DSLR-A300 v1.00"
     Exif:ApertureValue: 4.97085 (f/5.6)
     Exif:BrightnessValue: 137/100 (1.37)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 8/1 (8)
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 0 (no)
@@ -522,7 +518,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 1972, 1024, 1632, 1024
     raw:cam_xyz: 0.9847, -0.3091, -0.0928, -0.8485, 1.6345, 0.2225, -0.0715, 0.0595, 0.7103, 0, 0, 0

--- a/testsuite/raw/ref/out-libraw-0.20.2.txt
+++ b/testsuite/raw/ref/out-libraw-0.20.2.txt
@@ -52,7 +52,6 @@
     Canon:SpecularWhiteLevel: 12749
     Canon:SpotMeteringMode: 0 (center)
     Exif:ApertureValue: 2.97085 (f/2.8)
-    Exif:ColorSpace: 1
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2009:10:09 14:18:45"
     Exif:DateTimeOriginal: "2009:10:09 14:18:45"
@@ -77,7 +76,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 2076, 1024, 1584, 1024
     raw:cam_xyz: 0.6844, -0.0996, -0.0856, -0.3876, 1.1761, 0.2396, -0.0593, 0.1772, 0.6198, 0, 0, 0
@@ -167,7 +166,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -188,7 +187,6 @@
     Software: "Digital Camera FinePix F700  Ver2.00"
     Exif:ApertureValue: 3.69599 (f/3.6)
     Exif:BrightnessValue: 773/100 (7.73)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 30/10 (3)
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2007:01:06 14:20:22"
@@ -241,7 +239,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 131.532, 80, 97.3451, 80
     raw:cam_xyz: 1.0004, -0.3219, -0.1201, -0.7036, 1.5047, 0.2107, -0.1863, 0.2565, 0.7736, 0, 0, 0
@@ -331,7 +329,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -354,7 +352,6 @@
     PixelAspectRatio: 1
     Software: "Version 1.0                    "
     Exif:ApertureValue: 2 (f/2.0)
-    Exif:ColorSpace: 1
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 1 (yes)
     Exif:DateTimeDigitized: "2008:12:19 12:29:40"
@@ -378,7 +375,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 0
     Olympus:AFPoint: 0
@@ -437,7 +434,7 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     Panasonic:AFPoint: -1
     Panasonic:BlackLevel: 0, 0, 0, 0, 0, 0, 0, 0
     Panasonic:CameraFormat: 8
@@ -487,7 +484,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -2
@@ -536,7 +533,6 @@
     Software: "DSLR-A300 v1.00"
     Exif:ApertureValue: 4.97085 (f/5.6)
     Exif:BrightnessValue: 137/100 (1.37)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 8/1 (8)
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 0 (no)
@@ -562,7 +558,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 1972, 1024, 1632, 1024
     raw:cam_xyz: 0.9847, -0.3091, -0.0928, -0.8485, 1.6345, 0.2225, -0.0715, 0.0595, 0.7103, 0, 0, 0

--- a/testsuite/raw/ref/out-libraw0.20.0-gh.txt
+++ b/testsuite/raw/ref/out-libraw0.20.0-gh.txt
@@ -77,7 +77,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 2076, 1024, 1584, 1024
     raw:cam_xyz: 0.6844, -0.0996, -0.0856, -0.3876, 1.1761, 0.2396, -0.0593, 0.1772, 0.6198, 0, 0, 0
@@ -167,7 +167,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -188,7 +188,6 @@
     Software: "Digital Camera FinePix F700  Ver2.00"
     Exif:ApertureValue: 3.69599 (f/3.6)
     Exif:BrightnessValue: 773/100 (7.73)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 30/10 (3)
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2007:01:06 14:20:22"
@@ -241,7 +240,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 131.532, 80, 97.3451, 80
     raw:cam_xyz: 1.0004, -0.3219, -0.1201, -0.7036, 1.5047, 0.2107, -0.1863, 0.2565, 0.7736, 0, 0, 0
@@ -331,7 +330,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -354,7 +353,6 @@
     PixelAspectRatio: 1
     Software: "Version 1.0                    "
     Exif:ApertureValue: 2 (f/2.0)
-    Exif:ColorSpace: 1
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 1 (yes)
     Exif:DateTimeDigitized: "2008:12:19 12:29:40"
@@ -378,7 +376,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 0
     Olympus:AFPoint: 0
@@ -447,7 +445,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -2
@@ -496,7 +494,6 @@
     Software: "DSLR-A300 v1.00"
     Exif:ApertureValue: 4.97085 (f/5.6)
     Exif:BrightnessValue: 137/100 (1.37)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 8/1 (8)
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 0 (no)
@@ -522,7 +519,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 1972, 1024, 1632, 1024
     raw:cam_xyz: 0.9847, -0.3091, -0.0928, -0.8485, 1.6345, 0.2225, -0.0715, 0.0595, 0.7103, 0, 0, 0

--- a/testsuite/raw/ref/out-libraw0.20.0.txt
+++ b/testsuite/raw/ref/out-libraw0.20.0.txt
@@ -52,7 +52,6 @@
     Canon:SpecularWhiteLevel: 12749
     Canon:SpotMeteringMode: 0 (center)
     Exif:ApertureValue: 2.97085 (f/2.8)
-    Exif:ColorSpace: 1
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2009:10:09 14:18:45"
     Exif:DateTimeOriginal: "2009:10:09 14:18:45"
@@ -77,7 +76,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 2076, 1024, 1584, 1024
     raw:cam_xyz: 0.6844, -0.0996, -0.0856, -0.3876, 1.1761, 0.2396, -0.0593, 0.1772, 0.6198, 0, 0, 0
@@ -167,7 +166,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -188,7 +187,6 @@
     Software: "Digital Camera FinePix F700  Ver2.00"
     Exif:ApertureValue: 3.69599 (f/3.6)
     Exif:BrightnessValue: 773/100 (7.73)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 30/10 (3)
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2007:01:06 14:20:22"
@@ -241,7 +239,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 131.532, 80, 97.3451, 80
     raw:cam_xyz: 1.0004, -0.3219, -0.1201, -0.7036, 1.5047, 0.2107, -0.1863, 0.2565, 0.7736, 0, 0, 0
@@ -331,7 +329,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -354,7 +352,6 @@
     PixelAspectRatio: 1
     Software: "Version 1.0                    "
     Exif:ApertureValue: 2 (f/2.0)
-    Exif:ColorSpace: 1
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 1 (yes)
     Exif:DateTimeDigitized: "2008:12:19 12:29:40"
@@ -378,7 +375,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 0
     Olympus:AFPoint: 0
@@ -437,7 +434,7 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     Panasonic:AFPoint: -1
     Panasonic:BlackLevel: 0, 0, 0, 0, 0, 0, 0, 0
     Panasonic:CameraFormat: 8
@@ -487,7 +484,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -2
@@ -536,7 +533,6 @@
     Software: "DSLR-A300 v1.00"
     Exif:ApertureValue: 4.97085 (f/5.6)
     Exif:BrightnessValue: 137/100 (1.37)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 8/1 (8)
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 0 (no)
@@ -562,7 +558,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 1972, 1024, 1632, 1024
     raw:cam_xyz: 0.9847, -0.3091, -0.0928, -0.8485, 1.6345, 0.2225, -0.0715, 0.0595, 0.7103, 0, 0, 0

--- a/testsuite/raw/ref/out-libraw0.21.0-gh.txt
+++ b/testsuite/raw/ref/out-libraw0.21.0-gh.txt
@@ -49,7 +49,6 @@
     Canon:SpecularWhiteLevel: 12749
     Canon:SpotMeteringMode: 0 (center)
     Exif:ApertureValue: 2.97085 (f/2.8)
-    Exif:ColorSpace: 1
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2009:10:09 14:18:45"
     Exif:DateTimeOriginal: "2009:10:09 14:18:45"
@@ -74,7 +73,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 2076, 1024, 1584, 1024
     raw:cam_xyz: 0.6844, -0.0996, -0.0856, -0.3876, 1.1761, 0.2396, -0.0593, 0.1772, 0.6198, 0, 0, 0
@@ -161,7 +160,7 @@
     Nikon:NEFCompression: 3
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -182,7 +181,6 @@
     Software: "Digital Camera FinePix F700  Ver2.00"
     Exif:ApertureValue: 3.69599 (f/3.6)
     Exif:BrightnessValue: 773/100 (7.73)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 30/10 (3)
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2007:01:06 14:20:22"
@@ -233,7 +231,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 131, 80, 97, 80
     raw:cam_xyz: 1.0004, -0.3219, -0.1201, -0.7036, 1.5047, 0.2107, -0.1863, 0.2565, 0.7736, 0, 0, 0
@@ -320,7 +318,7 @@
     Nikon:NEFCompression: 3
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -343,7 +341,6 @@
     PixelAspectRatio: 1
     Software: "Version 1.0                    "
     Exif:ApertureValue: 2 (f/2.0)
-    Exif:ColorSpace: 1
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 1 (yes)
     Exif:DateTimeDigitized: "2008:12:19 12:29:40"
@@ -367,7 +364,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 255
     Olympus:AFFineTuneAdj: -32768, -32768, -32768
@@ -437,7 +434,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -2
@@ -486,7 +483,6 @@
     Software: "DSLR-A300 v1.00"
     Exif:ApertureValue: 4.97085 (f/5.6)
     Exif:BrightnessValue: 137/100 (1.37)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 8/1 (8)
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 0 (no)
@@ -512,7 +508,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 1972, 1024, 1632, 1024
     raw:cam_xyz: 0.9847, -0.3091, -0.0928, -0.8485, 1.6345, 0.2225, -0.0715, 0.0595, 0.7103, 0, 0, 0

--- a/testsuite/raw/ref/out-libraw0.21.0-mac.txt
+++ b/testsuite/raw/ref/out-libraw0.21.0-mac.txt
@@ -49,7 +49,6 @@
     Canon:SpecularWhiteLevel: 12749
     Canon:SpotMeteringMode: 0 (center)
     Exif:ApertureValue: 2.97085 (f/2.8)
-    Exif:ColorSpace: 1
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2009:10:09 14:18:45"
     Exif:DateTimeOriginal: "2009:10:09 14:18:45"
@@ -74,7 +73,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 2076, 1024, 1584, 1024
     raw:cam_xyz: 0.6844, -0.0996, -0.0856, -0.3876, 1.1761, 0.2396, -0.0593, 0.1772, 0.6198, 0, 0, 0
@@ -161,7 +160,7 @@
     Nikon:NEFCompression: 3
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -182,7 +181,6 @@
     Software: "Digital Camera FinePix F700  Ver2.00"
     Exif:ApertureValue: 3.69599 (f/3.6)
     Exif:BrightnessValue: 773/100 (7.73)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 30/10 (3)
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2007:01:06 14:20:22"
@@ -233,7 +231,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 131, 80, 97, 80
     raw:cam_xyz: 1.0004, -0.3219, -0.1201, -0.7036, 1.5047, 0.2107, -0.1863, 0.2565, 0.7736, 0, 0, 0
@@ -320,7 +318,7 @@
     Nikon:NEFCompression: 3
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -343,7 +341,6 @@
     PixelAspectRatio: 1
     Software: "Version 1.0                    "
     Exif:ApertureValue: 2 (f/2.0)
-    Exif:ColorSpace: 1
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 1 (yes)
     Exif:DateTimeDigitized: "2008:12:19 12:29:40"
@@ -367,7 +364,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 255
     Olympus:AFFineTuneAdj: -32768, -32768, -32768
@@ -427,7 +424,7 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     Panasonic:AFPoint: -1
     Panasonic:BlackLevel: 0, 0, 0, 0, 0, 0, 0, 0
     Panasonic:CameraFormat: 8
@@ -477,7 +474,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -2
@@ -526,7 +523,6 @@
     Software: "DSLR-A300 v1.00"
     Exif:ApertureValue: 4.97085 (f/5.6)
     Exif:BrightnessValue: 137/100 (1.37)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 8/1 (8)
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 0 (no)
@@ -552,7 +548,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 1972, 1024, 1632, 1024
     raw:cam_xyz: 0.9847, -0.3091, -0.0928, -0.8485, 1.6345, 0.2225, -0.0715, 0.0595, 0.7103, 0, 0, 0

--- a/testsuite/raw/ref/out.txt
+++ b/testsuite/raw/ref/out.txt
@@ -51,7 +51,6 @@
     Canon:SpecularWhiteLevel: 12749
     Canon:SpotMeteringMode: 0 (center)
     Exif:ApertureValue: 2.97085 (f/2.8)
-    Exif:ColorSpace: 1
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2009:10:09 14:18:45"
     Exif:DateTimeOriginal: "2009:10:09 14:18:45"
@@ -76,7 +75,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 2076, 1024, 1584, 1024
     raw:cam_xyz: 0.6844, -0.0996, -0.0856, -0.3876, 1.1761, 0.2396, -0.0593, 0.1772, 0.6198, 0, 0, 0
@@ -166,7 +165,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -187,7 +186,6 @@
     Software: "Digital Camera FinePix F700  Ver2.00"
     Exif:ApertureValue: 3.69599 (f/3.6)
     Exif:BrightnessValue: 773/100 (7.73)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 30/10 (3)
     Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2007:01:06 14:20:22"
@@ -238,7 +236,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 131.532, 80, 97.3451, 80
     raw:cam_xyz: 1.0004, -0.3219, -0.1201, -0.7036, 1.5047, 0.2107, -0.1863, 0.2565, 0.7736, 0, 0, 0
@@ -328,7 +326,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 463, 256, 396, 256
     raw:cam_xyz: 0.7171, -0.1986, -0.0648, -0.8085, 1.5555, 0.2718, -0.217, 0.2512, 0.7457, 0, 0, 0
@@ -351,7 +349,6 @@
     PixelAspectRatio: 1
     Software: "Version 1.0                    "
     Exif:ApertureValue: 2 (f/2.0)
-    Exif:ColorSpace: 1
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 1 (yes)
     Exif:DateTimeDigitized: "2008:12:19 12:29:40"
@@ -375,7 +372,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 0
     Olympus:AFPoint: 0
@@ -433,7 +430,7 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     Panasonic:AFPoint: -1
     Panasonic:BlackLevel: 0, 0, 0, 0, 0, 0, 0, 0
     Panasonic:CanonFocalUnits: 1
@@ -478,7 +475,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -1
@@ -527,7 +524,6 @@
     Software: "DSLR-A300 v1.00"
     Exif:ApertureValue: 4.97085 (f/5.6)
     Exif:BrightnessValue: 137/100 (1.37)
-    Exif:ColorSpace: 1
     Exif:CompressedBitsPerPixel: 8/1 (8)
     Exif:Contrast: 0 (normal)
     Exif:CustomRendered: 0 (no)
@@ -553,7 +549,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "linear"
+    oiio:ColorSpace: "lin_rec709"
     oiio:MakerNoteOffset: 0
     raw:cam_mul: 1972, 1024, 1632, 1024
     raw:cam_xyz: 0.9847, -0.3091, -0.0928, -0.8485, 1.6345, 0.2225, -0.0715, 0.0595, 0.7103, 0, 0, 0

--- a/testsuite/rla/ref/out.txt
+++ b/testsuite/rla/ref/out.txt
@@ -90,7 +90,7 @@ Reading ../oiio-images/rla/imgmake_rgba_nc10.rla
     compression: "rle"
     HostComputer: "hawk073.spimageworks.com"
     oiio:BitsPerSample: 10
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_srgb"
     rla:Aspect: " 1.333"
     rla:BlueChroma: 0.14, 0.14, 0.08
     rla:ColorChannel: "rgb"
@@ -193,7 +193,7 @@ Reading ../oiio-images/rla/imgmake_rgba_nc16.rla
     compression: "rle"
     HostComputer: "hawk073.spimageworks.com"
     oiio:BitsPerSample: 16
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_srgb"
     rla:Aspect: " 1.333"
     rla:BlueChroma: 0.14, 0.14, 0.08
     rla:ColorChannel: "rgb"
@@ -296,7 +296,7 @@ Reading ../oiio-images/rla/imgmake_rgba_nc8.rla
     compression: "rle"
     HostComputer: "hawk073.spimageworks.com"
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "lin_srgb"
     rla:Aspect: " 1.333"
     rla:BlueChroma: 0.14, 0.14, 0.08
     rla:ColorChannel: "rgb"


### PR DESCRIPTION
A round of color management improvements (I hope).

We were pretty squirrelly about what "linear" meant. Get more exact. Now we will treat "linear" as a legacy synonym for "lin_rec709" (sRGB primaries, but linear response). Change file format readers to say "lin_rec709" when they mean it, and not use the more generic alias "linear".

"scene_linear", on the other hand, is the internal working color space for math. Which concrete color space it is an alias for is determined by the OCIO config in use.

Use "g18_rec709" and "g22_rec709" for rec709 + gamma 1.8 or 2.2, respectvely.

A few new API calls help out: equivalent_colorspace(), set_colorspace(spec,name), set_colorspace_rec709_gamma().

OpenEXR always tagged files as linear by default. It was too aggressive about this, so with this PR, now it defaults to lin_rec709 only for files that appear to be RGB and not have any other clues about the color space.

Similarly, the raw reader was too eager to set the Exif:ColorSpace to look like sRGB even when it wasn't.

Lots of reference outputs needed to be updated.

This is a potentially big behavior change. But I think it's for the better.
