### PR TITLE
Detect libbz2 only if FFmpeg or FreeType is enabled.

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -121,11 +121,6 @@ endif ()
 
 checked_find_package (PNG VERSION_MIN 1.6.0)
 
-checked_find_package (BZip2)   # Used by ffmpeg and freetype
-if (NOT BZIP2_FOUND)
-    set (BZIP2_LIBRARIES "")  # TODO: why does it break without this?
-endif ()
-
 checked_find_package (Freetype
                       VERSION_MIN 2.10.0
                       DEFINITIONS USE_FREETYPE=1 )
@@ -190,6 +185,13 @@ checked_find_package (R3DSDK NO_RECORD_NOTFOUND)  # RED camera
 
 set (NUKE_VERSION "7.0" CACHE STRING "Nuke version to target")
 checked_find_package (Nuke NO_RECORD_NOTFOUND)
+
+if (FFmpeg_FOUND OR FREETYPE_FOUND)
+    checked_find_package (BZip2)   # Used by ffmpeg and freetype
+    if (NOT BZIP2_FOUND)
+        set (BZIP2_LIBRARIES "")  # TODO: why does it break without this?
+    endif ()
+endif()
 
 
 # Qt -- used for iv


### PR DESCRIPTION
## Description

Detect libbz2 only if necessary, i.e., FFmpeg or FreeType is enabled. This avoids an unnecessary dependency on libbz2 if these features are disabled.

In particular, with vcpkg, OpenImageIO might pick up a dependency on libbz2.so from the host system since bzip2 from vcpkg is not listed as a dependency of OpenImageIO (if the FFmpeg and FreeImage features are disabled, and bzip2 is not already installed for other reasons).

## Tests

Build issue, no additional tests.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
