### PR TITLE
TS: Version TextureOptBatch like we did for TextureOpt

### DIFF
--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -326,11 +326,28 @@ initialize_opt(TextureOptBatch& opt)
     opt.fill = (fill >= 0.0f) ? fill : 1.0f;
     if (missing[0] >= 0)
         opt.missingcolor = (float*)&missing;
+
+#if OIIO_TEXTUREOPTBATCH_VERSION == 1
+    // Current layout of TextureOptBatch_v1
+    Wrap sw, tw;
+    Tex::parse_wrapmodes(wrapmodes.c_str(), sw, tw);
+    opt.swrap       = int(sw);
+    opt.twrap       = int(tw);
+    opt.rwrap       = opt.swrap;
+    opt.anisotropic = anisomax;
+    opt.mipmode     = int(mipmode);     // ideal: MipMode(mipmode);
+    opt.interpmode  = int(interpmode);  // ideal: InterpMode(interpmode);
+#else
+    // Some day, maybe for TextureOptBatch_v2, we'd like to switch to this to
+    // completely match the types and layout of TextureOpt.
     Tex::parse_wrapmodes(wrapmodes.c_str(), opt.swrap, opt.twrap);
     opt.rwrap       = opt.swrap;
     opt.anisotropic = anisomax;
     opt.mipmode     = MipMode(mipmode);
     opt.interpmode  = InterpMode(interpmode);
+#endif
+
+
     if (subimage >= 0)
         opt.subimage = subimage;
     else if (!subimagename.empty())


### PR DESCRIPTION
I got part way through the OSL side changes to accommodate what we did
recently with TextureOpt and TextureOptBatch. Ugh, it's a lot harder than
I thought and I don't know how to finish the job without postponing the
3.0 release even more, which is unacceptable at this point. So here I do
to TextureOptBatch to get out of this mess:

* "Version" TextureOptBatch like we did for TextureOpt (should have done
  that all along).
* Revert "v1" to the same byte-for-byte layout we used to have, which
  involves using `int` for some fields as it implicitly did before, because
  the new enum classes totally change the field sizes and struct layout.
* Sketch out in comments what v2 might look like, to more fully match the
  TextureOpt. The introduction of struct versioning means we can make that
  change for 3.1, it doesn't need to wait years for 4.0.

  
 