### PR TITLE
build: Use target_compile_options

### DIFF
--- a/src/cmake/add_oiio_plugin.cmake
+++ b/src/cmake/add_oiio_plugin.cmake
@@ -12,6 +12,7 @@
 #                   [ SRC source1 ... ]
 #                   [ INCLUDE_DIRS include_dir1 ... ]
 #                   [ LINK_LIBRARIES external_lib1 ... ]
+#                   [ COMPILE_OPTIONS -Wflag ... ]
 #                   [ DEFINITIONS FOO=bar ... ])
 #
 # The plugin name can be specified with NAME, otherwise is inferred from the
@@ -34,7 +35,7 @@
 # be handed off too the setup of the later OpenImageIO target.
 #
 macro (add_oiio_plugin)
-    cmake_parse_arguments (_plugin "" "NAME" "SRC;INCLUDE_DIRS;LINK_LIBRARIES;DEFINITIONS" ${ARGN})
+    cmake_parse_arguments (_plugin "" "NAME" "SRC;INCLUDE_DIRS;LINK_LIBRARIES;COMPILE_OPTIONS;DEFINITIONS" ${ARGN})
        # Arguments: <prefix> <options> <one_value_keywords> <multi_value_keywords> args...
     get_filename_component (_plugin_name ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
     if (NOT _plugin_NAME)
@@ -61,6 +62,7 @@ macro (add_oiio_plugin)
             endforeach ()
             set (libOpenImageIO_srcs "${_plugin_all_source}" PARENT_SCOPE)
             set (format_plugin_definitions ${format_plugin_definitions} ${_plugin_DEFINITIONS} PARENT_SCOPE)
+            set (format_plugin_compile_options ${format_plugin_compile_options} ${_plugin_COMPILE_OPTIONS} PARENT_SCOPE)
             set (format_plugin_include_dirs ${format_plugin_include_dirs} ${_plugin_INCLUDE_DIRS} PARENT_SCOPE)
             set (format_plugin_libs ${format_plugin_libs} ${_plugin_LINK_LIBRARIES} PARENT_SCOPE)
         else ()
@@ -70,6 +72,7 @@ macro (add_oiio_plugin)
             target_compile_definitions (${_plugin_NAME} PRIVATE
                                         ${_plugin_DEFINITIONS}
                                         OpenImageIO_EXPORTS)
+            target_compile_options (${_plugin_NAME} PRIVATE ${_plugin_COMPILE_OPTIONS})
             target_include_directories (${_plugin_NAME} BEFORE PRIVATE ${_plugin_INCLUDE_DIRS})
             target_link_libraries (${_plugin_NAME} PUBLIC OpenImageIO
                                                    PRIVATE ${_plugin_LINK_LIBRARIES})

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -88,6 +88,8 @@ if (EMBEDPLUGINS)
                                 PRIVATE
                                     EMBED_PLUGINS=1
                                     ${format_plugin_definitions})
+    target_compile_options (OpenImageIO
+                            PRIVATE ${format_plugin_compile_options})
     target_include_directories (OpenImageIO BEFORE
                                 PRIVATE ${format_plugin_include_dirs})
 

--- a/src/raw.imageio/CMakeLists.txt
+++ b/src/raw.imageio/CMakeLists.txt
@@ -6,7 +6,8 @@ if (LIBRAW_FOUND)
     add_oiio_plugin (rawinput.cpp
                      INCLUDE_DIRS ${LibRaw_INCLUDE_DIR}
                      LINK_LIBRARIES ${LibRaw_r_LIBRARIES}
-                     DEFINITIONS "USE_LIBRAW=1" ${LibRaw_r_DEFINITIONS})
+                     COMPILE_OPTIONS ${LibRaw_r_DEFINITIONS}
+                     DEFINITIONS "USE_LIBRAW=1")
 else ()
     message (WARNING "Raw plugin will not be built")
 endif ()


### PR DESCRIPTION
## Description

When using pkgconfig the value of `<NAME>_CFLAGS_OTHER` can contain compiler flags along with preprocessor definitions. If there is a compiler flag and its passed to `target_compile_definitions` then it will be treated as if it is a preprocessor definition.

Found a case where a statically compiled LibRaw with a statically compiled Little-CMS caused `LibRaw_DEFINITIONS` to have `-pthread` in its listing which was passed to the compiler as a definition, `-D-pthread`. This caused a build failure with `auto-moc`.

Add an additional parameter for the `add_oiio_plugin` macro to take `COMPILE_OPTIONS` and pass those to `target_compile_options` which can differentiate between compiler flags and preprocessor definitions. Pass `LibRaw_DEFINITIONS` to the CMake macro to prevent the above error.

## Tests

Issue found while updating Little-CMS in https://github.com/microsoft/vcpkg/pull/42187 and the change fixes the build issue found there. This is an attempt to upstream it so the issue is fixed.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [X] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
