### PR TITLE
cleanup: Get rid of some compiler symbols no longer needed

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -180,14 +180,6 @@ if (CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_I
     endif ()
 endif ()
 
-if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-    # Options common to gcc and clang
-
-    # Ensure this macro is set for stdint.h
-    add_compile_definitions (__STDC_LIMIT_MACROS)
-    add_compile_definitions (__STDC_CONSTANT_MACROS)
-endif ()
-
 if (INTELCLANG_VERSION_STRING VERSION_GREATER_EQUAL 2022.1.0)
     # New versions of icx warn about changing certain floating point options
     add_compile_options ("-Wno-overriding-t-option")

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -8,25 +8,6 @@
 #include <stdexcept>
 #include <vector>
 
-// We're including stdint.h to get int64_t and INT64_MIN. But on some
-// platforms, stdint.h only defines them if __STDC_LIMIT_MACROS is defined,
-// so we do so. But, oops, if user code included stdint.h before this file,
-// and without defining the macro, it may have had ints one and only include
-// and not seen the definitions we need, so at least try to make a helpful
-// compile-time error in that case.
-// And very old MSVC 9 versions don't even have stdint.h.
-#if defined(_MSC_VER) && _MSC_VER < 1600
-typedef __int64 int64_t;
-#else
-#    ifndef __STDC_LIMIT_MACROS
-#        define __STDC_LIMIT_MACROS /* needed for some defs in stdint.h */
-#    endif
-#    include <cstdint>
-#    if !defined(INT64_MIN)
-#        error You must define __STDC_LIMIT_MACROS prior to including stdint.h
-#    endif
-#endif
-
 #include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/strided_ptr.h>
 


### PR DESCRIPTION
The newer versions of the compilers we now use no longer need this.
