### PR TITLE
perf: oiiotool --line --text --point --box speedups

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5016,7 +5016,8 @@ OIIOTOOL_INPLACE_OP(point, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 // --text
 OIIOTOOL_INPLACE_OP(text, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
-    img[0]->copy(*img[1]);
+    OIIO_ASSERT(img[0] == img[1]);  // Assume we're operating in-place
+    // img[0]->copy(*img[1]);  // what we'd do if we weren't in-place
     const ImageSpec& Rspec(img[0]->spec());
     int x            = op.options().get_int("x", Rspec.x + Rspec.width / 2);
     int y            = op.options().get_int("y", Rspec.y + Rspec.height / 2);

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -76,6 +76,18 @@ using pvt::print_info_options;
         op();                                                        \
     }
 
+// Lke OIIOTOOL_OP, but designate the op as "inplace" -- which means it
+// uses the input image itself as the destination.
+#define OIIOTOOL_INPLACE_OP(name, ninputs, ...)                      \
+    static void action_##name(Oiiotool& ot, cspan<const char*> argv) \
+    {                                                                \
+        if (ot.postpone_callback(ninputs, action_##name, argv))      \
+            return;                                                  \
+        OiiotoolOp op(ot, "-" #name, argv, ninputs, __VA_ARGS__);    \
+        op.inplace(true);                                            \
+        op();                                                        \
+    }
+
 // Canned setup for an op that uses one image on the stack.
 #define UNARY_IMAGE_OP(name, impl)                                 \
     OIIOTOOL_OP(name, 1, [](OiiotoolOp& op, span<ImageBuf*> img) { \
@@ -4940,7 +4952,7 @@ OIIOTOOL_OP(contrast, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 // --box
 // clang-format off
-OIIOTOOL_OP(box, 1, nullptr, ([&](OiiotoolOp& op, span<ImageBuf*> img) {
+OIIOTOOL_INPLACE_OP(box, 1, nullptr, ([&](OiiotoolOp& op, span<ImageBuf*> img) {
     img[0]->copy(*img[1]);
     const ImageSpec& Rspec(img[0]->spec());
     int x1, y1, x2, y2;
@@ -4963,7 +4975,7 @@ OIIOTOOL_OP(box, 1, nullptr, ([&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 
 // --line
-OIIOTOOL_OP(line, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
+OIIOTOOL_INPLACE_OP(line, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
     img[0]->copy(*img[1]);
     const ImageSpec& Rspec(img[0]->spec());
     std::vector<int> points;
@@ -4983,7 +4995,7 @@ OIIOTOOL_OP(line, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 
 // --point
-OIIOTOOL_OP(point, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
+OIIOTOOL_INPLACE_OP(point, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
     img[0]->copy(*img[1]);
     const ImageSpec& Rspec(img[0]->spec());
     std::vector<int> points;
@@ -5000,7 +5012,7 @@ OIIOTOOL_OP(point, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 
 // --text
-OIIOTOOL_OP(text, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
+OIIOTOOL_INPLACE_OP(text, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
     img[0]->copy(*img[1]);
     const ImageSpec& Rspec(img[0]->spec());
     int x            = op.options().get_int("x", Rspec.x + Rspec.width / 2);

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4953,7 +4953,8 @@ OIIOTOOL_OP(contrast, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
 // --box
 // clang-format off
 OIIOTOOL_INPLACE_OP(box, 1, nullptr, ([&](OiiotoolOp& op, span<ImageBuf*> img) {
-    img[0]->copy(*img[1]);
+    OIIO_ASSERT(img[0] == img[1]);  // Assume we're operating in-place
+    // img[0]->copy(*img[1]);  // what we'd do if we weren't in-place
     const ImageSpec& Rspec(img[0]->spec());
     int x1, y1, x2, y2;
     string_view s(op.args(1));
@@ -4976,7 +4977,8 @@ OIIOTOOL_INPLACE_OP(box, 1, nullptr, ([&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 // --line
 OIIOTOOL_INPLACE_OP(line, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
-    img[0]->copy(*img[1]);
+    OIIO_ASSERT(img[0] == img[1]);  // Assume we're operating in-place
+    // img[0]->copy(*img[1]);  // what we'd do if we weren't in-place
     const ImageSpec& Rspec(img[0]->spec());
     std::vector<int> points;
     Strutil::extract_from_list_string(points, op.args(1));
@@ -4996,7 +4998,8 @@ OIIOTOOL_INPLACE_OP(line, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 // --point
 OIIOTOOL_INPLACE_OP(point, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
-    img[0]->copy(*img[1]);
+    OIIO_ASSERT(img[0] == img[1]);  // Assume we're operating in-place
+    // img[0]->copy(*img[1]);  // what we'd do if we weren't in-place
     const ImageSpec& Rspec(img[0]->spec());
     std::vector<int> points;
     Strutil::extract_from_list_string(points, op.args(1));


### PR DESCRIPTION
These commands, which are intended to alter the top image on the stack, were each allocating and copying an image unnecessarily for each operation. By changing the implementation to the right calls that know it doesn't need to make a copy (already a feature I'd implemented in the OiiotoolOp helper class) greatly speeds them up.
