### PR TITLE
ci: Limit when automatic docs building ci happens

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,16 +9,20 @@ on:
     # Skip jobs when only cpp files are changed. The materials for
     # docs are all in md, rst, and .h files.
     paths-ignore:
+      - '**/ci.yml'
       - '**/analysis.yml'
       - '**.properties'
-      - '**.cpp'
+      - 'src/**.cpp'
       - '**.cmake'
+      - '**/run.py'
   pull_request:
     paths-ignore:
+      - '**/ci.yml'
       - '**/analysis.yml'
       - '**.properties'
-      - '**.cpp'
+      - 'src/**.cpp'
       - '**.cmake'
+      - '**/run.py'
   schedule:
     # Full nightly build
     - cron: "0 8 * * *"


### PR DESCRIPTION
Times we DON'T need to test rebuilding the docs:

* When just the ci.yml workflow changes (like when we bump what versions of dependencies ci tests use).
* When tests changes only by altering their run.py.

But DO try rebuilding docs:

* When cpp files change that are outside of src/, such as the cpp files in the testsuite that are used to supply code snippets that appear in the docs.
