### PR TITLE
[feat]IBA:demosaic add X-Trans demosaicing

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -4212,13 +4212,17 @@ current top image.
     Optional appended modifiers include:
 
       `pattern=` *name*
-        sensor pattern. Currently supported patterns: "bayer"
+        sensor pattern. Currently supported patterns: "bayer", "xtrans".
       `layout=` *name*
-        photosite order of the specified pattern. For layouts of the Bayer
-        pattern supported: "RGGB", "GRBG", "GBRG", "BGGR".
+        photosite order of the specified pattern. The default value is "RGGB"
+        for Bayer, and "GRBGBR BGGRGG RGGBGG GBRGRB RGGBGG BGGRGG" for X-Trans.
       `algorithm=` *name*
-        the name of the algorithm to use: "linear"(simple bilinear demosaicing),
-        "MHC"(Malvar-He-Cutler algorithm)
+        the name of the algorithm to use.
+        The Bayer-pattern algorithms:
+        - "linear"(simple bilinear demosaicing),
+        - "MHC"(Malvar-He-Cutler algorithm).
+        The X-Trans-pattern algorithms:
+        - "linear"(simple bilinear demosaicing).
       `white-balance=` *v1,v2,v3...*
         optional white balance weights, can contain either three (R,G,B) or four
         (R,G1,B,G2) values. The order of the white balance multipliers is as

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3701,9 +3701,10 @@ Color manipulation
                 bool ImageBufAlgo.demosaic (dst, src, pattern="", algorithm="", layout="", white_balance=py::none(), roi=ROI.All, nthreads=0)
     Demosaic a raw digital camera image.
 
-    `demosaic` can currently process Bayer pattern images (pattern="bayer")
+    `demosaic` can currently process Bayer-pattern images (pattern="bayer")
     using two algorithms: "linear" (simple bilinear demosaicing), and "MHC"
