### PR TITLE
Add Sphinx Viewcode to docs

### DIFF
--- a/src/doc/conf.py
+++ b/src/doc/conf.py
@@ -68,6 +68,7 @@ sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), '../
 #import latex_mods
 
 extensions = [
+              'sphinx.ext.viewcode',
               'breathe',
               'sphinx_tabs.tabs'
  ]


### PR DESCRIPTION
## Description

One-line change that addresses the request in #4406 to add links to source code from the docs as per https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4406#issuecomment-2331959930

Will confirm that the change is correctly built by checks in a comment below!

## Tests

n/a

## Checklist:

- [X] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [X] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
