### PR TITLE
cleanup: no longer need OIIO_INLINE_CONSTEXPR macro

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -173,13 +173,10 @@
 // See https://en.cppreference.com/w/cpp/compiler_support
 //
 // OIIO_CPLUSPLUS_VERSION : which C++ standard is compiling (14, 17, ...)
-// OIIO_CONSTEXPR14 :
 // OIIO_CONSTEXPR17 :
 // OIIO_CONSTEXPR20 : constexpr for C++ >= the designated version, otherwise
 //                    nothing (this is useful for things that can only be
 //                    constexpr for particular versions or greater).
-// OIIO_INLINE_CONSTEXPR : inline constexpr variables, added in C++17. For
-//                         older C++, static constexpr.
 //
 // Note: oiioversion.h defines OIIO_BUILD_CPP (set to 17, 20, etc.)
 // reflecting what OIIO itself was *built* with.  In contrast,
@@ -192,14 +189,15 @@
 #if (__cplusplus >= 202001L)
 #    define OIIO_CPLUSPLUS_VERSION 20
 #    define OIIO_CONSTEXPR20 constexpr
-#    define OIIO_INLINE_CONSTEXPR inline constexpr
 #elif (__cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER >= 1914)
 #    define OIIO_CPLUSPLUS_VERSION 17
 #    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
-#    define OIIO_INLINE_CONSTEXPR inline constexpr
 #else
 #    error "This version of OIIO is meant to work only with C++17 and above"
 #endif
+
+// DEPRECATED(3.1): use C++17 inline constexpr
+#define OIIO_INLINE_CONSTEXPR inline constexpr
 
 // DEPRECATED(3.0): use C++17 constexpr
 #define OIIO_CONSTEXPR17 constexpr

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -34,7 +34,7 @@ OIIO_NAMESPACE_BEGIN
 using span_size_t = size_t;
 using oiio_span_size_type = OIIO::span_size_t;  // back-compat alias
 
