### PR TITLE
ci(deps): Adjust some pugixml versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
             setenvs: export  CMAKE_VERSION=3.18.2
                              PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.1.0
+                             PUGIXML_VERSION=v1.8
             depcmds: sudo rm -rf /usr/local/include/OpenEXR
           - desc: hobbled gcc9.3/C++17 py3.7 exr-3.1 no-sse
             # Use the oldest supported versions of required dependencies, and
@@ -135,6 +136,7 @@ jobs:
                              USE_JPEGTURBO=0
                              USE_OPENCV=0
                              FREETYPE_VERSION=VER-2-10-0
+                             PUGIXML_VERSION=v1.8
             depcmds: sudo rm -rf /usr/local/include/OpenEXR
 
     runs-on: ${{ matrix.runner }}
@@ -279,6 +281,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             pybind11_ver: v2.10.0
+            setenvs: PUGIXML_VERSION=v1.13
           - desc: VFX2023 icc/C++17 py3.10 exr3.1 ocio2.1 qt5.15
             nametag: linux-vfx2023-icc
             runner: ubuntu-latest
@@ -318,6 +321,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             pybind11_ver: v2.12.0
+            setenvs: PUGIXML_VERSION=v1.14
           - desc: VFX2024 clang/C++17 py3.11 exr3.2 ocio2.3
             nametag: linux-vfx2024
             runner: ubuntu-latest
@@ -328,6 +332,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             pybind11_ver: v2.12.0
+            setenvs: PUGIXML_VERSION=v1.14
           - desc: VFX2024 sanitizers
             nametag: sanitizer
             runner: ubuntu-latest
@@ -395,7 +400,7 @@ jobs:
                             LIBTIFF_VERSION=v4.7.0
                             OPENJPEG_VERSION=v2.5.2
                             PTEX_VERSION=v2.4.3
-                            PUGIXML_VERSION=v1.14
+                            PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.5.0
                             FREETYPE_VERSION=VER-2-13-3
                             USE_OPENVDB=0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distributions with policies against
    embedding other projects), then just build with `-DUSE_EXTERNAL_PUGIXML=1`.
-   Any PugiXML >= 1.8 should be fine (we have tested through 1.14).
+   Any PugiXML >= 1.8 should be fine (we have tested through 1.15).
 
 
 


### PR DESCRIPTION
* Bump the 'latest' test to test the actual latest, 1.15.
* Be sure that the 'oldest' tests actually test the oldest we support, 1.8.
* Sprinkle around a couple other versions that we don't test currently.
