### PR TITLE
fix(pdf): Perform endian byteswap on correct buffer area for PSD RLE

### DIFF
--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -2233,6 +2233,7 @@ PSDInput::decompress_packbits(const char* src, char* dst,
     int16_t header;
     int length;
 
+    char* dst_start = dst;
     while (src_remaining > 0 && dst_remaining > 0) {
         header = *reinterpret_cast<const signed char*>(src);
         src++;
@@ -2275,8 +2276,8 @@ PSDInput::decompress_packbits(const char* src, char* dst,
 
     if (!bigendian()) {
         switch (m_header.depth) {
-        case 16: swap_endian((uint16_t*)dst, m_spec.width); break;
-        case 32: swap_endian((uint32_t*)dst, m_spec.width); break;
+        case 16: swap_endian((uint16_t*)dst_start, m_spec.width); break;
+        case 32: swap_endian((uint32_t*)dst_start, m_spec.width); break;
         }
     }
 

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -805,6 +805,36 @@ Reading ../oiio-images/psd/psd_rgba_8.psd
     stEvt:instanceID: "xmp.iid:037A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:when: "2011-08-22T22:07:44-04:00; 2011-08-25T17:39:28-04:00"
+Reading ../oiio-images/psd/psd_rgb_16_rle.psd
+../oiio-images/psd/psd_rgb_16_rle.psd : 3840 x 2160, 3 channel, uint16 psd
+    SHA-1: CF2071CFD7AF69ECEFC9EA00DC0EA7F8ED6A2E2B
+    channel list: R, G, B
+    DateTime: "2025-01-10T23:27:45+02:00"
+    ICCProfile: 0, 0, 2, 48, 65, 68, 66, 69, 2, 16, 0, 0, 109, 110, 116, 114, ... [560 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 26.0 (Windows)"
+    thumbnail_height: 90
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 3840
+    Exif:PixelYDimension: 2160
+    IPTC:DocumentID: "xmp.did:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    IPTC:InstanceID: "xmp.iid:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    IPTC:MetadataDate: "2025-01-10T23:28:11+02:00"
+    IPTC:ModifyDate: "2025-01-10T23:28:11+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "Adobe RGB (1998)"
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    stEvt:softwareAgent: "Adobe Photoshop 26.0 (Windows)"
+    stEvt:when: "2025-01-10T23:27:45+02:00"
 Reading ../oiio-images/psd/psd_123.psd
 ../oiio-images/psd/psd_123.psd :  257 x  126, 4 channel, uint8 psd
     4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]

--- a/testsuite/psd/run.py
+++ b/testsuite/psd/run.py
@@ -8,7 +8,7 @@ redirect = ' >> out.txt 2>&1 '
 
 files = [ "psd_123.psd", "psd_123_nomaxcompat.psd", "psd_bitmap.psd",
           "psd_indexed_trans.psd", "psd_rgb_8.psd", "psd_rgb_16.psd",
-          "psd_rgb_32.psd", "psd_rgba_8.psd" ]
+          "psd_rgb_32.psd", "psd_rgba_8.psd", "psd_rgb_16_rle.psd" ]
 for f in files:
     command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)
 


### PR DESCRIPTION
## Description

Perform the endian byteswap on the correct buffer area for PSD RLE decoding.  The original code used `dst` but that pointer is modified from its original value as it progresses through decoding.

Fixes #4599 

## Tests

It might be prudent to add a test for this.  Is the repro file attached to the bug too big for this repo(842kb) or do you want them in the oiio-images repo maybe?

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
