### PR TITLE
build: fix build_cmake.bash script for aarch64, bump its default version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=20`, etc.
  * Compilers: **gcc 9.3** - 14.2, **clang 5** - 19, MSVS 2017 - 2019 (**v19.14
    and up**), **Intel icc 19+**, Intel OneAPI C++ compiler 2022+.
- * **CMake >= 3.18.2** (tested through 3.30)
+ * **CMake >= 3.18.2** (tested through 3.31)
  * **Imath >= 3.1** (tested through 3.1.x and main)
  * **OpenEXR >= 3.1** (tested through 3.3 and main)
  * **libTIFF >= 4.0** (tested through 4.7)

--- a/src/build-scripts/build_cmake.bash
+++ b/src/build-scripts/build_cmake.bash
@@ -12,7 +12,7 @@ set -ex
 echo "Building cmake"
 uname
 
-CMAKE_VERSION=${CMAKE_VERSION:=3.18.5}
+CMAKE_VERSION=${CMAKE_VERSION:=3.31.3}
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 CMAKE_INSTALL_DIR=${CMAKE_INSTALL_DIR:=${LOCAL_DEPS_DIR}/cmake}
 
@@ -25,8 +25,8 @@ fi
 
 if [[ `uname` == "Linux" && `uname -m` == "aarch64" ]] ; then
     mkdir -p ${CMAKE_INSTALL_DIR} || true
-    curl --location https://anaconda.org/conda-forge/cmake/3.17.0/download/linux-aarch64/cmake-3.17.0-h28c56e5_0.tar.bz2 -o cmake-3.17.0-h28c56e5_0.tar.bz2
-    tar -xjf cmake-3.17.0-h28c56e5_0.tar.bz2 -C ${CMAKE_INSTALL_DIR}
+    curl --location "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-aarch64.sh" -o "cmake.sh"
+    sh cmake.sh --skip-license --prefix=${CMAKE_INSTALL_DIR}
     export PATH=${CMAKE_INSTALL_DIR}/bin:$PATH
 
     # In case we ever need to build from scratch:


### PR DESCRIPTION
* When the script was run on aarch64, it was actually hard-coded to retrieve a version older than we currently require as a minimum. Use the CMAKE_VERSION hint just like we do for x86_64.
* Bump the default version that this script makes to the latest, 3.31.3.  (This does not change OIIO's minimum required cmake version, it merely changes the default if this hepler script that we use for CI is run without any specific version requested.)
