### PR TITLE
api: Change Strutil::format to default to std::format conventions

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -38,7 +38,7 @@
 // behave like sprintf (OIIO_FORMAT_IS_FMT==0) or like python / {fmt} /
 // C++20ish std::format (OIIO_FORMAT_IS_FMT==1).
 #ifndef OIIO_FORMAT_IS_FMT
-#    define OIIO_FORMAT_IS_FMT 0
+#    define OIIO_FORMAT_IS_FMT 1
 #endif
 
 #define OIIO_FORMAT_DEPRECATED OIIO_DEPRECATED("old style (printf-like) formatting version of this function is deprecated")
@@ -309,15 +309,6 @@ std::string OIIO_UTIL_API vsprintf (const char *fmt, va_list ap)
 #endif
     ;
 
-/// Return a std::string formatted like Strutil::format, but passed
-/// already as a va_list.  This is not guaranteed type-safe and is not
-/// extensible like format(). Use with caution!
-OIIO_DEPRECATED("use `vsprintf` instead")
-std::string OIIO_UTIL_API vformat (const char *fmt, va_list ap)
-#if defined(__GNUC__) && !defined(__CUDACC__)
-    __attribute__ ((format (printf, 1, 0) ))
-#endif
-    ;
 
 /// Return a string expressing a number of bytes, in human readable form.
 ///  - memformat(153)           -> "153 B"

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -323,15 +323,6 @@ Strutil::vsprintf(const char* fmt, va_list ap)
 
 
 std::string
-Strutil::vformat(const char* fmt, va_list ap)
-{
-    // For now, just treat as a synonym for vsprintf
-    return vsprintf(fmt, ap);
-}
-
-
-
-std::string
 Strutil::memformat(long long bytes, int digits)
 {
     const long long KB = (1 << 10);


### PR DESCRIPTION
This finally switches Strutil::format to use std::format conventions. You can still access the old printf convention via `Strutil::old::format()`, and can explicitly access the new convention uniformly on both 2.x and 3.x via `Strutil::fmt::format()`.

It also removes a long-deprecated vformat function.

We've been waiting for 3.0 to make this non-back-compatible change.
