### PR TITLE
BUILD_MISSING_DEPS - fix minor configuration options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,11 +202,6 @@ ifneq (${CLANG_FORMAT_EXCLUDES},)
   MY_CMAKE_FLAGS += -DCLANG_FORMAT_EXCLUDES:STRING=${CLANG_FORMAT_EXCLUDES}
 endif
 
-ifneq (${BUILD_MISSING_DEPS},)
-  MY_CMAKE_FLAGS += -DBUILD_MISSING_DEPS:BOOL=${BUILD_MISSING_DEPS}
-endif
-
-
 #$(info MY_CMAKE_FLAGS = ${MY_CMAKE_FLAGS})
 #$(info MY_MAKE_FLAGS = ${MY_MAKE_FLAGS})
 
@@ -395,7 +390,6 @@ help:
 	@echo "                                  0, sse2, sse3, ssse3, sse4.1, sse4.2, f16c,"
 	@echo "                                  avx, avx2, avx512f)"
 	@echo "      TEX_BATCH_SIZE=16        Override TextureSystem SIMD batch size"
-	@echo "      BUILD_MISSING_DEPS=1     Try to download/build missing dependencies"
 	@echo "  make test, extra options:"
 	@echo "      TEST=regex               Run only tests matching the regex"
 	@echo ""

--- a/src/cmake/dependency_utils.cmake
+++ b/src/cmake/dependency_utils.cmake
@@ -426,7 +426,7 @@ macro (checked_find_package pkgname)
         #   ${pkgname}_REFIND_ARGS    : additional arguments to pass to find_package
         if (${pkgname}_REFIND)
             message (STATUS "Refinding ${pkgname} with ${pkgname}_ROOT=${${pkgname}_ROOT}")
-            find_package (${pkgname} ${_pkg_UNPARSED_ARGUMENTS} ${${pkgname}_REFIND_ARGS})
+            find_package (${pkgname} ${${pkgname}_REFIND_VERSION} REQUIRED ${_pkg_UNPARSED_ARGUMENTS} ${${pkgname}_REFIND_ARGS})
             unset (${pkgname}_REFIND)
         endif()
         # It's all downhill from here: if we found the package, follow the

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -453,10 +453,11 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // Output 16 bit images
     m_processor->imgdata.params.output_bps = 16;
 
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
     // Exposing max_raw_memory_mb setting. Default max is 2048.
     m_processor->imgdata.rawparams.max_raw_memory_mb
         = config.get_int_attribute("raw:max_raw_memory_mb", 2048);
-
+#endif
 
     // Disable exposure correction (unless config "raw:auto_bright" == 1)
     m_processor->imgdata.params.no_auto_bright
@@ -715,7 +716,9 @@ RawInput::open_raw(bool unpack, const std::string& name,
             crop_top    = p->get_int_indexed(1);
             crop_width  = p->get_int_indexed(2);
             crop_height = p->get_int_indexed(3);
-        } else if (m_processor->imgdata.sizes.raw_inset_crops[0].cwidth != 0) {
+        }
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
+        else if (m_processor->imgdata.sizes.raw_inset_crops[0].cwidth != 0) {
             crop_left   = m_processor->imgdata.sizes.raw_inset_crops[0].cleft;
             crop_top    = m_processor->imgdata.sizes.raw_inset_crops[0].ctop;
             crop_width  = m_processor->imgdata.sizes.raw_inset_crops[0].cwidth;
@@ -723,7 +726,16 @@ RawInput::open_raw(bool unpack, const std::string& name,
             left_margin = m_processor->imgdata.sizes.left_margin;
             top_margin  = m_processor->imgdata.sizes.top_margin;
         }
-
+#else
+        else if (m_processor->imgdata.sizes.raw_inset_crop.cwidth != 0) {
+            crop_left   = m_processor->imgdata.sizes.raw_inset_crop.cleft;
+            crop_top    = m_processor->imgdata.sizes.raw_inset_crop.ctop;
+            crop_width  = m_processor->imgdata.sizes.raw_inset_crop.cwidth;
+            crop_height = m_processor->imgdata.sizes.raw_inset_crop.cheight;
+            left_margin = m_processor->imgdata.sizes.left_margin;
+            top_margin  = m_processor->imgdata.sizes.top_margin;
+        }
+#endif
         if (crop_width > 0 && crop_height > 0) {
             ushort image_width  = m_processor->imgdata.sizes.width;
             ushort image_height = m_processor->imgdata.sizes.height;


### PR DESCRIPTION
## Description
Address a few small issues encountered during CMake configuration step and during build using Makefile `BUILD_MISSING_DEPS` option enabled.
- Mismatch between expected libraw versions specified in `build_libraw.bash` 0.21.3 and `externalpackages.cmake` 0.20.0
- OpenEXR link error in libutil tests
- Update top level Makefile to accept `BUILD_MISSING_DEPS` as string instead of bool. Pass the string option down to CMake

## Test
Verified build completes with no errors: `BUILD_MISSING_DEPS=all make`
