### PR TITLE
ci: Retire deprecated macos12 runner, try beta macos15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,16 +506,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: MacOS-12
-            runner: macos-12
-            nametag: macos12-py310
-            cc_compiler: clang
-            cxx_compiler: clang++
-            cxx_std: 17
-            python_ver: "3.11"
-            aclang: 13
-            setenvs: export INSTALL_QT=0 INSTALL_OPENCV=0
-          - desc: MacOS-13
+          - desc: MacOS-13-Intel
             runner: macos-13
             nametag: macos13-py311
             cc_compiler: clang
@@ -524,6 +515,7 @@ jobs:
             python_ver: "3.11"
             aclang: 14
             simd: sse4.2,avx2
+            setenvs: export MACOSX_DEPLOYMENT_TARGET=12.0
           - desc: MacOS-14-ARM
             runner: macos-14
             nametag: macos14-arm-py312
@@ -532,6 +524,14 @@ jobs:
             cxx_std: 20
             python_ver: "3.12"
             aclang: 15
+          - desc: MacOS-15-ARM
+            runner: macos-15
+            nametag: macos15-arm-py313
+            cc_compiler: clang
+            cxx_compiler: clang++
+            cxx_std: 20
+            python_ver: "3.13"
+            aclang: 16
     runs-on: ${{ matrix.runner }}
     env:
       CXX: ${{matrix.cxx_compiler}}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Qt5 >= 5.6 (tested through 5.15) or Qt6 (tested through 6.7)
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
-     * **Python >= 3.7** (tested through 3.12)
+     * **Python >= 3.7** (tested through 3.13)
      * **pybind11 >= 2.7** (tested through 2.12)
      * NumPy
  * If you want support for PNG files:


### PR DESCRIPTION
The GHA macos-12 runner is deprecated and soon to be retired. It's already flaky and they're doing purposeful outages to remind people (the cloud equivalent of turning the lights on and off right before the bar closes).

We still want to test earlier MacOS-12 compatibility to match VFX Reference Platform, so use the macos-13 runner as the minmum but set MACOSX_DEPLOYMENT_TARGET=12.0 to test that configurations.

Also, the MacOS-15 runner is in beta, so add that to the mix. (Along the way, that also verifies that we run fine against python 3.13.)