-OIIO_INLINE_CONSTEXPR span_size_t dynamic_extent = -1;
+inline constexpr span_size_t dynamic_extent = -1;
 
 
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -148,8 +148,8 @@ enum class InterpMode : uint8_t {
 /// The SIMD width for batched texturing operations. This is fixed within
 /// any release of OpenImageIO, but may change from release to release and
 /// also may be overridden at build time. A typical batch size is 16.
-OIIO_INLINE_CONSTEXPR int BatchWidth = OIIO_TEXTURE_SIMD_BATCH_WIDTH;
-OIIO_INLINE_CONSTEXPR int BatchAlign = BatchWidth * sizeof(float);
+inline constexpr int BatchWidth = OIIO_TEXTURE_SIMD_BATCH_WIDTH;
+inline constexpr int BatchAlign = BatchWidth * sizeof(float);
 
 /// A type alias for a SIMD vector of floats with the batch width.
 typedef simd::VecType<float, OIIO_TEXTURE_SIMD_BATCH_WIDTH>::type FloatWide;
@@ -168,15 +168,15 @@ typedef uint64_t RunMask;
 // The defined constant `RunMaskOn` contains the value with all bits
 // `0..BatchWidth-1` set to 1.
 #if OIIO_TEXTURE_SIMD_BATCH_WIDTH == 4
-OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xf;
+inline constexpr RunMask RunMaskOn = 0xf;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 8
-OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xff;
+inline constexpr RunMask RunMaskOn = 0xff;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 16
-OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xffff;
+inline constexpr RunMask RunMaskOn = 0xffff;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 32
-OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xffffffff;
+inline constexpr RunMask RunMaskOn = 0xffffffff;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 64
-OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xffffffffffffffffULL;
+inline constexpr RunMask RunMaskOn = 0xffffffffffffffffULL;
 #else
 #    error "Not a valid OIIO_TEXTURE_SIMD_BATCH_WIDTH choice"
 #endif

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -351,42 +351,42 @@ static_assert(std::is_trivially_move_assignable<TypeDesc>(), "TypeDesc is not mo
 // Static values for commonly used types. Because these are constexpr,
 // they should incur no runtime construction cost and should optimize nicely
 // in various ways.
-OIIO_INLINE_CONSTEXPR TypeDesc TypeUnknown (TypeDesc::UNKNOWN);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeFloat (TypeDesc::FLOAT);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeColor (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::COLOR);
-OIIO_INLINE_CONSTEXPR TypeDesc TypePoint (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::POINT);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeVector (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::VECTOR);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeNormal (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NORMAL);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeMatrix33 (TypeDesc::FLOAT, TypeDesc::MATRIX33);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeMatrix44 (TypeDesc::FLOAT, TypeDesc::MATRIX44);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeMatrix = TypeMatrix44;
-OIIO_INLINE_CONSTEXPR TypeDesc TypeFloat2 (TypeDesc::FLOAT, TypeDesc::VEC2);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeVector2 (TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::VECTOR);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeFloat4 (TypeDesc::FLOAT, TypeDesc::VEC4);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeVector4 = TypeFloat4;
-OIIO_INLINE_CONSTEXPR TypeDesc TypeString (TypeDesc::STRING);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeInt (TypeDesc::INT);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt (TypeDesc::UINT);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeInt32 (TypeDesc::INT);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt32 (TypeDesc::UINT);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeInt16 (TypeDesc::INT16);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt16 (TypeDesc::UINT16);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeInt8 (TypeDesc::INT8);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt8 (TypeDesc::UINT8);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeInt64 (TypeDesc::INT64);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt64 (TypeDesc::UINT64);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeVector2i(TypeDesc::INT, TypeDesc::VEC2);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeVector3i(TypeDesc::INT, TypeDesc::VEC3);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeBox2(TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::BOX, 2);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeBox3(TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::BOX, 2);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeBox2i(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX, 2);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeBox3i(TypeDesc::INT, TypeDesc::VEC3, TypeDesc::BOX, 2);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeHalf (TypeDesc::HALF);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, TypeDesc::TIMECODE, 2);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeRational(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::RATIONAL);
-OIIO_INLINE_CONSTEXPR TypeDesc TypePointer(TypeDesc::PTR);
-OIIO_INLINE_CONSTEXPR TypeDesc TypeUstringhash(TypeDesc::USTRINGHASH);
+inline constexpr TypeDesc TypeUnknown (TypeDesc::UNKNOWN);
+inline constexpr TypeDesc TypeFloat (TypeDesc::FLOAT);
+inline constexpr TypeDesc TypeColor (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::COLOR);
+inline constexpr TypeDesc TypePoint (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::POINT);
+inline constexpr TypeDesc TypeVector (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::VECTOR);
+inline constexpr TypeDesc TypeNormal (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NORMAL);
+inline constexpr TypeDesc TypeMatrix33 (TypeDesc::FLOAT, TypeDesc::MATRIX33);
+inline constexpr TypeDesc TypeMatrix44 (TypeDesc::FLOAT, TypeDesc::MATRIX44);
+inline constexpr TypeDesc TypeMatrix = TypeMatrix44;
+inline constexpr TypeDesc TypeFloat2 (TypeDesc::FLOAT, TypeDesc::VEC2);
+inline constexpr TypeDesc TypeVector2 (TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::VECTOR);
+inline constexpr TypeDesc TypeFloat4 (TypeDesc::FLOAT, TypeDesc::VEC4);
+inline constexpr TypeDesc TypeVector4 = TypeFloat4;
+inline constexpr TypeDesc TypeString (TypeDesc::STRING);
+inline constexpr TypeDesc TypeInt (TypeDesc::INT);
+inline constexpr TypeDesc TypeUInt (TypeDesc::UINT);
+inline constexpr TypeDesc TypeInt32 (TypeDesc::INT);
+inline constexpr TypeDesc TypeUInt32 (TypeDesc::UINT);
+inline constexpr TypeDesc TypeInt16 (TypeDesc::INT16);
+inline constexpr TypeDesc TypeUInt16 (TypeDesc::UINT16);
+inline constexpr TypeDesc TypeInt8 (TypeDesc::INT8);
+inline constexpr TypeDesc TypeUInt8 (TypeDesc::UINT8);
+inline constexpr TypeDesc TypeInt64 (TypeDesc::INT64);
+inline constexpr TypeDesc TypeUInt64 (TypeDesc::UINT64);
+inline constexpr TypeDesc TypeVector2i(TypeDesc::INT, TypeDesc::VEC2);
+inline constexpr TypeDesc TypeVector3i(TypeDesc::INT, TypeDesc::VEC3);
+inline constexpr TypeDesc TypeBox2(TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::BOX, 2);
+inline constexpr TypeDesc TypeBox3(TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::BOX, 2);
+inline constexpr TypeDesc TypeBox2i(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX, 2);
+inline constexpr TypeDesc TypeBox3i(TypeDesc::INT, TypeDesc::VEC3, TypeDesc::BOX, 2);
+inline constexpr TypeDesc TypeHalf (TypeDesc::HALF);
+inline constexpr TypeDesc TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, TypeDesc::TIMECODE, 2);
+inline constexpr TypeDesc TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
+inline constexpr TypeDesc TypeRational(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::RATIONAL);
+inline constexpr TypeDesc TypePointer(TypeDesc::PTR);
+inline constexpr TypeDesc TypeUstringhash(TypeDesc::USTRINGHASH);
 
 
 

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -157,7 +157,7 @@ private:
 
 
 // Access to an internal periodic blue noise table.
-OIIO_INLINE_CONSTEXPR int bntable_res = 256;
+inline constexpr int bntable_res = 256;
 extern float bluenoise_table[bntable_res][bntable_res][4];
 
 // 1-channel value lookup of periodic blue noise of a 2D coordinate.


### PR DESCRIPTION
Our minimum C++ version allows `inline constexpr`, just use it.
