### PR TITLE
fix(exr): allow an empty "name" metadata to be read

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -652,7 +652,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
     }
 
     // EXR "name" also gets passed along as "oiio:subimagename".
-    if (header->hasName() && header->name() != "")
+    if (header->hasName())
         spec.attribute("oiio:subimagename", header->name());
 
     spec.attribute("oiio:subimages", in->m_nsubimages);


### PR DESCRIPTION
When the exr "name" metadata (used for the names of subimages/parts) existed but was the empty string, we were treating it like it didn't exist (and upon write substituted our own "subimageXY" name, as we are wont to do for unnamed parts). But now we've seen multi-part exrs where the name is "" (exists, but empty string) and we want a read-write cycle to preserve that. Even though it's not a very sensible or helpful part name, it's technically legal, so we should honor it.