-    (Malvar-He-Cutler algorithm). The optional white_balance parameter can take
+    (Malvar-He-Cutler algorithm); or X-Trans-pattern images (pattern="xtrans")
+    using "linear" algorithm. The optional white_balance parameter can take
     a tuple of three (R,G,B), or four (R,G1,B,G2) values. The order of the
     white balance multipliers is as specified, it does not depend on the matrix
     layout.

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -2164,7 +2164,9 @@ bool OIIO_API repremult (ImageBuf &dst, const ImageBuf &src,
 ///
 ///   - "pattern" : string (default: "bayer")
 ///
-///     The type of image sensor color filter array. Currently only the Bayer-pattern images are supported.
+///     The type of image sensor color filter array. Currently suported patterns:
+///     - `bayer` - Bayer-pattern image.
+///     - `xtrans` - X-Trans-pattern image.
 ///
 ///   - "algorithm" : string (default: "linear")
 ///
@@ -2174,11 +2176,14 @@ bool OIIO_API repremult (ImageBuf &dst, const ImageBuf &src,
 ///     - `MHC` - Malvar-He-Cutler linear demosaicing algorithm. Slower than `linear`, but produces 
 ///       significantly better results.
 ///
-///   - "layout" : string (default: "RGGB")
+///     The following algorithms are supported for X-Trans-pattern images:
+///     - `linear` - simple linear demosaicing. Fast, but can produce artefacts along sharp edges.
+///
+///   - "layout" : string (default: "RGGB" for Bayer, "GRBGBR BGGRGG RGGBGG GBRGRB RGGBGG BGGRGG" for X-Trans)
 ///
 ///     The order the color filter array elements are arranged in, pattern-specific.
 ///
-///   - "white-balance" : float[3] or float[4] (default: {1.0, 1.0, 1.0, 1.0})
+///   - "white-balance" : float[3] or float[4], (default: {1.0, 1.0, 1.0, 1.0})
 ///
 ///     Optional white-balancing weights. Can contain either three (R,G,B), or four (R,G1,B,G2) values.
 ///     The order of the white balance multipliers does not depend on the matrix layout.

--- a/src/libOpenImageIO/imagebufalgo_demosaic.cpp
+++ b/src/libOpenImageIO/imagebufalgo_demosaic.cpp
@@ -80,8 +80,8 @@ protected:
         Window(int y, int xbegin, const ImageBuf& src, int x_offset,
                int y_offset, const float (&white_balance_values)[4])
         {
-            assert(window_size >= 3);
-            assert(window_size % 2 == 1);
+            OIIO_DASSERT(window_size >= 3);
+            OIIO_DASSERT(window_size % 2 == 1);
 
             const ImageSpec& spec = src.spec();
             src_xbegin            = spec.x;
@@ -283,7 +283,7 @@ public:
         for (size_t y = 0; y < pattern_size; y++) {
             for (size_t x = 0; x < pattern_size; x++) {
                 int c = channel_at_offset(x + x_offset, y + y_offset);
-                assert(c < 4);
+                OIIO_DASSERT(c < 4);
 
                 layout[i] = channels[c];
                 i++;

--- a/src/libOpenImageIO/imagebufalgo_demosaic.cpp
+++ b/src/libOpenImageIO/imagebufalgo_demosaic.cpp
@@ -9,6 +9,7 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
 
+#include "imagebufalgo_demosaic_prv.h"
 #include "imageio_pvt.h"
 
 OIIO_NAMESPACE_BEGIN
@@ -22,7 +23,11 @@ static const ustring white_balance_us("white_balance");
 
 }  // namespace
 
-template<class Rtype, class Atype, int size> class BayerDemosaicing {
+namespace ImageBufAlgo {
+
+template<class Rtype, class Atype, int pattern_size, int window_size,
+         const size_t channel_map[pattern_size][pattern_size]>
+class DemosaicingBase {
 protected:
     /// Sliding window, holds `size*size` pixel values to filter over.
     /// The `size` is expected to be an odd number, so the pixel being
@@ -32,15 +37,31 @@ protected:
         /// the source iterator.
         struct Row {
             ImageBuf::ConstIterator<Atype> iterator;
-            float white_balance[2];
+
             int x_offset;
-            float data[size];
+            const int y_offset;
+            const float (&white_balance_values)[4];
+
+            float data[window_size];
 
             float fetch()
             {
-                float result = iterator[0] * white_balance[x_offset];
-                iterator++;
-                x_offset = 1 - x_offset;
+                float white_balance
+                    = white_balance_values[channel_map[y_offset][x_offset]];
+                float result = iterator[0] * white_balance;
+
+                if (iterator.x() == iterator.range().xend - 1) {
+                    // When we have reached the rightmost pixel, jump back by
+                    // `pattern_size` pixels to re-fetch the last available
+                    // column of the pixels with the required channel layout.
+                    iterator.pos(iterator.x() - pattern_size + 1, iterator.y());
+                } else {
+                    iterator++;
+                }
+
+                x_offset++;
+                if (x_offset == pattern_size)
+                    x_offset = 0;
                 return result;
             }
         };
@@ -49,28 +70,26 @@ protected:
 
         /// Column mapping. Insead of shifting every pixel value as the sliding
         /// window advances, we just rotate the indices in this table.
-        int column_mapping[size];
+        int column_mapping[window_size];
 
         int src_xbegin;
         int src_xend;
         int src_ybegin;
         int src_yend;
-        int x;
 
         Window(int y, int xbegin, const ImageBuf& src, int x_offset,
-               int y_offset, const float white_balance[4])
+               int y_offset, const float (&white_balance_values)[4])
         {
-            assert(size >= 3);
-            assert(size % 2 == 1);
+            assert(window_size >= 3);
+            assert(window_size % 2 == 1);
 
             const ImageSpec& spec = src.spec();
             src_xbegin            = spec.x;
             src_xend              = spec.x + spec.width;
             src_ybegin            = spec.y;
             src_yend              = spec.y + spec.height;
-            x                     = xbegin;
 
-            int central = size / 2;
+            int central = window_size / 2;
 
             int skip = src_xbegin - xbegin + central;
             if (skip < 0)
@@ -78,31 +97,53 @@ protected:
 
             int xstart = xbegin - central + skip;
 
-            for (int i = 0; i < size; i++) {
+            for (int i = 0; i < window_size; i++) {
                 column_mapping[i] = i;
             }
 
-            for (int i = 0; i < size; i++) {
+            for (int i = 0; i < window_size; i++) {
                 int ystart = y - central + i;
-                if (ystart < src_ybegin) {
-                    ystart = src_ybegin + (src_ybegin - ystart) % 2;
-                } else if (ystart > src_yend - 1) {
-                    ystart = src_yend - 1 - (ystart - src_yend + 1) % 2;
+                while (ystart < src_ybegin) {
+                    ystart += pattern_size;
+                }
+                while (ystart > src_yend - 1) {
+                    ystart -= pattern_size;
                 }
 
-                int x_off = (xstart + x_offset) % 2;
-                int y_off = ((ystart + y_offset) % 2) * 2;
+                int x_off = (xstart + x_offset) % pattern_size;
+                int y_off = (ystart + y_offset) % pattern_size;
 
                 Row row = { ImageBuf::ConstIterator<Atype>(src, xstart, ystart),
-                            { white_balance[y_off], white_balance[y_off + 1] },
-                            x_off };
+                            x_off, y_off, white_balance_values };
 
-                for (int j = skip; j < size; j++) {
+                // Fill the window with the values needed to process the first
+                // (leftmost) pixel. First fetch the pixels which are directly
+                // available in the image. We may need to skip a few columns,
+                // as the image doesn't have any pixels to the left of the first
+                // pixel of the row.
+                for (int j = skip; j < window_size; j++) {
                     row.data[j] = row.fetch();
                 }
 
+                // Now fill in the columns we had skipped. First, check if the
+                // rows we have already filled in have one with the same channel
+                // layout we need. If so, just copy the values. Otherwise
+                // calculate which column of the image would have such layout
+                // and read the pixels.
                 for (int j = 0; j < skip; j++) {
-                    row.data[j] = row.data[skip + (skip - j) % 2];
+                    int k = j - skip;
+                    while (k < 0)
+                        k += pattern_size;
+
+                    if (k + skip < window_size) {
+                        row.data[j] = row.data[k + skip];
+                    } else {
+                        float v;
+                        src.getpixel(xstart + k, ystart, 0, &v, 1);
+                        int x_off2  = (x_off + k) % pattern_size;
+                        int chan    = channel_map[y_off][x_off2];
+                        row.data[j] = v * white_balance_values[chan];
+                    }
                 }
 
                 rows.push_back(row);
@@ -110,32 +151,18 @@ protected:
         }
 
         /// Advances the sliding window to the right by one pixel. Rotates the
-        /// indices in the `column_mapping`. Fetches the rightmost column
-        /// from the source, if available. If we have reached the right border
-        /// and there are no more pixels to fetch, duplicates the values we
-        /// have fetched 2 steps ago, as the Bayer pattern repeats every 2
-        /// columns.
+        /// indices in the `column_mapping`.
         void update()
         {
-            x++;
-
             int curr = column_mapping[0];
-            for (int i = 0; i < size - 1; i++) {
+            for (int i = 0; i < window_size - 1; i++) {
                 column_mapping[i] = column_mapping[i + 1];
             }
-            column_mapping[size - 1] = curr;
+            column_mapping[window_size - 1] = curr;
 
-            if (x + size / 2 < src_xend) {
-                for (int i = 0; i < size; i++) {
-                    Row& row       = rows[i];
-                    row.data[curr] = row.fetch();
-                }
-            } else {
-                int src = column_mapping[size - 3];
-                for (int i = 0; i < size; i++) {
-                    Row& row       = rows[i];
-                    row.data[curr] = row.data[src];
-                }
+            for (int i = 0; i < window_size; i++) {
+                Row& row       = rows[i];
+                row.data[curr] = row.fetch();
             }
         };
 
@@ -146,33 +173,59 @@ protected:
         }
     };
 
-    typedef void (*Decoder)(Window& window, ImageBuf::Iterator<Rtype>& out,
-                            int chbegin);
+    struct Context {
+        Window& window;
+        ImageBuf::Iterator<Rtype>& out;
+        int chbegin;
+        int skip;
+        int count;
+    };
 
-    /// The decoder function pointers in RGGB order.
+    /// Check the boundaries and process the pixel. We only need to check the
+    /// boundaries for the first and the last few pixels of each line. As soon
+    /// as we have reached the pixel aligned with the default layout, we can
+    /// process the full stride without needing to check the boundaries
+    /// (2 pixels for Bayer and 6 pixels for XTrans).
+    template<bool check, typename Func>
+    inline static bool check_and_decode(Context& context, const Func& func)
+    {
+        if constexpr (check) {
+            if (context.skip > 0) {
+                context.skip--;
+            } else if (context.count == 0) {
+                return true;
+            } else {
+                func();
+                context.out++;
+                context.count--;
+                context.window.update();
+            }
+            return false;
+        }
+
+        func();
+        context.out++;
+        context.count--;
+        context.window.update();
+        return false;
+    }
+
     /// All subclasses must initialize this table.
-    Decoder decoders[2][2] = { { nullptr, nullptr }, { nullptr, nullptr } };
+    typedef void (*Decoder)(Context& context);
+    Decoder fast_decoders[pattern_size];
+    Decoder slow_decoders[pattern_size];
+
+    int x_offset = 0;
+    int y_offset = 0;
+
+    std::string error;
 
 public:
-    bool process(ImageBuf& dst, const ImageBuf& src, const std::string& layout,
-                 const float white_balance[4], ROI roi, int nthreads)
+    bool process(ImageBuf& dst, const ImageBuf& src,
+                 const float (&white_balance)[4], ROI roi, int nthreads)
     {
-        int x_offset, y_offset;
-
-        if (layout == "RGGB") {
-            x_offset = 0;
-            y_offset = 0;
-        } else if (layout == "GRBG") {
-            x_offset = 1;
-            y_offset = 0;
-        } else if (layout == "GBRG") {
-            x_offset = 0;
-            y_offset = 1;
-        } else if (layout == "BGGR") {
-            x_offset = 1;
-            y_offset = 1;
-        } else {
-            dst.errorfmt("BayerDemosaicing::process() invalid Bayer layout");
+        if (error.length() > 0) {
+            dst.errorfmt("Demosaic::process() {}", error);
             return false;
         }
 
@@ -180,109 +233,186 @@ public:
             ImageBuf::Iterator<Rtype> it(dst, roi);
 
             for (int y = roi.ybegin; y < roi.yend; y++) {
-                typename BayerDemosaicing<Rtype, Atype, size>::Window window(
-                    y, roi.xbegin, src, x_offset, y_offset, white_balance);
+                typename DemosaicingBase<Rtype, Atype, pattern_size,
+                                         window_size, channel_map>::Window
+                    window(y, roi.xbegin, src, x_offset, y_offset,
+                           white_balance);
 
-                int r          = (y_offset + y) % 2;
-                Decoder calc_0 = decoders[r][(x_offset + roi.xbegin + 0) % 2];
-                Decoder calc_1 = decoders[r][(x_offset + roi.xbegin + 1) % 2];
+                int r = (y_offset + y) % pattern_size;
 
-                assert(calc_0 != nullptr);
-                assert(calc_1 != nullptr);
+                Decoder& fast_decoder = fast_decoders[r];
+                Decoder& slow_decoder = slow_decoders[r];
 
+                int skip        = (x_offset + roi.xbegin) % pattern_size;
+                int count       = roi.width();
+                Context context = { window, it, roi.chbegin, skip, count };
 
-                int x = roi.xbegin;
-
-                // Process the leftmost pixel first.
-                if (x < roi.xend) {
-                    (calc_0)(window, it, 0);
-                    it++;
-                    x++;
+                if (skip > 0) {
+                    slow_decoder(context);
                 }
 
-                // Now, process two pixels at a time.
-                while (x < roi.xend - 1) {
-                    window.update();
-                    (calc_1)(window, it, 0);
-                    it++;
-                    x++;
-
-                    window.update();
-                    (calc_0)(window, it, 0);
-                    it++;
-                    x++;
+                size_t cc = context.count / pattern_size;
+                for (size_t i = 0; i < cc; i++) {
+                    fast_decoder(context);
                 }
 
-                // Process the rightmost pixel if needed.
-                if (x < roi.xend) {
-                    window.update();
-                    (calc_1)(window, it, 0);
-                    it++;
-                }
+                slow_decoder(context);
             }
         });
 
         return true;
     };
+
+    inline static size_t channel_at_offset(int x_offset, int y_offset)
+    {
+        return channel_map[y_offset % pattern_size][x_offset % pattern_size];
+    }
+
+    static void layout_from_offset(int x_offset, int y_offset,
+                                   std::string& layout, bool whitespaces)
+    {
+        const char* channels = "RGBG";
+
+        size_t length = pattern_size * pattern_size;
+        if (whitespaces)
+            length += pattern_size - 1;
+
+        layout.resize(length);
+
+        size_t i = 0;
+        for (size_t y = 0; y < pattern_size; y++) {
+            for (size_t x = 0; x < pattern_size; x++) {
+                int c = channel_at_offset(x + x_offset, y + y_offset);
+                assert(c < 4);
+
+                layout[i] = channels[c];
+                i++;
+            }
+            if (whitespaces) {
+                layout[i] = ' ';
+                i++;
+            }
+        }
+    }
+
+    bool init_offsets(const std::string& layout)
+    {
+        if (layout.length() == 0) {
+            x_offset = 0;
+            y_offset = 0;
+            return true;
+        }
+
+        std::string stripped_layout = layout;
+        if (layout.size() == pattern_size * pattern_size + pattern_size - 1) {
+            stripped_layout.erase(std::remove(stripped_layout.begin(),
+                                              stripped_layout.end(), ' '),
+                                  stripped_layout.end());
+        }
+
+        std::string current_layout;
+
+        for (size_t y = 0; y < pattern_size; y++) {
+            for (size_t x = 0; x < pattern_size; x++) {
+                layout_from_offset(x, y, current_layout, false);
+                if (stripped_layout == current_layout) {
+                    x_offset = x;
+                    y_offset = y;
+                    return true;
+                }
+            }
+        }
+
+        x_offset = 0;
+        y_offset = 0;
+        error    = "unrecognised layout \"" + layout + "\"";
+        return false;
+    }
+
+    DemosaicingBase(const std::string& layout) { this->init_offsets(layout); }
 };
 
+constexpr size_t bayer_channel_map[2][2] = {
+    { 0, 1 },  // RG
+    { 3, 2 }   // GB
+};
 
-template<class Rtype, class Atype, int size = 3>
-class LinearBayerDemosaicing : public BayerDemosaicing<Rtype, Atype, size> {
+template<class Rtype, class Atype, int window_size>
+class BayerDemosaicing
+    : public DemosaicingBase<Rtype, Atype, 2, window_size, bayer_channel_map> {
+public:
+    using DemosaicingBase<Rtype, Atype, 2, window_size,
+                          bayer_channel_map>::DemosaicingBase;
+};
+
+template<class Rtype, class Atype>
+class LinearBayerDemosaicing : public BayerDemosaicing<Rtype, Atype, 3> {
 private:
-    static void
-    calc_red(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-             ImageBuf::Iterator<Rtype>& out, int chbegin)
+    using Window  = typename LinearBayerDemosaicing<Rtype, Atype>::Window;
+    using Context = typename LinearBayerDemosaicing<Rtype, Atype>::Context;
+
+    template<bool check> static void calc_RG(Context& c)
     {
-        out[chbegin + 0] = w(1, 1);
-        out[chbegin + 1] = (w(0, 1) + w(2, 1) + w(1, 0) + w(1, 2)) / 4.0f;
-        out[chbegin + 2] = (w(0, 0) + w(0, 2) + w(2, 0) + w(2, 2)) / 4.0f;
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (LinearBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                         ch]() {
+                c.out[ch + 0] = w(1, 1);
+                c.out[ch + 1] = (w(0, 1) + w(2, 1) + w(1, 0) + w(1, 2)) / 4.0f;
+                c.out[ch + 2] = (w(0, 0) + w(0, 2) + w(2, 0) + w(2, 2)) / 4.0f;
+            }))
+            return;
+
+        if (LinearBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                         ch]() {
+                c.out[ch + 0] = (w(1, 0) + w(1, 2)) / 2.0f;
+                c.out[ch + 1] = w(1, 1);
+                c.out[ch + 2] = (w(0, 1) + w(2, 1)) / 2.0f;
+            }))
+            return;
     }
 
-    static void
-    calc_blue(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-              ImageBuf::Iterator<Rtype>& out, int chbegin)
+    template<bool check> static void calc_GB(Context& c)
     {
-        out[chbegin + 0] = (w(0, 0) + w(0, 2) + w(2, 0) + w(2, 2)) / 4.0f;
-        out[chbegin + 1] = (w(0, 1) + w(2, 1) + w(1, 0) + w(1, 2)) / 4.0f;
-        out[chbegin + 2] = w(1, 1);
-    }
+        auto& w = c.window;
+        auto ch = c.chbegin;
 
-    static void
-    calc_green_in_red(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-                      ImageBuf::Iterator<Rtype>& out, int chbegin)
-    {
-        out[chbegin + 0] = (w(1, 0) + w(1, 2)) / 2.0f;
-        out[chbegin + 1] = w(1, 1);
-        out[chbegin + 2] = (w(0, 1) + w(2, 1)) / 2.0f;
-    }
+        if (LinearBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                         ch]() {
+                c.out[ch + 0] = (w(0, 1) + w(2, 1)) / 2.0f;
+                c.out[ch + 1] = w(1, 1);
+                c.out[ch + 2] = (w(1, 0) + w(1, 2)) / 2.0f;
+            }))
+            return;
 
-    static void
-    calc_green_in_blue(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-                       ImageBuf::Iterator<Rtype>& out, int chbegin)
-    {
-        out[chbegin + 0] = (w(0, 1) + w(2, 1)) / 2.0f;
-        out[chbegin + 1] = w(1, 1);
-        out[chbegin + 2] = (w(1, 0) + w(1, 2)) / 2.0f;
+        if (LinearBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                         ch]() {
+                c.out[ch + 0] = (w(0, 0) + w(0, 2) + w(2, 0) + w(2, 2)) / 4.0f;
+                c.out[ch + 1] = (w(0, 1) + w(2, 1) + w(1, 0) + w(1, 2)) / 4.0f;
+                c.out[ch + 2] = w(1, 1);
+            }))
+            return;
     }
 
 public:
-    LinearBayerDemosaicing()
+    LinearBayerDemosaicing(const std::string& layout)
+        : BayerDemosaicing<Rtype, Atype, 3>(layout)
     {
-        BayerDemosaicing<Rtype, Atype, size>::decoders[0][0] = calc_red;
-        BayerDemosaicing<Rtype, Atype, size>::decoders[0][1] = calc_green_in_red;
-        BayerDemosaicing<Rtype, Atype, size>::decoders[1][0]
-            = calc_green_in_blue;
-        BayerDemosaicing<Rtype, Atype, size>::decoders[1][1] = calc_blue;
+        this->fast_decoders[0] = calc_RG<false>;
+        this->fast_decoders[1] = calc_GB<false>;
+
+        this->slow_decoders[0] = calc_RG<true>;
+        this->slow_decoders[1] = calc_GB<true>;
     };
 };
 
-template<class Rtype, class Atype, int size = 5>
-class MHCBayerDemosaicing : public BayerDemosaicing<Rtype, Atype, size> {
+template<class Rtype, class Atype>
+class MHCBayerDemosaicing : public BayerDemosaicing<Rtype, Atype, 5> {
 private:
-    inline static void
-    mix1(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-         float& out_mix1, float& out_mix2)
+    using Window = typename MHCBayerDemosaicing<Rtype, Atype>::Window;
+
+    inline static void mix1(Window& w, float& out_mix1, float& out_mix2)
     {
         float tmp = w(0, 2) + w(4, 2) + w(2, 0) + w(2, 4);
         out_mix1  = (8.0f * w(2, 2)
@@ -295,9 +425,7 @@ private:
                    / 16.0f;
     }
 
-    inline static void
-    mix2(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-         float& out_mix1, float& out_mix2)
+    inline static void mix2(Window& w, float& out_mix1, float& out_mix2)
     {
         float tmp = w(1, 1) + w(1, 3) + w(3, 1) + w(3, 3);
 
@@ -311,92 +439,530 @@ private:
                    / 16.0f;
     }
 
-    static void
-    calc_red(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-             ImageBuf::Iterator<Rtype>& out, int chbegin)
-    {
-        float val1, val2;
-        mix1(w, val1, val2);
+    using Context = typename MHCBayerDemosaicing<Rtype, Atype>::Context;
 
-        out[chbegin + 0] = w(2, 2);
-        out[chbegin + 1] = val1;
-        out[chbegin + 2] = val2;
+
+    template<bool check> static void calc_RG(Context& c)
+    {
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (MHCBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                      ch]() {
+                float val1, val2;
+                mix1(w, val1, val2);
+
+                c.out[ch + 0] = w(2, 2);
+                c.out[ch + 1] = val1;
+                c.out[ch + 2] = val2;
+            }))
+            return;
+
+        if (MHCBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                      ch]() {
+                float val1, val2;
+                mix2(w, val1, val2);
+
+                c.out[ch + 0] = val1;
+                c.out[ch + 1] = w(2, 2);
+                c.out[ch + 2] = val2;
+            }))
+            return;
     }
 
-    static void
-    calc_blue(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-              ImageBuf::Iterator<Rtype>& out, int chbegin)
+    template<bool check> static void calc_GB(Context& c)
     {
-        float val1, val2;
-        mix1(w, val1, val2);
+        auto& w = c.window;
+        auto ch = c.chbegin;
 
-        out[chbegin + 0] = val2;
-        out[chbegin + 1] = val1;
-        out[chbegin + 2] = w(2, 2);
-    }
+        if (MHCBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                      ch]() {
+                float val1, val2;
+                mix2(w, val1, val2);
 
-    static void
-    calc_green_in_red(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-                      ImageBuf::Iterator<Rtype>& out, int chbegin)
-    {
-        float val1, val2;
-        mix2(w, val1, val2);
+                c.out[ch + 0] = val2;
+                c.out[ch + 1] = w(2, 2);
+                c.out[ch + 2] = val1;
+            }))
+            return;
 
-        out[chbegin + 0] = val1;
-        out[chbegin + 1] = w(2, 2);
-        out[chbegin + 2] = val2;
-    }
+        if (MHCBayerDemosaicing::template check_and_decode<check>(c, [&c, &w,
+                                                                      ch]() {
+                float val1, val2;
+                mix1(w, val1, val2);
 
-    static void
-    calc_green_in_blue(typename BayerDemosaicing<Rtype, Atype, size>::Window& w,
-                       ImageBuf::Iterator<Rtype>& out, int chbegin)
-    {
-        float val1, val2;
-        mix2(w, val1, val2);
-
-        out[chbegin + 0] = val2;
-        out[chbegin + 1] = w(2, 2);
-        out[chbegin + 2] = val1;
+                c.out[ch + 0] = val2;
+                c.out[ch + 1] = val1;
+                c.out[ch + 2] = w(2, 2);
+            }))
+            return;
     }
 
 public:
-    MHCBayerDemosaicing()
+    MHCBayerDemosaicing(const std::string& layout)
+        : BayerDemosaicing<Rtype, Atype, 5>(layout)
     {
-        BayerDemosaicing<Rtype, Atype, size>::decoders[0][0] = calc_red;
-        BayerDemosaicing<Rtype, Atype, size>::decoders[0][1] = calc_green_in_red;
-        BayerDemosaicing<Rtype, Atype, size>::decoders[1][0]
-            = calc_green_in_blue;
-        BayerDemosaicing<Rtype, Atype, size>::decoders[1][1] = calc_blue;
+        this->fast_decoders[0] = calc_RG<false>;
+        this->fast_decoders[1] = calc_GB<false>;
+
+        this->slow_decoders[0] = calc_RG<true>;
+        this->slow_decoders[1] = calc_GB<true>;
     };
+};
+
+constexpr size_t xtrans_channel_map[6][6] = {
+    { 1, 0, 2, 1, 2, 0 },  // GRBGBR
+    { 2, 1, 1, 0, 1, 1 },  // BGGRGG
+    { 0, 1, 1, 2, 1, 1 },  // RGGBGG
+    { 1, 2, 0, 1, 0, 2 },  // GBRGRB
+    { 0, 1, 1, 2, 1, 1 },  // RGGBGG
+    { 2, 1, 1, 0, 1, 1 },  // BGGRGG
+};
+
+template<class Rtype, class Atype, int window_size>
+class XTransDemosaicing
+    : public DemosaicingBase<Rtype, Atype, 6, window_size, xtrans_channel_map> {
+public:
+    using DemosaicingBase<Rtype, Atype, 6, window_size,
+                          xtrans_channel_map>::DemosaicingBase;
+};
+
+template<class Rtype, class Atype>
+class LinearXTransDemosaicing : public XTransDemosaicing<Rtype, Atype, 5> {
+private:
+    using Context = typename LinearXTransDemosaicing<Rtype, Atype>::Context;
+
+    // ..b..
+    // a.X.d
+    // ..c..
+    inline static float cross(float a, float b, float c, float d)
+    {
+        return (a + d + (b + c) * 2.0) / 6.0;
+    }
+
+    // ...b.
+    // .aX..
+    // ...c.
+    inline static float triangle(float a, float b, float c)
+    {
+        return (a + (b + c) * M_SQRT1_2) / (1.0 + M_SQRT1_2 + M_SQRT1_2);
+    }
+
+    // ..bd.
+    // .aX..
+    // ..ce.
+    inline static float pentagon(float a, float b, float c, float d, float e)
+    {
+        return (a + b + c + (d + e) * M_SQRT1_2)
+               / (3.0 + M_SQRT1_2 + M_SQRT1_2);
+    }
+
+    // ...b.
+    // .aX..
+    // ....d
+    // ..c..
+    inline static float square(float a, float b, float c, float d)
+    {
+        return (a + b * M_SQRT1_2 + c * 0.5 + d / sqrt(5.0))
+               / (1.5 + M_SQRT1_2 + 1.0 / sqrt(5.0));
+    }
+
+    template<bool check> inline static bool calc_GRB_bgg(Context& c)
+    {
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // ggrgg
+                    // ggbgg
+                    // brGrb
+                    // ggbgg
+                    // ggrgg
+                    c.out[ch + 0] = cross(w(0, 2), w(2, 1), w(2, 3), w(4, 2));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = cross(w(2, 0), w(1, 2), w(3, 2), w(2, 4));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // grggb
+                    // gbggr
+                    // rgRbg
+                    // gbggr
+                    // grggb
+                    c.out[ch + 0] = w(2, 2);
+                    c.out[ch + 1] = pentagon(w(2, 1), w(1, 2), w(3, 2), w(1, 3),
+                                             w(3, 3));
+                    c.out[ch + 2] = triangle(w(2, 3), w(1, 1), w(3, 1));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // rggbg
+                    // bggrg
+                    // grBgb
+                    // bggrg
+                    // rggbg
+                    c.out[ch + 0] = triangle(w(2, 1), w(1, 3), w(3, 3));
+                    c.out[ch + 1] = pentagon(w(2, 3), w(1, 2), w(3, 2), w(1, 1),
+                                             w(3, 1));
+                    c.out[ch + 2] = w(2, 2);
+                }))
+            return true;
+
+        return false;
+    }
+
+    template<bool check> inline static bool calc_GBR_rgg(Context& c)
+    {
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // ggbgg
+                    // ggrgg
+                    // rbGbr
+                    // ggrgg
+                    // ggbgg
+                    c.out[ch + 0] = cross(w(2, 0), w(1, 2), w(3, 2), w(2, 4));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = cross(w(0, 2), w(2, 1), w(2, 3), w(4, 2));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // gbggr
+                    // grggb
+                    // bgBrg
+                    // grggb
+                    // gbggr
+                    c.out[ch + 0] = triangle(w(2, 3), w(1, 1), w(3, 1));
+                    c.out[ch + 1] = pentagon(w(2, 1), w(1, 2), w(3, 2), w(1, 3),
+                                             w(3, 3));
+                    c.out[ch + 2] = w(2, 2);
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // bggrg
+                    // rggbg
+                    // gbRgr
+                    // rggbg
+                    // bggrg
+                    c.out[ch + 0] = w(2, 2);
+                    c.out[ch + 1] = pentagon(w(2, 3), w(1, 2), w(3, 2), w(1, 1),
+                                             w(3, 1));
+                    c.out[ch + 2] = triangle(w(2, 1), w(1, 3), w(3, 3));
+                }))
+            return true;
+
+        return false;
+    }
+
+    template<bool check> inline static bool calc_BGG_rgg(Context& c)
+    {
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // ggbgg
+                    // brgrb
+                    // ggBgg
+                    // ggrgg
+                    // rbgbr
+                    c.out[ch + 0] = triangle(w(3, 2), w(1, 1), w(1, 3));
+                    c.out[ch + 1] = pentagon(w(1, 2), w(2, 1), w(2, 3), w(3, 1),
+                                             w(3, 3));
+                    c.out[ch + 2] = w(2, 2);
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // gbggr
+                    // rgrbg
+                    // gbGgr
+                    // grggb
+                    // bgbrg
+                    c.out[ch + 0] = square(w(1, 2), w(3, 1), w(2, 4), w(4, 3));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(2, 1), w(1, 3), w(4, 2), w(3, 4));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // bggrg
+                    // grbgb
+                    // bgGrg
+                    // rggbg
+                    // gbrgr
+                    c.out[ch + 0] = square(w(2, 3), w(1, 1), w(4, 2), w(3, 0));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(1, 2), w(3, 3), w(2, 0), w(4, 1));
+                }))
+            return true;
+
+        return false;
+    }
+
+    template<bool check> inline static bool calc_RGG_bgg(Context& c)
+    {
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // ggrgg
+                    // rbgbr
+                    // ggRgg
+                    // ggbgg
+                    // brgrb
+                    c.out[ch + 0] = w(2, 2);
+                    c.out[ch + 1] = pentagon(w(1, 2), w(2, 1), w(2, 3), w(3, 1),
+                                             w(3, 3));
+                    c.out[ch + 2] = triangle(w(3, 2), w(1, 1), w(1, 3));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // ggrggb
+                    // rbgbrg
+                    // ggrGgb
+                    // ggbggr
+                    // brgrbg
+                    c.out[ch + 0] = square(w(2, 1), w(1, 3), w(4, 2), w(3, 4));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(1, 2), w(3, 1), w(2, 4), w(4, 3));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // grggbg
+                    // bgbrgr
+                    // grgGbg
+                    // gbggrg
+                    // rgrbgb
+                    c.out[ch + 0] = square(w(1, 2), w(3, 3), w(2, 0), w(4, 1));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(2, 3), w(1, 1), w(4, 2), w(3, 0));
+                }))
+            return true;
+
+        return false;
+    }
+
+    template<bool check> inline static bool calc_RGG_gbr(Context& c)
+    {
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // brgrb
+                    // ggbgg
+                    // ggRgg
+                    // rbgbr
+                    // ggrgg
+                    c.out[ch + 0] = w(2, 2);
+                    c.out[ch + 1] = pentagon(w(3, 2), w(2, 1), w(2, 3), w(1, 1),
+                                             w(1, 3));
+                    c.out[ch + 2] = triangle(w(1, 2), w(3, 1), w(3, 3));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // rgrbg
+                    // gbggr
+                    // grGgb
+                    // bgbrg
+                    // grggb
+                    c.out[ch + 0] = square(w(2, 1), w(3, 3), w(0, 2), w(1, 4));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(3, 2), w(1, 1), w(2, 4), w(0, 3));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // grbgb
+                    // bggrg
+                    // rgGbg
+                    // gbrgr
+                    // rggbg
+                    c.out[ch + 0] = square(w(3, 2), w(1, 3), w(2, 0), w(3, 4));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(2, 3), w(3, 1), w(0, 2), w(1, 0));
+                }))
+            return true;
+
+        return false;
+    }
+
+    template<bool check> inline static bool calc_BGG_grb(Context& c)
+    {
+        auto& w = c.window;
+        auto ch = c.chbegin;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // rbgbr
+                    // ggrgg
+                    // ggBgg
+                    // brgrb
+                    // ggbgg
+                    c.out[ch + 0] = triangle(w(1, 2), w(3, 1), w(3, 3));
+                    c.out[ch + 1] = pentagon(w(3, 2), w(2, 1), w(2, 3), w(1, 1),
+                                             w(1, 3));
+                    c.out[ch + 2] = w(2, 2);
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // bgbrg
+                    // grggb
+                    // gbGgr
+                    // rgrbg
+                    // gbggr
+                    c.out[ch + 0] = square(w(3, 2), w(1, 1), w(2, 4), w(0, 3));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(2, 1), w(3, 3), w(0, 2), w(1, 4));
+                }))
+            return true;
+
+        if (LinearXTransDemosaicing::template check_and_decode<check>(
+                c, [&c, &w, ch]() {
+                    // gbrgr
+                    // rggbg
+                    // bgGrg
+                    // grbgb
+                    // bggrg
+                    c.out[ch + 0] = square(w(2, 3), w(3, 1), w(0, 2), w(1, 0));
+                    c.out[ch + 1] = w(2, 2);
+                    c.out[ch + 2] = square(w(3, 2), w(1, 3), w(2, 0), w(3, 4));
+                }))
+            return true;
+
+        return false;
+    }
+
+    template<bool check> static void calc_GRBGBR_bggrgg(Context& c)
+    {
+        if (calc_GRB_bgg<check>(c))
+            return;
+        if (calc_GBR_rgg<check>(c))
+            return;
+    }
+
+    template<bool check> static void calc_BGGRGG_rggbgg(Context& c)
+    {
+        if (calc_BGG_rgg<check>(c))
+            return;
+        if (calc_RGG_bgg<check>(c))
+            return;
+    }
+
+    template<bool check> static void calc_RGGBGG_gbrgrb(Context& c)
+    {
+        if (calc_RGG_gbr<check>(c))
+            return;
+        if (calc_BGG_grb<check>(c))
+            return;
+    }
+
+    template<bool check> static void calc_GBRGRB_rggbgg(Context& c)
+    {
+        if (calc_GBR_rgg<check>(c))
+            return;
+        if (calc_GRB_bgg<check>(c))
+            return;
+    }
+
+    template<bool check> static void calc_RGGBGG_bggrgg(Context& c)
+    {
+        if (calc_RGG_bgg<check>(c))
+            return;
+        if (calc_BGG_rgg<check>(c))
+            return;
+    }
+
+    template<bool check> static void calc_BGGRGG_grbgbr(Context& c)
+    {
+        if (calc_BGG_grb<check>(c))
+            return;
+        if (calc_RGG_gbr<check>(c))
+            return;
+    }
+
+public:
+    LinearXTransDemosaicing(const std::string& layout)
+        : XTransDemosaicing<Rtype, Atype, 5>(layout)
+    {
+        this->slow_decoders[0] = calc_GRBGBR_bggrgg<true>;
+        this->slow_decoders[1] = calc_BGGRGG_rggbgg<true>;
+        this->slow_decoders[2] = calc_RGGBGG_gbrgrb<true>;
+        this->slow_decoders[3] = calc_GBRGRB_rggbgg<true>;
+        this->slow_decoders[4] = calc_RGGBGG_bggrgg<true>;
+        this->slow_decoders[5] = calc_BGGRGG_grbgbr<true>;
+
+        this->fast_decoders[0] = calc_GRBGBR_bggrgg<false>;
+        this->fast_decoders[1] = calc_BGGRGG_rggbgg<false>;
+        this->fast_decoders[2] = calc_RGGBGG_gbrgrb<false>;
+        this->fast_decoders[3] = calc_GBRGRB_rggbgg<false>;
+        this->fast_decoders[4] = calc_RGGBGG_bggrgg<false>;
+        this->fast_decoders[5] = calc_BGGRGG_grbgbr<false>;
+    }
 };
 
 
 template<class Rtype, class Atype>
 static bool
 bayer_demosaic_linear_impl(ImageBuf& dst, const ImageBuf& src,
-                           const std::string& bayer_pattern,
-                           const float white_balance[4], ROI roi, int nthreads)
+                           const std::string& layout,
+                           const float (&white_balance)[4], ROI roi,
+                           int nthreads)
 {
-    LinearBayerDemosaicing<Rtype, Atype> obj;
-    return obj.process(dst, src, bayer_pattern, white_balance, roi, nthreads);
+    LinearBayerDemosaicing<Rtype, Atype> obj(layout);
+    return obj.process(dst, src, white_balance, roi, nthreads);
 }
 
 template<class Rtype, class Atype>
 static bool
 bayer_demosaic_MHC_impl(ImageBuf& dst, const ImageBuf& src,
-                        const std::string& bayer_pattern,
-                        const float white_balance[4], ROI roi, int nthreads)
+                        const std::string& layout,
+                        const float (&white_balance)[4], ROI roi, int nthreads)
 {
-    MHCBayerDemosaicing<Rtype, Atype> obj;
-    return obj.process(dst, src, bayer_pattern, white_balance, roi, nthreads);
+    MHCBayerDemosaicing<Rtype, Atype> obj(layout);
+    return obj.process(dst, src, white_balance, roi, nthreads);
 
     return true;
 }
 
