### PR TITLE
fix(exr): allow an empty "name" metadata to be read

### DIFF
--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -757,7 +757,7 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
     // EXR "name" also gets passed along as "oiio:subimagename".
     const char* partname;
     if (exr_get_name(ctxt, subimage, &partname) == EXR_ERR_SUCCESS) {
-        if (partname && partname[0] != '\0')
+        if (partname)
             spec.attribute("oiio:subimagename", partname);
     }
 


### PR DESCRIPTION
Continuation of PR #4528. I forgot to change the spot in the OpenEXR "core" API as well.
