### PR TITLE
fix(IBA): demosaic - fix roi channels

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_demosaic.cpp
+++ b/src/libOpenImageIO/imagebufalgo_demosaic.cpp
@@ -1019,11 +1019,10 @@ demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options, ROI roi,
 
     ROI dst_roi = roi;
     if (!dst_roi.defined()) {
-        dst_roi = src.roi();
+        dst_roi         = src.roi();
+        dst_roi.chbegin = 0;
+        dst_roi.chend   = 3;
     }
-
-    dst_roi.chbegin = 0;
-    dst_roi.chend   = 2;
 
     ImageSpec dst_spec = src.spec();
     dst_spec.nchannels = 3;
@@ -1071,7 +1070,7 @@ demosaic(ImageBuf& dst, const ImageBuf& src, KWArgs options, ROI roi,
         dst.errorfmt("ImageBufAlgo::demosaic() invalid pattern");
     }
 
-    return true;
+    return ok;
 }
 
 ImageBuf


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Fixes a bug in demosaicing where the code ignores the ROI channels.
The old behaviour was to always decode into the first 3 channels.

## Tests

None of the current tests use preallocated output buffers. Should we have some? The change is fairly trivial though.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
