### PR TITLE
api: Add API to query available font families and styles

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -386,6 +386,37 @@ ROI OIIO_API text_size (string_view text, int fontsize=16,
                         string_view fontname="");
 
 
+/// Return the list of available font families in alphabetical order,
+/// such as "Arial", "Times New Roman", etc.
+/// Fonts are read from system font folders, folders defined by
+/// the global `font_searchpath` attribute or the `OPENIMAGEIO_FONTS`
+/// or `OpenImageIO_ROOT` environment variables.
+const std::vector<std::string>& OIIO_API font_families();
+
+
+/// Return the list of available font styles of a given font family,
+/// such as "Regular", "Bold", "Italic", etc.
+///
+/// @param  family
+///             Font family name.
+///
+const std::vector<std::string> OIIO_API font_styles(string_view family);
+
+
+/// Return the font filename that defines the font with the given 
+/// family and style, or an empty string if the font does not exist.
+///
+/// @param  family
+///             Font family name.
+///
+/// @param  style
+///             Font style name. If not given that means the 'Regular'
+///             style (if exists).
+///
+const std::string OIIO_API font_filename(string_view family, 
+                                         string_view style = "");
+
+
 /// Generic channel shuffling: return (or store in `dst`) a copy of `src`,
 /// but with channels in the order `channelorder[0..nchannels-1]` (or set to
 /// a constant value, designated by `channelorder[i] = -1` and having the

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -391,7 +391,7 @@ ROI OIIO_API text_size (string_view text, int fontsize=16,
 /// Fonts are read from system font folders, folders defined by
 /// the global `font_searchpath` attribute or the `OPENIMAGEIO_FONTS`
 /// or `OpenImageIO_ROOT` environment variables.
-const std::vector<std::string>& OIIO_API font_families();
+OIIO_API const std::vector<std::string>& font_families();
 
 
 /// Return the list of available font styles of a given font family,
@@ -400,7 +400,7 @@ const std::vector<std::string>& OIIO_API font_families();
 /// @param  family
 ///             Font family name.
 ///
-const std::vector<std::string> OIIO_API font_styles(string_view family);
+OIIO_API const std::vector<std::string> font_styles(string_view family);
 
 
 /// Return the font filename that defines the font with the given 
@@ -413,7 +413,7 @@ const std::vector<std::string> OIIO_API font_styles(string_view family);
 ///             Font style name. If not given that means the 'Regular'
 ///             style (if exists).
 ///
-const std::string OIIO_API font_filename(string_view family, 
+OIIO_API const std::string font_filename(string_view family, 
                                          string_view style = "");
 
 
@@ -1628,9 +1628,7 @@ bool OIIO_API convolve (ImageBuf &dst, const ImageBuf &src, const ImageBuf &kern
 /// Laplacian kernel,
 ///
 ///                     [ 0  1  0 ]
-///                     [ 1 -4  1 ]
 ///                     [ 0  1  0 ]
-///
 ImageBuf OIIO_API laplacian (const ImageBuf &src, ROI roi={}, int nthreads=0);
 /// Write to an existing image `dst` (allocating if it is uninitialized).
 bool OIIO_API laplacian (ImageBuf &dst, const ImageBuf &src,

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1628,7 +1628,9 @@ bool OIIO_API convolve (ImageBuf &dst, const ImageBuf &src, const ImageBuf &kern
 /// Laplacian kernel,
 ///
 ///                     [ 0  1  0 ]
+///                     [ 1 -4  1 ]
 ///                     [ 0  1  0 ]
+///
 ImageBuf OIIO_API laplacian (const ImageBuf &src, ROI roi={}, int nthreads=0);
 /// Write to an existing image `dst` (allocating if it is uninitialized).
 bool OIIO_API laplacian (ImageBuf &dst, const ImageBuf &src,

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -386,37 +386,6 @@ ROI OIIO_API text_size (string_view text, int fontsize=16,
                         string_view fontname="");
 
 
-/// Return the list of available font families in alphabetical order,
-/// such as "Arial", "Times New Roman", etc.
-/// Fonts are read from system font folders, folders defined by
-/// the global `font_searchpath` attribute or the `OPENIMAGEIO_FONTS`
-/// or `OpenImageIO_ROOT` environment variables.
-OIIO_API const std::vector<std::string>& font_families();
-
-
-/// Return the list of available font styles of a given font family,
-/// such as "Regular", "Bold", "Italic", etc.
-///
-/// @param  family
-///             Font family name.
-///
-OIIO_API const std::vector<std::string> font_styles(string_view family);
-
-
-/// Return the font filename that defines the font with the given 
-/// family and style, or an empty string if the font does not exist.
-///
-/// @param  family
-///             Font family name.
-///
-/// @param  style
-///             Font style name. If not given that means the 'Regular'
-///             style (if exists).
-///
-OIIO_API const std::string font_filename(string_view family, 
-                                         string_view style = "");
-
-
 /// Generic channel shuffling: return (or store in `dst`) a copy of `src`,
 /// but with channels in the order `channelorder[0..nchannels-1]` (or set to
 /// a constant value, designated by `channelorder[i] = -1` and having the

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3039,6 +3039,21 @@ inline bool attribute (string_view name, string_view val) {
 ///   full paths), and all the directories that OpenImageIO will search for
 ///   fonts.  (Added in OpenImageIO 2.5)
 ///
+/// - `string font_family_list`
+///
+///   A semicolon-separated list of all the font family names that
+///   OpenImageIO can find.  (Added in OpenImageIO 3.0)
+///
+/// - `string font_style_list:family`
+///
+///   A semicolon-separated list of all the font style names that
+///   belong to the given font family.  (Added in OpenImageIO 3.0)
+///
+/// - `string font_filename:family:style`
+///
+///   The font file (with full path) that defines the given font
+///   family and style.  (Added in OpenImageIO 3.0)
+///
 /// - `string filter_list`
 ///
 ///   A semicolon-separated list of all built-in 2D filters. (Added in

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -62,9 +62,7 @@ font_family_list();
 OIIO_API const std::vector<std::string>
 font_style_list(string_view family);
 OIIO_API const std::string
-font_filename(string_view family, 
-              string_view style = "");
-
+font_filename(string_view family, string_view style = "");
 
 
 // Make sure all plugins are inventoried. For internal use only.

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -57,6 +57,13 @@ OIIO_API const std::vector<std::string>&
 font_file_list();
 OIIO_API const std::vector<std::string>&
 font_list();
+OIIO_API const std::vector<std::string>&
+font_family_list();
+OIIO_API const std::vector<std::string>
+font_style_list(string_view family);
+OIIO_API const std::string
+font_filename(string_view family, 
+              string_view style = "");
 
 
 

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -1319,7 +1319,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
 
 
 const std::vector<std::string>&
-ImageBufAlgo::font_families()
+pvt::font_family_list()
 {
 #ifdef USE_FREETYPE
     lock_guard ft_lock(ft_mutex);
@@ -1330,7 +1330,7 @@ ImageBufAlgo::font_families()
 
 
 const std::vector<std::string>
-ImageBufAlgo::font_styles(string_view family)
+pvt::font_style_list(string_view family)
 {
 #ifdef USE_FREETYPE
     lock_guard ft_lock(ft_mutex);
@@ -1345,7 +1345,7 @@ ImageBufAlgo::font_styles(string_view family)
 
 
 const std::string
-ImageBufAlgo::font_filename(string_view family, string_view style)
+pvt::font_filename(string_view family, string_view style)
 {
     if (family.empty())
         return std::string();

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -1318,4 +1318,55 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
 
 
 
+const std::vector<std::string>&
+ImageBufAlgo::font_families()
+{
+#ifdef USE_FREETYPE
+    lock_guard ft_lock(ft_mutex);
+    init_font_families();
+#endif
+    return s_font_families;
+}
+
+
+const std::vector<std::string>
+ImageBufAlgo::font_styles(string_view family)
+{
+#ifdef USE_FREETYPE
+    lock_guard ft_lock(ft_mutex);
+    init_font_families();
+#endif
+    auto it = s_font_styles.find(family);
+    if (it != s_font_styles.end())
+        return it->second;
+    else
+        return std::vector<std::string>();
+}
+
+
+const std::string
+ImageBufAlgo::font_filename(string_view family, 
+                            string_view style)
+{
+   if (family.empty())
+      return std::string();
+
+#ifdef USE_FREETYPE
+    lock_guard ft_lock(ft_mutex);
+    init_font_families();
+#endif
+
+   std::string font = family;
+   if (!style.empty())
+      font = Strutil::fmt::format("{} {}", family, style);
+
+   auto it = s_font_filename_per_family.find(font);
+   if (it != s_font_filename_per_family.end())
+      return it->second;
+   else
+      return std::string();
+}
+
+
+
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -1345,26 +1345,25 @@ ImageBufAlgo::font_styles(string_view family)
 
 
 const std::string
-ImageBufAlgo::font_filename(string_view family, 
-                            string_view style)
+ImageBufAlgo::font_filename(string_view family, string_view style)
 {
-   if (family.empty())
-      return std::string();
+    if (family.empty())
+        return std::string();
 
 #ifdef USE_FREETYPE
     lock_guard ft_lock(ft_mutex);
     init_font_families();
 #endif
 
-   std::string font = family;
-   if (!style.empty())
-      font = Strutil::fmt::format("{} {}", family, style);
+    std::string font = family;
+    if (!style.empty())
+        font = Strutil::fmt::format("{} {}", family, style);
 
-   auto it = s_font_filename_per_family.find(font);
-   if (it != s_font_filename_per_family.end())
-      return it->second;
-   else
-      return std::string();
+    auto it = s_font_filename_per_family.find(font);
+    if (it != s_font_filename_per_family.end())
+        return it->second;
+    else
+        return std::string();
 }
 
 

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -505,6 +505,23 @@ getattribute(string_view name, TypeDesc type, void* val)
         *(ustring*)val = ustring(Strutil::join(font_list(), ";"));
         return true;
     }
+    if (name == "font_family_list" && type == TypeString) {
+        *(ustring*)val = ustring(Strutil::join(font_family_list(), ";"));
+        return true;
+    }
+    if (Strutil::starts_with(name, "font_style_list:") && type == TypeString) {
+        string_view family = name.substr(strlen("font_style_list:"));
+        *(ustring*)val = ustring(Strutil::join(font_style_list(family), ";"));
+        return true;
+    }
+    if (Strutil::starts_with(name, "font_filename:") && type == TypeString) {
+        std::vector<string_view> tokens;
+        Strutil::split(name, tokens, ":");
+        string_view family = tokens.size() >= 1 ? tokens[1] : string_view();
+        string_view style = tokens.size() >= 2 ? tokens[2] : string_view();
+        *(ustring*)val = ustring(font_filename(family, style));
+        return true;
+    }
     if (name == "filter_list" && type == TypeString) {
         std::vector<string_view> filternames;
         for (int i = 0, e = Filter2D::num_filters(); i < e; ++i)

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -518,8 +518,8 @@ getattribute(string_view name, TypeDesc type, void* val)
         std::vector<string_view> tokens;
         Strutil::split(name, tokens, ":");
         string_view family = tokens.size() >= 1 ? tokens[1] : string_view();
-        string_view style = tokens.size() >= 2 ? tokens[2] : string_view();
-        *(ustring*)val = ustring(font_filename(family, style));
+        string_view style  = tokens.size() >= 2 ? tokens[2] : string_view();
+        *(ustring*)val     = ustring(font_filename(family, style));
         return true;
     }
     if (name == "filter_list" && type == TypeString) {


### PR DESCRIPTION
## Description

Fixes #4503.

Add an API to query available fonts based on family and style name. The API can be used to build a UI where users can select a font from a list.

- **font_families()**: Return the list of available font families in alphabetical order.
- **font_styles(family)**: Return the list of available font styles of a given font family.
- **font_filename(family, style)**: Return the font filename that defines the font with the given family and style.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