+template<class Rtype, class Atype>
+static bool
+xtrans_demosaic_linear_impl(ImageBuf& dst, const ImageBuf& src,
+                            const std::string& layout,
+                            const float (&white_balance)[4], ROI roi,
+                            int nthreads)
+{
+    LinearXTransDemosaicing<Rtype, Atype> obj(layout);
+    return obj.process(dst, src, white_balance, roi, nthreads);
+}
 
 bool
-ImageBufAlgo::demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options,
-                       ROI roi, int nthreads)
+demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options, ROI roi,
+         int nthreads)
 {
     bool ok = false;
     pvt::LoggedTimer logtime("IBA::demosaic");
@@ -404,7 +970,8 @@ ImageBufAlgo::demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options,
     std::string pattern;
     std::string algorithm;
     std::string layout;
-    float white_balance_RGGB[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+    float white_balance_RGBG[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+    std::string error;
 
     for (auto&& pv : options) {
         if (pv.name() == pattern_us) {
@@ -428,19 +995,19 @@ ImageBufAlgo::demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options,
         } else if (pv.name() == white_balance_us) {
             if (pv.type() == TypeFloat && pv.nvalues() == 4) {
                 // The order in the options is always (R,G1,B,G2)
-                white_balance_RGGB[0] = pv.get_float_indexed(0);
-                white_balance_RGGB[1] = pv.get_float_indexed(1);
-                white_balance_RGGB[2] = pv.get_float_indexed(3);
-                white_balance_RGGB[3] = pv.get_float_indexed(2);
+                white_balance_RGBG[0] = pv.get_float_indexed(0);
+                white_balance_RGBG[1] = pv.get_float_indexed(1);
+                white_balance_RGBG[2] = pv.get_float_indexed(2);
+                white_balance_RGBG[3] = pv.get_float_indexed(3);
 
-                if (white_balance_RGGB[2] == 0)
-                    white_balance_RGGB[2] = white_balance_RGGB[1];
+                if (white_balance_RGBG[3] == 0)
+                    white_balance_RGBG[3] = white_balance_RGBG[1];
             } else if (pv.type() == TypeFloat && pv.nvalues() == 3) {
                 // The order in the options is always (R,G,B)
-                white_balance_RGGB[0] = pv.get_float_indexed(0);
-                white_balance_RGGB[1] = pv.get_float_indexed(1);
-                white_balance_RGGB[2] = white_balance_RGGB[1];
-                white_balance_RGGB[3] = pv.get_float_indexed(2);
+                white_balance_RGBG[0] = pv.get_float_indexed(0);
+                white_balance_RGBG[1] = pv.get_float_indexed(1);
+                white_balance_RGBG[2] = pv.get_float_indexed(2);
+                white_balance_RGBG[3] = white_balance_RGBG[2];
             } else {
                 dst.errorfmt("ImageBufAlgo::demosaic() invalid white balance");
             }
@@ -449,7 +1016,6 @@ ImageBufAlgo::demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options,
                          pv.name());
         }
     }
-
 
     ROI dst_roi = roi;
     if (!dst_roi.defined()) {
@@ -476,25 +1042,31 @@ ImageBufAlgo::demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options,
             algorithm = "linear";
         }
 
-        if (layout.length() == 0) {
-            layout = "RGGB";
-        }
-
         if (algorithm == "linear") {
             OIIO_DISPATCH_COMMON_TYPES2(ok, "bayer_demosaic_linear",
                                         bayer_demosaic_linear_impl,
                                         dst.spec().format, src.spec().format,
-                                        dst, src, layout, white_balance_RGGB,
-                                        dst_roi, nthreads);
+                                        dst, src, layout, white_balance_RGBG,
+                                        dst_roi, 1);
         } else if (algorithm == "MHC") {
             OIIO_DISPATCH_COMMON_TYPES2(ok, "bayer_demosaic_MHC",
                                         bayer_demosaic_MHC_impl,
                                         dst.spec().format, src.spec().format,
-                                        dst, src, layout, white_balance_RGGB,
-                                        dst_roi, nthreads);
+                                        dst, src, layout, white_balance_RGBG,
+                                        dst_roi, 1);
         } else {
             dst.errorfmt("ImageBufAlgo::demosaic() invalid algorithm");
         }
