### PR TITLE
fix: various internal fixes to address Sonar and other warnings

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.links.issue=https://github.com/AcademySoftwareFoundation/OpenImageIO/issue
 
 # Source properties
 sonar.sources=src
-sonar.exclusions=src/doc/**,src/include/OpenImageIO/detail/pugixml/**,src/libutil/stb_sprintf.h,src/libutil/xxhash.cpp,src/include/OpenImageIO/detail/farmhash.h,src/libutil/farmhash.cpp
+sonar.exclusions=src/doc/**,src/build-scripts/**,src/include/OpenImageIO/detail/pugixml/**,src/libutil/stb_sprintf.h,src/libutil/xxhash.cpp,src/include/OpenImageIO/detail/farmhash.h,src/libutil/farmhash.cpp
 sonar.sourceEncoding=UTF-8
 
 # C/C++ analyzer properties

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -104,7 +104,7 @@ private:
 
     /// Helper function - set keycode values from int array
     ///
-    void set_keycode_values(int* array);
+    void set_keycode_values(cspan<int> array);
 };
 
 
@@ -370,8 +370,7 @@ DPXOutput::open(const std::string& name, const ImageSpec& userspec,
 
     ParamValue* kc = spec0.find_attribute("smpte:KeyCode", TypeKeyCode, false);
     if (kc) {
-        int* array = (int*)kc->data();
-        set_keycode_values(array);
+        set_keycode_values(cspan<int>((int*)kc->data(), 7));
 
         // See if there is an overloaded dpx:Format
         std::string format = spec0.get_string_attribute("dpx:Format", "");
@@ -727,7 +726,7 @@ DPXOutput::get_image_descriptor()
 
 
 void
-DPXOutput::set_keycode_values(int* array)
+DPXOutput::set_keycode_values(cspan<int> array)
 {
     // Manufacturer code
     {
@@ -760,8 +759,8 @@ DPXOutput::set_keycode_values(int* array)
     }
 
     // Format
-    int& perfsPerFrame = array[5];
-    int& perfsPerCount = array[6];
+    int perfsPerFrame = array[5];
+    int perfsPerCount = array[6];
 
     if (perfsPerFrame == 15 && perfsPerCount == 120) {
         Strutil::safe_strcpy(m_dpx.header.format, "8kimax",

--- a/src/include/OpenImageIO/benchmark.h
+++ b/src/include/OpenImageIO/benchmark.h
@@ -243,11 +243,11 @@ private:
     size_t m_trials          = 10;
     size_t m_work            = 1;
     std::string m_name;
-    std::vector<double> m_times;  // times for each trial
-    double m_avg;                 // average time per iteration
-    double m_stddev;              // standard deviation per iteration
-    double m_range;               // range per iteration
-    double m_median;              // median per-iteration time
+    std::vector<double> m_times;   // times for each trial
+    double m_avg           = 0.0;  // average time per iteration
+    double m_stddev        = 0.0;  // standard deviation per iteration
+    double m_range         = 0.0;  // range per iteration
+    double m_median        = 0.0;  // median per-iteration time
     int m_exclude_outliers = 1;
     int m_verbose          = 1;
     int m_indent           = 0;

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -760,9 +760,9 @@ ColorConfig::Impl::identify_builtin_equivalents()
 const char*
 ColorConfig::Impl::IdentifyBuiltinColorSpace(const char* name) const
 {
+#if OCIO_VERSION_HEX >= MAKE_OCIO_VERSION_HEX(2, 3, 0)
     if (!config_ || disable_builtin_configs)
         return nullptr;
-#if OCIO_VERSION_HEX >= MAKE_OCIO_VERSION_HEX(2, 3, 0)
     try {
         return OCIO::Config::IdentifyBuiltinColorSpace(config_, builtinconfig_,
                                                        name);

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -1003,9 +1003,8 @@ Filesystem::scan_for_matching_filenames(const std::string& pattern,
         // case 3: pattern has format, but no view
         return scan_for_matching_filenames(pattern, frame_numbers, filenames);
     }
-
-    return true;
 }
+
 
 bool
 Filesystem::scan_for_matching_filenames(const std::string& pattern_,
@@ -1285,10 +1284,6 @@ Filesystem::IOFile::pwrite(const void* buf, size_t size, int64_t offset)
     // FIXME: the system pwrite returns ssize_t and is -1 on error.
     return r < 0 ? size_t(0) : size_t(r);
 #endif
-    offset += r;
-    if (m_pos > int64_t(m_size))
-        m_size = offset;
-    return r;
 }
 
 size_t

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -552,9 +552,8 @@ Sysutil::put_in_background(int argc, char* argv[])
     // Simplest case:
     // daemon returns 0 if successful, thus return true if successful
     return daemon(1, 1) == 0;
-#endif
 
-#if defined(__APPLE__) && TARGET_OS_OSX
+#elif defined(__APPLE__) && TARGET_OS_OSX
     std::string newcmd = std::string(argv[0]) + " -F";
     for (int i = 1; i < argc; ++i) {
         newcmd += " \"";
@@ -565,14 +564,14 @@ Sysutil::put_in_background(int argc, char* argv[])
     if (system(newcmd.c_str()) != -1)
         exit(0);
     return true;
-#endif
 
-#ifdef _WIN32
+#elif defined(_WIN32)
     return true;
-#endif
 
+#else
     // Otherwise, we don't know what to do
     return false;
+#endif
 }
 
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1209,6 +1209,7 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             m_input_rgba->readPixels(ybegin, yend - 1);
 
             // FIXME There is probably some optimized code for this somewhere.
+            OIIO_DASSERT(chbegin >= 0 && chend > chbegin);
             for (int c = chbegin; c < chend; ++c) {
                 size_t chanbytes = m_spec.channelformat(c).size();
                 half* src        = &pixels[0][0].r + c;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1066,10 +1066,10 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
                                   Imf::FloatAttribute((float)*(half*)data));
                     return true;
                 }
-                if (type == TypeString && *(const char**)data) {
+                if (type == TypeString && !((const ustring*)data)->empty()) {
                     header.insert(xname.c_str(),
                                   Imf::StringAttribute(
-                                      *(const char**)data));  //NOSONAR
+                                      ((const ustring*)data)->c_str()));
                     return true;
                 }
                 if (type == TypeDesc::DOUBLE) {


### PR DESCRIPTION
Chipping away at minor warnings and areas identified by static analysis as potentially problematic or hard to analyze.

* benchmark.h: suppress warnings about uninitialized Benchmarker members.
* dpxoutput.cpp: change some raw pointers to spans
* dead code removal (color_ocio.cpp, filesystem.cpp, sysutil.cpp)
* exclude build-scripts from static analysis
* some misc warning suppression
