### PR TITLE
ci: Run wheel workflow on certain pushes

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,9 +13,13 @@ permissions:
 
 on:
   push:
-    # Workflow run on tags for v3 only.
+    # Workflow run on tags for v3 only, or pre-tagged pushes of release, or
+    # dev-3.* branches.
     tags:
       - v3.*
+    branches:
+      - release
+      - dev-3.*
   pull_request:
     # Workflow run on pull_request only when related files change.
     paths:


### PR DESCRIPTION
We were only running the wheel workflow on pushes of TAGS, but this change also will run it when we push to release, and dev-3.* branches.

My usual release workflow is to first push the "release" branch, watch for it to pass CI, then add the tag and push the tag and draft the release.  If a problem with the wheel workflow isn't discovered until we've already pushed the tag, then a fix will require a new tag and new release (we never re-tag a release). So this change will allow us to catch any problems with the wheel worflow BEFORE we actually irrevocably make the tag, since it's no big deal to add corrections to the branch before tagging. It still won't upload the wheels until the tag itself is pushed.