+    } else if (pattern == "xtrans") {
+        if (algorithm.length() == 0) {
+            algorithm = "linear";
+        }
+
+        OIIO_DISPATCH_COMMON_TYPES2(ok, "xtrans_demosaic_linear",
+                                    xtrans_demosaic_linear_impl,
+                                    dst.spec().format, src.spec().format, dst,
+                                    src, layout, white_balance_RGBG, dst_roi,
+                                    1);
     } else {
         dst.errorfmt("ImageBufAlgo::demosaic() invalid pattern");
     }
@@ -503,8 +1075,7 @@ ImageBufAlgo::demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options,
 }
 
 ImageBuf
-ImageBufAlgo::demosaic(const ImageBuf& src, KWArgs options, ROI roi,
-                       int nthreads)
+demosaic(const ImageBuf& src, KWArgs options, ROI roi, int nthreads)
 {
     ImageBuf result;
     bool ok = demosaic(result, src, options, roi, nthreads);
@@ -512,5 +1083,107 @@ ImageBufAlgo::demosaic(const ImageBuf& src, KWArgs options, ROI roi,
         result.errorfmt("ImageBufAlgo::demosaic() error");
     return result;
 }
+
+/// Creates a mosaiced version of the input image using the provided Demosaic
+/// class's pattern, layout, and white balancing weights. Used for testing.
+template<class Demosaic, class Rtype, class Atype>
+void
+mosaic(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+       const float (&wb)[4], int nthreads)
+{
+    ImageSpec src_spec = src.spec();
+
+    ROI roi = src.roi_full();
+
+    ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
+        ImageBuf::ConstIterator<Atype> s(src, roi);
+        ImageBuf::Iterator<Rtype> d(dst, roi);
+
+        for (int y = roi.ybegin; y < roi.yend; y++) {
+            for (int x = roi.xbegin; x < roi.xend; x++) {
+                size_t chan = Demosaic::channel_at_offset(x_offset + x,
+                                                          y_offset + y);
+                size_t c    = chan;
+                if (c == 3)
+                    c = 1;
+                d[0] = s[c] / wb[chan];
+                s++;
+                d++;
+            }
+        }
+    });
+}
+
+/// Creates a mosaiced version of the input image using the provided pattern,
+/// layout, and white balancing weights. Returns the layout string calculated
+/// from the given offsets. Used for testing.
+template<class T>
+std::string
+mosaic(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+       const std::string& pattern, const float (&white_balance)[4],
+       int nthreads)
+{
+    std::string layout;
+
+    if (pattern == "bayer") {
+        BayerDemosaicing<float, float, 3>::layout_from_offset(x_offset,
+                                                              y_offset, layout,
+                                                              false);
+        mosaic<BayerDemosaicing<float, float, 3>, T, T>(dst, src, x_offset,
+                                                        y_offset, white_balance,
+                                                        nthreads);
+    } else if (pattern == "xtrans") {
+        XTransDemosaicing<float, float, 3>::layout_from_offset(x_offset,
+                                                               y_offset, layout,
+                                                               false);
+        mosaic<XTransDemosaicing<float, float, 3>, T, T>(dst, src, x_offset,
+                                                         y_offset,
+                                                         white_balance,
+                                                         nthreads);
+    } else {
+        return "";
+    }
+
+
+    return layout;
+}
+
+std::string
+mosaic_float(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+             const std::string& pattern, const float (&white_balance)[4],
+             int nthreads)
+{
+    return mosaic<float>(dst, src, x_offset, y_offset, pattern, white_balance,
+                         nthreads);
+}
+
+std::string
+mosaic_half(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+            const std::string& pattern, const float (&white_balance)[4],
+            int nthreads)
+{
+    return mosaic<half>(dst, src, x_offset, y_offset, pattern, white_balance,
+                        nthreads);
+}
+
+std::string
+mosaic_uint16(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+              const std::string& pattern, const float (&white_balance)[4],
+              int nthreads)
+{
+    return mosaic<uint16_t>(dst, src, x_offset, y_offset, pattern,
+                            white_balance, nthreads);
+}
+
+std::string
+mosaic_uint8(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+             const std::string& pattern, const float (&white_balance)[4],
+             int nthreads)
+{
+    return mosaic<uint8_t>(dst, src, x_offset, y_offset, pattern, white_balance,
+                           nthreads);
+}
+
+}  // namespace ImageBufAlgo
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imagebufalgo_demosaic_prv.h
+++ b/src/libOpenImageIO/imagebufalgo_demosaic_prv.h
@@ -1,0 +1,36 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
+#pragma once
+
+#include <OpenImageIO/imagebufalgo.h>
+
+OIIO_NAMESPACE_BEGIN
+
+namespace ImageBufAlgo {
+
+std::string OIIO_API
+mosaic_float(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+             const std::string& pattern, const float (&white_balance)[4],
+             int nthreads);
+
+std::string OIIO_API
+mosaic_half(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+            const std::string& pattern, const float (&white_balance)[4],
+            int nthreads);
+
+std::string OIIO_API
+mosaic_uint16(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+              const std::string& pattern, const float (&white_balance)[4],
+              int nthreads);
+
+std::string OIIO_API
+mosaic_uint8(ImageBuf& dst, const ImageBuf& src, int x_offset, int y_offset,
+             const std::string& pattern, const float (&white_balance)[4],
+             int nthreads);
+
+}  // namespace ImageBufAlgo
+
+OIIO_NAMESPACE_END


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Implements X-Trans pattern demosaicing using a simple bilinear algorithm. Adds the Xtrans pattern layout to the ImageBuf attributes in the raw reader plugin. 

## Tests

I have implemented unittests in imagebufalgo_test.cpp which cover all permutations of the Bayer and X-Trans layouts, as the X-Trans pattern is a bit too complicated to generate using oiiotool.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.