### PR TITLE
ci: Switch to using ARM-native linux runners

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -157,7 +157,7 @@ jobs:
 
   linux-arm:
       name: Build wheels on Linux ARM
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04-arm
       if: |
         github.event_name != 'schedule' ||
         github.repository == 'AcademySoftwareFoundation/OpenImageIO'
@@ -199,12 +199,7 @@ jobs:
           name: Install Python
           with:
             python-version: '3.9'
-
-        - name: Set up QEMU
-          uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-          with:
-            platforms: all
-
+        
         - name: Build wheels
           uses: pypa/cibuildwheel@d4a2945fcc8d13f20a1b99d461b8e844d5fc6e23 # v2.21.1
           env:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -206,10 +206,6 @@ jobs:
             CIBW_BUILD: ${{ matrix.python }}
             CIBW_ARCHS: ${{ matrix.arch }}
             CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
-            # Apparently, the x86_64 runners aren't able to execute tests
-            # tests for ARM wheels. 
-            # TODO: Re-enable tests when linux ARM runners are available
-            CIBW_TEST_SKIP: '*'
 
         - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
           with:


### PR DESCRIPTION
## Description

Use the publicly-available ARM-native linux runners for CI checks and building Python wheels