### PR TITLE
fix(ImageBuf): IB::pixeltype() did not always return the right value

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -189,7 +189,7 @@ public:
     TypeDesc pixeltype() const
     {
         validate_spec();
-        return m_localpixels ? m_spec.format : m_cachedpixeltype;
+        return cachedpixels() ? m_cachedpixeltype : m_spec.format;
     }
 
     DeepData* deepdata()
@@ -1128,6 +1128,7 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
         if (peltype != TypeDesc::UNKNOWN) {
             m_spec.format = (TypeDesc::BASETYPE)peltype;
             m_spec.channelformats.clear();
+            m_cachedpixeltype = m_spec.format;
         }
 
         if (m_nsubimages) {


### PR DESCRIPTION
The implementation of IB::pixeltype() was:

- Make sure at least the spec had been read (lazy read).
- If there are "local pixels", return the pixel type from the spec, otherwise return the cache pixel type.

But there is a flaw in this logic: If only the metadata has been read but not the pixels, the local pixels might not be allocated yet, but also there is not a cache and no cached pixel type, so pixeltype() will return UNKNOWN even though we do already know what type of pixels will be stored when they are eventually read.

The correct logic is:

- Make sure at least the spec had been read (lazy read).
- If it's a cached image, return the cache pixel type, otherwise return the pixel type from the spec (which will be correct because we definitely have read the spec at this point).

Also, for legit cached images, ensure that cachedpixeltype is set upon read_spec() and doesn't have to wait for a full read().
