### PR TITLE
IBA::Unsharp_mask() speed and memory optimization

### DIFF
--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1008,7 +1008,7 @@ ImageBufAlgo::unsharp_mask(ImageBuf& dst, const ImageBuf& src,
             return false;
         }
     } else {
-        ImageBuf K = make_kernel(kernel, 1, width);
+        ImageBuf K = make_kernel(kernel, width, width);
         if (K.has_error()) {
             dst.errorfmt("{}", K.geterror());
             return false;

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -971,15 +971,14 @@ unsharp_impl(ImageBuf& dst, const ImageBuf& blr, const ImageBuf& src,
 {
     OIIO_DASSERT(dst.spec().nchannels == src.spec().nchannels
                  && dst.spec().nchannels == blr.spec().nchannels);
-    // source + contrast * ((source - blurred) > threshold ? (source - blurred) : 0)
-    // -> source + (contrast * (source - blurred)) > (threshold * contrast) ? (contrast * (source - blurred) : 0)
+
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         ImageBuf::ConstIterator<Rtype> s(src, roi);
         ImageBuf::ConstIterator<float> b(blr, roi);
         for (ImageBuf::Iterator<Rtype> d(dst, roi); !d.done(); ++s, ++d, ++b) {
             for (int c = roi.chbegin; c < roi.chend; ++c) {
-                const float diff             = s[c] - b[c];
-                const float abs_diff         = fabsf(diff);
+                const float diff     = s[c] - b[c];
+                const float abs_diff = std::fabsf(diff);
                 if (abs_diff > threshold) {
                     d[c] = s[c] + contrast * diff;
                 } else {

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -994,7 +994,7 @@ ImageBufAlgo::unsharp_mask(ImageBuf& dst, const ImageBuf& src,
     if (kernel == "median") {
         median_filter(Blurry, src, ceilf(width), 0, roi, nthreads);
     } else if (width > 3.0) {
-        ImageBuf K  = make_kernel(kernel, width, 1);
+        ImageBuf K  = make_kernel(kernel, 1, width);
         ImageBuf Kt = ImageBufAlgo::transpose(K);
         if (K.has_error()) {
             dst.errorfmt("{}", K.geterror());

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -993,7 +993,7 @@ ImageBufAlgo::unsharp_mask(ImageBuf& dst, const ImageBuf& src,
     if (kernel == "median") {
         median_filter(Blurry, src, ceilf(width), 0, roi, nthreads);
     } else if (width > 3.0) {
-        ImageBuf K = make_kernel(kernel, 1, width);
+        ImageBuf K  = make_kernel(kernel, 1, width);
         ImageBuf Kt = ImageBufAlgo::transpose(K);
         if (K.has_error()) {
             dst.errorfmt("{}", K.geterror());
@@ -1008,7 +1008,7 @@ ImageBufAlgo::unsharp_mask(ImageBuf& dst, const ImageBuf& src,
             return false;
         }
     } else {
-        ImageBuf K  = make_kernel(kernel, 1, width);
+        ImageBuf K = make_kernel(kernel, 1, width);
         if (K.has_error()) {
             dst.errorfmt("{}", K.geterror());
             return false;

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -992,8 +992,23 @@ ImageBufAlgo::unsharp_mask(ImageBuf& dst, const ImageBuf& src,
 
     if (kernel == "median") {
         median_filter(Blurry, src, ceilf(width), 0, roi, nthreads);
+    } else if (width > 3.0) {
+        ImageBuf K = make_kernel(kernel, 1, width);
+        ImageBuf Kt = ImageBufAlgo::transpose(K);
+        if (K.has_error()) {
+            dst.errorfmt("{}", K.geterror());
+            return false;
+        }
+        if (!convolve(Blurry, src, K, true, roi, nthreads)) {
+            dst.errorfmt("{}", Blurry.geterror());
+            return false;
+        }
+        if (!convolve(Blurry, Blurry, Kt, true, roi, nthreads)) {
+            dst.errorfmt("{}", Blurry.geterror());
+            return false;
+        }
     } else {
-        ImageBuf K = make_kernel(kernel, width, width);
+        ImageBuf K  = make_kernel(kernel, 1, width);
         if (K.has_error()) {
             dst.errorfmt("{}", K.geterror());
             return false;

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -947,23 +947,6 @@ ImageBufAlgo::make_kernel(string_view name, float width, float height,
 
 
 
-// Helper function for unsharp mask to perform the thresholding
-static bool
-threshold_to_zero(ImageBuf& dst, float threshold, ROI roi, int nthreads)
-{
-    OIIO_DASSERT(dst.spec().format.basetype == TypeDesc::FLOAT);
-
-    ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
-        for (ImageBuf::Iterator<float> p(dst, roi); !p.done(); ++p)
-            for (int c = roi.chbegin; c < roi.chend; ++c)
-                if (fabsf(p[c]) < threshold)
-                    p[c] = 0.0f;
-    });
-    return true;
-}
-
-
-
 template<class Rtype>
 static bool
 unsharp_impl(ImageBuf& dst, const ImageBuf& blr, const ImageBuf& src,
@@ -978,7 +961,7 @@ unsharp_impl(ImageBuf& dst, const ImageBuf& blr, const ImageBuf& src,
         for (ImageBuf::Iterator<Rtype> d(dst, roi); !d.done(); ++s, ++d, ++b) {
             for (int c = roi.chbegin; c < roi.chend; ++c) {
                 const float diff     = s[c] - b[c];
-                const float abs_diff = std::fabsf(diff);
+                const float abs_diff = fabsf(diff);
                 if (abs_diff > threshold) {
                     d[c] = s[c] + contrast * diff;
                 } else {

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -988,22 +988,23 @@ ImageBufAlgo::unsharp_mask(ImageBuf& dst, const ImageBuf& src,
     // Blur the source image, store in Blurry
     ImageSpec BlurrySpec = src.spec();
     BlurrySpec.set_format(TypeDesc::FLOAT);  // force float
+    ImageBuf fst_pass(BlurrySpec);
     ImageBuf Blurry(BlurrySpec);
 
     if (kernel == "median") {
         median_filter(Blurry, src, ceilf(width), 0, roi, nthreads);
     } else if (width > 3.0) {
-        ImageBuf K  = make_kernel(kernel, 1, width);
+        ImageBuf K  = make_kernel(kernel, width, 1);
         ImageBuf Kt = ImageBufAlgo::transpose(K);
         if (K.has_error()) {
             dst.errorfmt("{}", K.geterror());
             return false;
         }
-        if (!convolve(Blurry, src, K, true, roi, nthreads)) {
-            dst.errorfmt("{}", Blurry.geterror());
+        if (!convolve(fst_pass, src, K, true, roi, nthreads)) {
+            dst.errorfmt("{}", fst_pass.geterror());
             return false;
         }
-        if (!convolve(Blurry, Blurry, Kt, true, roi, nthreads)) {
+        if (!convolve(Blurry, fst_pass, Kt, true, roi, nthreads)) {
             dst.errorfmt("{}", Blurry.geterror());
             return false;
         }

--- a/testsuite/docs-examples-cpp/ref/out-arm.txt
+++ b/testsuite/docs-examples-cpp/ref/out-arm.txt
@@ -137,7 +137,7 @@ checker_with_alpha_filled.exr :  256 x  256, 4 channel, half openexr
 tahoe_median_filter.tif :  512 x  384, 3 channel, uint8 tiff
     SHA-1: A0B2E3A10A16EA8CC905F144C5F91B6A0964A177
 tahoe_unsharp_mask.tif :  512 x  384, 3 channel, uint8 tiff
-    SHA-1: CDE3FAC8053381C59B7BEB3B47991F357E14D9D2
+    SHA-1: 5842D16483BC74700DE9FD27967B2FFBD54DFCD2
 Comparing "simple.tif" and "ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "ref/scanlines.tif"

--- a/testsuite/docs-examples-cpp/ref/out.txt
+++ b/testsuite/docs-examples-cpp/ref/out.txt
@@ -137,7 +137,7 @@ checker_with_alpha_filled.exr :  256 x  256, 4 channel, half openexr
 tahoe_median_filter.tif :  512 x  384, 3 channel, uint8 tiff
     SHA-1: A0B2E3A10A16EA8CC905F144C5F91B6A0964A177
 tahoe_unsharp_mask.tif :  512 x  384, 3 channel, uint8 tiff
-    SHA-1: D3B56074F48EC5D3ADDA4BDE1F487192ABE9BA76
+    SHA-1: C1C9C843D45D90B7C0BBD7BCDB7A11814668FC6D
 Comparing "simple.tif" and "ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "ref/scanlines.tif"

--- a/testsuite/docs-examples-python/ref/out-arm.txt
+++ b/testsuite/docs-examples-python/ref/out-arm.txt
@@ -137,7 +137,7 @@ checker_with_alpha_filled.exr :  256 x  256, 4 channel, half openexr
 tahoe_median_filter.tif :  512 x  384, 3 channel, uint8 tiff
     SHA-1: A0B2E3A10A16EA8CC905F144C5F91B6A0964A177
 tahoe_unsharp_mask.tif :  512 x  384, 3 channel, uint8 tiff
-    SHA-1: CDE3FAC8053381C59B7BEB3B47991F357E14D9D2
+    SHA-1: 5842D16483BC74700DE9FD27967B2FFBD54DFCD2
 Comparing "simple.tif" and "../docs-examples-cpp/ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "../docs-examples-cpp/ref/scanlines.tif"

--- a/testsuite/docs-examples-python/ref/out.txt
+++ b/testsuite/docs-examples-python/ref/out.txt
@@ -137,7 +137,7 @@ checker_with_alpha_filled.exr :  256 x  256, 4 channel, half openexr
 tahoe_median_filter.tif :  512 x  384, 3 channel, uint8 tiff
     SHA-1: A0B2E3A10A16EA8CC905F144C5F91B6A0964A177
 tahoe_unsharp_mask.tif :  512 x  384, 3 channel, uint8 tiff
-    SHA-1: D3B56074F48EC5D3ADDA4BDE1F487192ABE9BA76
+    SHA-1: C1C9C843D45D90B7C0BBD7BCDB7A11814668FC6D
 Comparing "simple.tif" and "../docs-examples-cpp/ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "../docs-examples-cpp/ref/scanlines.tif"


### PR DESCRIPTION
## Description

Replacing 3x IBA + Helper function that generate 4 fulls size image buffers with single unsharp_mask_impl() that use parallel_image() to compute unsharp: 
src + contr * (((src - blur) < threshold) ? 0.0 : (src - blur))

Added two pass 1D convolution for a kernels higher than 3x3

## Tests

```
	ImageBuf sharped(input.spec());
	const int repeats = 50;

	std::cout << "Start sharpening\n";
	auto start = std::chrono::high_resolution_clock::now();

	for (int i = 0; i < repeats; i++)
	{
		//ok = ImageBufAlgo::unsharp_mask(sharped, input, "gaussian", 15.0f, 10.0f, 0.01f);
		ok = ImageBufAlgo::unsharp_mask(sharped, input, "gaussian", 5.0f, 2.0f, 0.05f);
		std::cout << ".";
	}

	std::cout << "\n";

	auto part1 = std::chrono::high_resolution_clock::now();
	std::chrono::duration<double> elapsed_part1 = part1 - start;
	std::cout << "Elapsed time: " << elapsed_part1.count() << " s\n";
```

both single threaded (one IB at time) and multithreaded (multiply IB at time) show pretty good speedup:
~30-40% with less memory use.

for 5x5 gaussian kernels two pass mode should add at least 20% speedup.

(if someone can do independent benchmark, will be great. As soon as I had a big differences on them depend on real or synthetic use)

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
