### PR TITLE
docs: Clarify 'copy_image' example

### DIFF
--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -1455,7 +1455,7 @@ without alteration while modifying the image description metadata:
   
       // Create the output file and copy the image
       auto out = ImageOutput::create ("output.jpg");
-      out->open (output, out_spec);
+      out->open ("output.jpg", out_spec);
       out->copy_image (in);
   
       // Clean up
@@ -1473,7 +1473,7 @@ without alteration while modifying the image description metadata:
   
       # Create the output file and copy the image
       out = ImageOutput.create ("output.jpg")
-      out.open (output, out_spec)
+      out.open ("output.jpg", out_spec)
       out.copy_image (inp)
   
       # Clean up


### PR DESCRIPTION
It was pointed out on Slack that this example was unclear as to what should be passed to open().
