### PR TITLE
fix(build): Fix recently broken rpath setting

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -698,9 +698,9 @@ else ()
         else()
             set(BASEPOINT $ORIGIN)
         endif()
-        set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR}
-                                 ${BASEPOINT}
-                                 ${BASEPOINT}/${CMAKE_INSTALL_LIBDIR})
+        set (CMAKE_INSTALL_RPATH ${BASEPOINT}
+                                 ${BASEPOINT}/${CMAKE_INSTALL_LIBDIR}
+                                 ${BASEPOINT}/../${CMAKE_INSTALL_LIBDIR})
     endif ()
     # add the automatically determined parts of the RPATH that
     # point to directories outside the build tree to the install RPATH

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -698,7 +698,9 @@ else ()
         else()
             set(BASEPOINT $ORIGIN)
         endif()
-        set (CMAKE_INSTALL_RPATH ${BASEPOINT} ${BASEPOINT}/${CMAKE_INSTALL_LIBDIR})
+        set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR}
+                                 ${BASEPOINT}
+                                 ${BASEPOINT}/${CMAKE_INSTALL_LIBDIR})
     endif ()
     # add the automatically determined parts of the RPATH that
     # point to directories outside the build tree to the install RPATH

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -699,7 +699,6 @@ else ()
             set(BASEPOINT $ORIGIN)
         endif()
         set (CMAKE_INSTALL_RPATH ${BASEPOINT}
-                                 ${BASEPOINT}/${CMAKE_INSTALL_LIBDIR}
                                  ${BASEPOINT}/../${CMAKE_INSTALL_LIBDIR})
     endif ()
     # add the automatically determined parts of the RPATH that

--- a/src/cmake/fancy_add_executable.cmake
+++ b/src/cmake/fancy_add_executable.cmake
@@ -53,12 +53,6 @@ macro (fancy_add_executable)
         target_link_libraries (${_target_NAME} PRIVATE ${_target_LINK_LIBRARIES})
         target_link_libraries (${_target_NAME} PRIVATE ${PROFILER_LIBRARIES})
         set_target_properties (${_target_NAME} PROPERTIES FOLDER ${_target_FOLDER})
-        if (SKBUILD) 
-            # The installed bin and lib directories are at the same level, so we
-            # need to set the rpath to look for the libraries in ../lib
-            set_target_properties (${_target_NAME} PROPERTIES
-                INSTALL_RPATH "$<IF:$<BOOL:${APPLE}>,@loader_path,$ORIGIN>/../${CMAKE_INSTALL_LIBDIR}")
-        endif ()
         check_is_enabled (INSTALL_${_target_NAME} _target_NAME_INSTALL_enabled)
         if (CMAKE_UNITY_BUILD AND UNITY_BUILD_MODE STREQUAL GROUP)
             set_source_files_properties(${_target_SRC} PROPERTIES

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -107,8 +107,6 @@ function (setup_oiio_util_library targetname)
     
     if (SKBUILD)
         set (PYTHON_SITE_DIR .)
-        set_target_properties (${targetname} PROPERTIES
-                INSTALL_RPATH "$<IF:$<BOOL:${APPLE}>,@loader_path,$ORIGIN>/${CMAKE_INSTALL_LIBDIR}")
         install_targets (NAMELINK_SKIP ${targetname})
     else ()
         install_targets (${targetname})


### PR DESCRIPTION
As part of the recent big python wheel merge, compiler.cmake got changed in a subtle way in how it sets CMAKE_INSTALL_RPATH.

This broken iv for me on a Mac with dynamic libraries. Strangely (and I'm too lazy to chase down exactly why), oiiotool seems fine.  So this was missed entirely by the CI, which never runs 'iv', since it's an interactive app. (Note to self: we should find some way to at least verify that it can execute as part of the testsuite.)

Anyway, I believe that this change adds the install lib area back to the path, and it does seem to repair my ability to run iv on my end.
