### PR TITLE
ci: Fix Windows 2019 CI -- make python version match the runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,7 @@ jobs:
             runner: windows-2019
             vsver: 2019
             generator: "Visual Studio 16 2019"
-            python_ver: 3.7
+            python_ver: "3.9"
           - desc: Windows-2022 VS2022
             runner: windows-2022
             vsver: 2022


### PR DESCRIPTION
For reasons that are unclear (maybe a change to which python versions are installed where on the GH runners?) this seems to have broken within the past couple days, in a way that did not correspond to any change we made on the OIIO side.
