### PR TITLE
ci: Fix broken bleeding edge test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,11 +358,11 @@ jobs:
                             PUGIXML_VERSION=master
                             WEBP_VERSION=main
                             OIIO_CMAKE_FLAGS="-DFORTIFY_SOURCE=2"
-                            QT_VERSION=6
                             EXTRA_DEP_PACKAGES="python3.12-dev python3-numpy"
                             USE_OPENVDB=0
                             SKIP_APT_GET_UPDATE=1
                             FREETYPE_VERSION=master
+                            QT_VERSION=0 INSTALL_OPENCV=0
                             # The installed OpenVDB has a TLS conflict with Python 3.8
                             # Disabling the `apt-get update` in gh-installdeps.bash 
                             # addresses a job killing problem in the GHA Ubuntu

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -91,14 +91,16 @@ else
         libilmbase-dev libopenexr-dev \
         libtiff-dev libgif-dev libpng-dev
     if [[ "${SKIP_SYSTEM_DEPS_INSTALL}" != "1" ]] ; then
-        time sudo apt-get -q install -y \
+        time sudo apt-get -q install -y --fix-missing \
             libraw-dev libwebp-dev \
             libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
             dcmtk libopenvdb-dev \
             libfreetype6-dev \
             libopencolorio-dev \
-            libtbb-dev \
-            libopencv-dev
+            libtbb-dev || true
+    fi
+    if [[ "${USE_OPENCV}" != "0" ]] && [[ "${INSTALL_OPENCV}" != "0" ]] ; then
+        sudo apt-get -q install -y --fix-missing libopencv-dev || true
     fi
     if [[ "${QT_VERSION:-5}" == "5" ]] ; then
         time sudo apt-get -q install -y \


### PR DESCRIPTION
It's failing to get Mesa packages for some reason. Disable Qt and OpenCV on this one test to work around it for now.
