### PR TITLE
oiiotool: better handling of wildcards that match no files

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -7329,6 +7329,12 @@ handle_sequence(Oiiotool& ot, int argc, const char** argv)
         nfilenames = frame_numbers[0].size();
     }
 
+    if (!nfilenames) {
+        // No filenames matched the first wildcard pattern
+        ot.warning("", "No frame number or views matched the wildcards");
+        return false;
+    }
+
     // Make sure frame_numbers[0] has the canonical frame number list
     if (sequence_args.size() && frame_numbers[0].empty())
         frame_numbers[0] = frame_numbers[sequence_args[0]];

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -281,7 +281,10 @@ Sequence -5--2:  -5
 Sequence -5--2:  -4
 Sequence -5--2:  -3
 Sequence -5--2:  -2
-oiiotool WARNING : oiiotool produced no output. Did you forget -o?
+oiiotool WARNING : No frame number or views matched the wildcards
+oiiotool ERROR: read : File does not exist: "notfound.#.jpg"
+Full command line was:
+> oiiotool notfound.#.jpg -o alsonotfound.#.jpg
 oiiotool ERROR : Not all sequence specifications matched: copyA.#.jpg (10 frames) vs. copyC.1-5#.jpg (5 frames)
 Full command line was:
 > 


### PR DESCRIPTION
When you use frame or view wildcards, for example:

    oiiotool foo.%04d.tif -o bar.%04d.exr

we noticed that if NO files matched, no iteration would occur. You would get this output:

```
$ oiiotool foo.%04d.tif -o bar.%04d.exr
oiiotool WARNING : oiiotool produced no output. Did you forget -o?
```

But maybe this is not helpful and it should be some kind of error to ask for a match and not get one? Or at least give a more clear explanation of what happened.

This PR detects the case where there is no match of the wildcard at all, warns about that, and then tries interpreting the command line literally (no wildcard expansion). So now the output is

```
$ oiiotool foo.%04d.tif -o bar.%04d.exr
oiiotool WARNING : No frame number or views matched the wildcards
oiiotool ERROR: read : File does not exist: "foo.%04d.tif"
Full command line was:
> oiiotool foo.%04d.tif -o bar.%04d.exr
```

Closes #4623
