### PR TITLE
fix: some LoggedTimer instances lacked a variable name

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1500,7 +1500,7 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
     }
     bool ok = true;
     ok &= m_impl->validate_pixels();
-    pvt::LoggedTimer("IB::write inner");
+    pvt::LoggedTimer logtime("IB::write inner");
     if (out->supports("thumbnail") && has_thumbnail()) {
         auto thumb = get_thumbnail();
         // Strutil::print("IB::write: has thumbnail ROI {}\n", thumb->roi());
@@ -1617,7 +1617,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
                 ProgressCallback progress_callback,
                 void* progress_callback_data) const
 {
-    pvt::LoggedTimer("IB::write");
+    pvt::LoggedTimer logtime("IB::write");
     string_view filename   = _filename.size() ? _filename : string_view(name());
     string_view fileformat = _fileformat.size() ? _fileformat : filename;
     if (filename.size() == 0) {

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -487,7 +487,7 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
                          ProgressCallback progress_callback,
                          void* progress_callback_data)
 {
-    pvt::LoggedTimer("ImageOutput::write image");
+    pvt::LoggedTimer logtime("ImageOutput::write image");
     bool native          = (format == TypeDesc::UNKNOWN);
     stride_t pixel_bytes = native ? (stride_t)m_spec.pixel_bytes(native)
                                   : format.size() * m_spec.nchannels;

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1348,7 +1348,7 @@ TIFFOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
                             const void* data, stride_t xstride,
                             stride_t ystride)
 {
-    pvt::LoggedTimer("TIFFOutput::write_scanlines");
+    pvt::LoggedTimer logger("TIFFOutput::write_scanlines");
     // If the stars all align properly, try to write strips, and use the
     // thread pool to parallelize the compression. This can give a large
     // speedup (5x or more!) because the zip compression dwarfs the
@@ -1575,7 +1575,7 @@ TIFFOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
                         int zend, TypeDesc format, const void* data,
                         stride_t xstride, stride_t ystride, stride_t zstride)
 {
-    pvt::LoggedTimer("TIFFOutput::write_tiles");
+    pvt::LoggedTimer logger("TIFFOutput::write_tiles");
     if (!m_spec.valid_tile_range(xbegin, xend, ybegin, yend, zbegin, zend))
         return false;
 


### PR DESCRIPTION
It was syntactically correct, but without an actual variable, there was no RAII scope and so it destructs immediately, causing the timers to capture 0 time.

Found by Sonar warnings.
