### PR TITLE
fix(exr): fill in OpenEXR lineOrder attribute when reading

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -129,7 +129,6 @@ static std::map<std::string, std::string> exr_tag_to_oiio_std {
     { "envmap", "" },
     { "tiledesc", "" },
     { "tiles", "" },
-    { "openexr:lineOrder", "openexr:lineOrder" },
     { "type", "" },
 
     // FIXME: Things to consider in the future:
@@ -637,18 +636,18 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
                         oname, n, d);
                 }
             }
-        }
-        else if (type == "lineOrder"
-            && (lattr = header->findTypedAttribute<Imf::LineOrderAttribute>(
-            name))) {
-                std::string lineOrder = "increasingY";
-                switch (lattr->value()) {
-                case Imf::INCREASING_Y: lineOrder = "increasingY"; break;
-                case Imf::DECREASING_Y: lineOrder = "decreasingY"; break;
-                case Imf::RANDOM_Y: lineOrder = "randomY"; break;
-                default: break;
-                }
-                spec.attribute(oname, lineOrder);
+        } else if (type == "lineOrder"
+                   && (lattr
+                       = header->findTypedAttribute<Imf::LineOrderAttribute>(
+                           name))) {
+            const char* lineOrder = "increasingY";
+            switch (lattr->value()) {
+            case Imf::INCREASING_Y: lineOrder = "increasingY"; break;
+            case Imf::DECREASING_Y: lineOrder = "decreasingY"; break;
+            case Imf::RANDOM_Y: lineOrder = "randomY"; break;
+            default: break;
+            }
+            spec.attribute("openexr:lineOrder", lineOrder);
         } else {
 #if 0
             print(std::cerr, "  unknown attribute '{}' name '{}'\n",

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -47,6 +47,7 @@ OIIO_GCC_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")
 #include <OpenEXR/ImfInputPart.h>
 #include <OpenEXR/ImfIntAttribute.h>
 #include <OpenEXR/ImfKeyCodeAttribute.h>
+#include <OpenEXR/ImfLineOrderAttribute.h>
 #include <OpenEXR/ImfMatrixAttribute.h>
 #include <OpenEXR/ImfMultiPartInputFile.h>
 #include <OpenEXR/ImfPartType.h>
@@ -128,7 +129,7 @@ static std::map<std::string, std::string> exr_tag_to_oiio_std {
     { "envmap", "" },
     { "tiledesc", "" },
     { "tiles", "" },
-    { "openexr:lineOrder", "" },
+    { "openexr:lineOrder", "openexr:lineOrder" },
     { "type", "" },
 
     // FIXME: Things to consider in the future:
@@ -467,6 +468,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         const Imf::V3dAttribute* v3dattr;
         const Imf::M33dAttribute* m33dattr;
         const Imf::M44dAttribute* m44dattr;
+        const Imf::LineOrderAttribute* lattr;
         const char* name = hit.name();
         auto found       = exr_tag_to_oiio_std.find(name);
         std::string oname(found != exr_tag_to_oiio_std.end() ? found->second
@@ -635,6 +637,18 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
                         oname, n, d);
                 }
             }
+        }
+        else if (type == "lineOrder"
+            && (lattr = header->findTypedAttribute<Imf::LineOrderAttribute>(
+            name))) {
+                std::string lineOrder = "increasingY";
+                switch (lattr->value()) {
+                case Imf::INCREASING_Y: lineOrder = "increasingY"; break;
+                case Imf::DECREASING_Y: lineOrder = "decreasingY"; break;
+                case Imf::RANDOM_Y: lineOrder = "randomY"; break;
+                default: break;
+                }
+                spec.attribute(oname, lineOrder);
         } else {
 #if 0
             print(std::cerr, "  unknown attribute '{}' name '{}'\n",

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -275,7 +275,6 @@ static std::map<std::string, std::string> cexr_tag_to_oiio_std {
     { "envmap", "" },
     { "tiledesc", "" },
     { "tiles", "" },
-    { "openexr:lineOrder", "openexr:lineOrder" },
     { "type", "" },
 
     // FIXME: Things to consider in the future:
@@ -737,7 +736,7 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
             case EXR_LINEORDER_RANDOM_Y: lineOrder = "randomY"; break;
             default: break;
             }
-            spec.attribute(oname, lineOrder);
+            spec.attribute("openexr:lineOrder", lineOrder);
             break;
         }
 

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -275,7 +275,7 @@ static std::map<std::string, std::string> cexr_tag_to_oiio_std {
     { "envmap", "" },
     { "tiledesc", "" },
     { "tiles", "" },
-    { "openexr:lineOrder", "" },
+    { "openexr:lineOrder", "openexr:lineOrder" },
     { "type", "" },
 
     // FIXME: Things to consider in the future:
@@ -737,7 +737,7 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
             case EXR_LINEORDER_RANDOM_Y: lineOrder = "randomY"; break;
             default: break;
             }
-            spec.attribute("openexr:lineOrder", lineOrder);
+            spec.attribute(oname, lineOrder);
             break;
         }
 

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -729,12 +729,23 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
             break;
         }
 
+        case EXR_ATTR_LINEORDER: {
+            std::string lineOrder = "increasingY";
+            switch (attr->uc) {
+            case EXR_LINEORDER_INCREASING_Y: lineOrder = "increasingY"; break;
+            case EXR_LINEORDER_DECREASING_Y: lineOrder = "decreasingY"; break;
+            case EXR_LINEORDER_RANDOM_Y: lineOrder = "randomY"; break;
+            default: break;
+            }
+            spec.attribute("openexr:lineOrder", lineOrder);
+            break;
+        }
+
         case EXR_ATTR_PREVIEW:
         case EXR_ATTR_OPAQUE:
         case EXR_ATTR_ENVMAP:
         case EXR_ATTR_COMPRESSION:
         case EXR_ATTR_CHLIST:
-        case EXR_ATTR_LINEORDER:
         case EXR_ATTR_TILEDESC:
         default:
 #if 0

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -8,6 +8,7 @@ out.exr              :   64 x   64, 6 channel, half openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading out2.exr
 out2.exr             :   64 x   64, 6 channel, half openexr
     SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
@@ -21,3 +22,4 @@ out2.exr             :   64 x   64, 6 channel, half openexr
     oiio:subimagename: "Aimg"
     oiio:subimages: 1
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"

--- a/testsuite/iinfo/ref/out-fmt6.txt
+++ b/testsuite/iinfo/ref/out-fmt6.txt
@@ -149,6 +149,7 @@ src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern cons
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     oiio:ColorSpace: "lin_rec709"
 src/tiny-az.exr :     oiio:subimages: 1
+src/tiny-az.exr :     openexr:lineOrder: "increasingY"
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
     Stats Max: 0.250000 0.500000 0.750000 (float)
     Stats Avg: 0.250000 0.500000 0.750000 (float)
@@ -176,6 +177,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000
     Pixel (3, 2): 0.250000000 0.500000000 0.750000000
     Pixel (4, 2): 0.250000000 0.500000000 0.750000000
@@ -215,6 +217,7 @@ src/tinydeep.exr :    4 x    4, 2 channel, deep float openexr
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     oiio:subimages: 1
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
     Stats Min: 1.000000 10.000000 (float)
     Stats Max: 1.000000 10.000000 (float)
     Stats Avg: 1.000000 10.000000 (float)
@@ -249,6 +252,7 @@ src/tinydeep.exr     :    4 x    4, 2 channel, deep float openexr
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     oiio:subimages: 1
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
     Pixel (0, 0): 0 samples 
     Pixel (1, 0): 0 samples 
     Pixel (2, 0): 0 samples 

--- a/testsuite/iinfo/ref/out.txt
+++ b/testsuite/iinfo/ref/out.txt
@@ -149,6 +149,7 @@ src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern cons
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     oiio:ColorSpace: "lin_rec709"
 src/tiny-az.exr :     oiio:subimages: 1
+src/tiny-az.exr :     openexr:lineOrder: "increasingY"
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
     Stats Max: 0.250000 0.500000 0.750000 (float)
     Stats Avg: 0.250000 0.500000 0.750000 (float)
@@ -176,6 +177,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000
     Pixel (3, 2): 0.250000000 0.500000000 0.750000000
     Pixel (4, 2): 0.250000000 0.500000000 0.750000000
@@ -215,6 +217,7 @@ src/tinydeep.exr :    4 x    4, 2 channel, deep float openexr
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     oiio:subimages: 1
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
     Stats Min: 1.000000 10.000000 (float)
     Stats Max: 1.000000 10.000000 (float)
     Stats Avg: 1.000000 10.000000 (float)
@@ -249,6 +252,7 @@ src/tinydeep.exr     :    4 x    4, 2 channel, deep float openexr
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     oiio:subimages: 1
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
     Pixel (0, 0): 0 samples 
     Pixel (1, 0): 0 samples 
     Pixel (2, 0): 0 samples 

--- a/testsuite/maketx/ref/out-macarm.txt
+++ b/testsuite/maketx/ref/out-macarm.txt
@@ -319,6 +319,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -346,6 +347,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading small.tif
 small.tif            :   64 x   64, 3 channel, uint8 tiff
@@ -437,6 +439,7 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading cdf.exr
 cdf.exr              :   64 x   64, 1 channel, half openexr
@@ -457,6 +460,7 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     oiio:AverageColor: "0.499779"
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading bumpslope-cdf.exr
 bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
@@ -488,6 +492,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading checker-attribs.tx
 checker-attribs.tx   :  128 x  128, 4 channel, uint8 tiff

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -319,6 +319,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -346,6 +347,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading small.tif
 small.tif            :   64 x   64, 3 channel, uint8 tiff
@@ -437,6 +439,7 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading cdf.exr
 cdf.exr              :   64 x   64, 1 channel, half openexr
@@ -457,6 +460,7 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     oiio:AverageColor: "0.499779"
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading bumpslope-cdf.exr
 bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
@@ -488,6 +492,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading checker-attribs.tx
 checker-attribs.tx   :  128 x  128, 4 channel, uint8 tiff

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -72,6 +72,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
  subimage  1:   64 x   64, 3 channel, half openexr
     SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
     channel list: R, G, B
@@ -85,6 +86,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
 Reading attrib0.exr
 attrib0.exr          :   64 x   64, 3 channel, half openexr
     2 subimages: 64x64 [h,h,h], 64x64 [h,h,h]
@@ -100,6 +102,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
  subimage  1:   64 x   64, 3 channel, half openexr
     SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
     channel list: R, G, B
@@ -112,6 +115,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
 Reading tahoe-icc.jpg
 tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     SHA-1: 9119399610EF6CACDAD0EBAF4D663E4EDEF70B58

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -72,6 +72,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
  subimage  1:   64 x   64, 3 channel, half openexr
     SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
     channel list: R, G, B
@@ -85,6 +86,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
 Reading attrib0.exr
 attrib0.exr          :   64 x   64, 3 channel, half openexr
     2 subimages: 64x64 [h,h,h], 64x64 [h,h,h]
@@ -100,6 +102,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
  subimage  1:   64 x   64, 3 channel, half openexr
     SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
     channel list: R, G, B
@@ -112,6 +115,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
 Reading tahoe-icc.jpg
 tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     SHA-1: BC4C6090E793819E1A2869AAA8FBEE3587CC6947

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -15,6 +15,7 @@ allhalf.exr          :   38 x   38, 5 channel, half openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading rgbahalf-zfloat.exr
 rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     SHA-1: 9324AFD44451321A8D87E09F656C7B86E827E5CD
@@ -28,6 +29,7 @@ rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 explicit -d uint save result: 
 uint8.tif            :  128 x  128, 3 channel, uint8 tiff
     tile size: 16 x 16
@@ -68,6 +70,7 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading green.exr
 green.exr            :   64 x   64, 3 channel, half openexr
     SHA-1: 8B61993247469F3C208CA894D71856727B11606A
@@ -78,6 +81,7 @@ green.exr            :   64 x   64, 3 channel, half openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading greenmeta.exr
 greenmeta.exr        :   64 x   64, 3 channel, half openexr
     SHA-1: 8B61993247469F3C208CA894D71856727B11606A
@@ -91,6 +95,7 @@ greenmeta.exr        :   64 x   64, 3 channel, half openexr
     weight: 20.5
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading nometamerge.exr
 nometamerge.exr      :   64 x   64, 6 channel, float openexr
     SHA-1: 9F13A523321C66208E90D45F87FA0CD9B370E111
@@ -102,6 +107,7 @@ nometamerge.exr      :   64 x   64, 6 channel, float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading metamerge.exr
 metamerge.exr        :   64 x   64, 6 channel, float openexr
     SHA-1: 9F13A523321C66208E90D45F87FA0CD9B370E111
@@ -114,6 +120,7 @@ metamerge.exr        :   64 x   64, 6 channel, float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Testing -o with no image
 oiiotool WARNING: -o : out.tif did not have any current image to output.
 Comparing "rgonly.exr" and "ref/rgonly.exr"

--- a/testsuite/oiiotool-deep/ref/out-fmt6.txt
+++ b/testsuite/oiiotool-deep/ref/out-fmt6.txt
@@ -14,6 +14,7 @@ allhalf.exr          :  160 x  120, 2 channel, deep half openexr
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
     oiio:subimages: 1
     openexr:chunkCount: 6
+    openexr:lineOrder: "randomY"
     Stats Min: 0.011902 3.031250 (float)
     Stats Max: 0.261963 5.000000 (float)
     Stats Avg: 0.082321 4.119433 (float)
@@ -57,6 +58,7 @@ swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
     oiio:subimages: 1
     openexr:chunkCount: 6
+    openexr:lineOrder: "randomY"
     Stats Min: 0.011902 3.031250 (float)
     Stats Max: 0.261963 5.000000 (float)
     Stats Avg: 0.082321 4.119433 (float)
@@ -95,6 +97,7 @@ tinydeep.exr         :    4 x    4, 2 channel, deep float openexr
     version: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
     Pixel (0, 0): 0 samples 
     Pixel (1, 0): 0 samples 
     Pixel (2, 0): 0 samples 

--- a/testsuite/oiiotool-deep/ref/out.txt
+++ b/testsuite/oiiotool-deep/ref/out.txt
@@ -14,6 +14,7 @@ allhalf.exr          :  160 x  120, 2 channel, deep half openexr
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
     oiio:subimages: 1
     openexr:chunkCount: 6
+    openexr:lineOrder: "randomY"
     Stats Min: 0.011902 3.031250 (float)
     Stats Max: 0.261963 5.000000 (float)
     Stats Avg: 0.082321 4.119433 (float)
@@ -57,6 +58,7 @@ swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
     oiio:subimages: 1
     openexr:chunkCount: 6
+    openexr:lineOrder: "randomY"
     Stats Min: 0.011902 3.031250 (float)
     Stats Max: 0.261963 5.000000 (float)
     Stats Avg: 0.082321 4.119433 (float)
@@ -95,6 +97,7 @@ tinydeep.exr         :    4 x    4, 2 channel, deep float openexr
     version: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
     Pixel (0, 0): 0 samples 
     Pixel (1, 0): 0 samples 
     Pixel (2, 0): 0 samples 

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -11,6 +11,7 @@ src/bad.exr          :   64 x   64, 3 channel, half openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -30,6 +31,7 @@ black.exr            :   64 x   64, 3 channel, half openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.499756 0.500000 0.500000 (float)
@@ -49,6 +51,7 @@ box3.exr             :   64 x   64, 3 channel, half openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)

--- a/testsuite/oiiotool-maketx/ref/out-macarm.txt
+++ b/testsuite/oiiotool-maketx/ref/out-macarm.txt
@@ -281,6 +281,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -310,6 +311,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
     MIP 0 of 2 (2 x 2):
       Stats Min: 65504.000000 65504.000000 65504.000000 (float)
@@ -352,6 +354,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading grid.tx
     oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
@@ -600,4 +603,5 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -555,4 +555,5 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out-win.txt
+++ b/testsuite/oiiotool-maketx/ref/out-win.txt
@@ -281,6 +281,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -310,6 +311,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
     MIP 0 of 2 (2 x 2):
       Stats Min: 65504.000000 65504.000000 65504.000000 (float)
@@ -352,6 +354,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading grid.tx
     oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
@@ -600,4 +603,5 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -281,6 +281,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
+    openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -310,6 +311,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
     MIP 0 of 2 (2 x 2):
       Stats Min: 65504.000000 65504.000000 65504.000000 (float)
@@ -352,6 +354,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Reading grid.tx
     oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
@@ -600,4 +603,5 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-subimage/ref/out.txt
+++ b/testsuite/oiiotool-subimage/ref/out.txt
@@ -14,6 +14,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "layerA"
     oiio:subimages: 4
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
  subimage  1:   64 x   64, 3 channel, half openexr
     SHA-1: 0E19BEFEF868E356A6A4C6450DA9A7B17DD11E12
     channel list: R, G, B
@@ -27,6 +28,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "layerB"
     oiio:subimages: 4
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
  subimage  2:   64 x   64, 3 channel, half openexr
     SHA-1: CFAF4AFC253320AC35B8E9014C6D750768354059
     channel list: R, G, B
@@ -40,6 +42,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "layerC"
     oiio:subimages: 4
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
  subimage  3:   64 x   64, 3 channel, half openexr
     SHA-1: 5FFA4616F46509627873D2C53744E47E2F492719
     channel list: R, G, B
@@ -53,6 +56,7 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     oiio:subimagename: "layerD"
     oiio:subimages: 4
     openexr:chunkCount: 4
+    openexr:lineOrder: "increasingY"
 Reading mip4.tif
 mip4.tif             :   64 x   64, 4 channel, uint8 tiff
     SHA-1: 36CE573A20E682720B020FC689E2067579DE5B37

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -42,6 +42,7 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 dumpdata:
 dump.exr             :    2 x    2, 3 channel, half openexr
     Pixel (0, 0): 0.000000000 0.000000000 0.000000000

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -9,6 +9,7 @@ Reading ../openexr-images/Chromaticities/Rec709.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Chromaticities/Rec709.exr" and "Rec709.exr"
 PASS
 Reading ../openexr-images/Chromaticities/XYZ.exr
@@ -23,6 +24,7 @@ Reading ../openexr-images/Chromaticities/XYZ.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Chromaticities/XYZ.exr" and "XYZ.exr"
 PASS
 Reading ../openexr-images/LuminanceChroma/Garden.exr
@@ -36,5 +38,6 @@ Reading ../openexr-images/LuminanceChroma/Garden.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/LuminanceChroma/Garden.exr" and "Garden.exr"
 PASS

--- a/testsuite/openexr-decreasingy/ref/out.txt
+++ b/testsuite/openexr-decreasingy/ref/out.txt
@@ -11,6 +11,7 @@ increasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
     YResolution: 72
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading increasingY-copy.exr
 increasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     channel list: R, G, B
@@ -24,6 +25,7 @@ increasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     YResolution: 72
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Reading decreasingY-resize.exr
 decreasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
     channel list: R, G, B
@@ -37,6 +39,7 @@ decreasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
     YResolution: 72
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "decreasingY"
 Reading decreasingY-copy.exr
 decreasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     channel list: R, G, B
@@ -50,6 +53,7 @@ decreasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     YResolution: 72
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "decreasingY"
 Comparing "increasingY-copy.exr" and "decreasingY-copy.exr"
 PASS
 Comparing "increasingY-resize.exr" and "decreasingY-resize.exr"

--- a/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
@@ -9,6 +9,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/Rec709_YC.exr" and "Rec709_YC.exr"
 PASS
@@ -24,6 +25,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/XYZ_YC.exr" and "XYZ_YC.exr"
 PASS
@@ -39,6 +41,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/CrissyField.exr" and "CrissyField.exr"
 PASS
@@ -53,6 +56,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/Flowers.exr" and "Flowers.exr"
 PASS
@@ -67,6 +71,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/MtTamNorth.exr" and "MtTamNorth.exr"
 PASS
@@ -81,6 +86,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/StarField.exr" and "StarField.exr"
 PASS

--- a/testsuite/openexr-luminance-chroma/ref/out.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out.txt
@@ -9,6 +9,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/Rec709_YC.exr" and "Rec709_YC.exr"
 PASS
@@ -24,6 +25,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/Chromaticities/XYZ_YC.exr" and "XYZ_YC.exr"
 PASS
@@ -39,6 +41,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/CrissyField.exr" and "CrissyField.exr"
 PASS
@@ -53,6 +56,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/Flowers.exr" and "Flowers.exr"
 PASS
@@ -67,6 +71,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/MtTamNorth.exr" and "MtTamNorth.exr"
 PASS
@@ -81,6 +86,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
 Comparing "../openexr-images/LuminanceChroma/StarField.exr" and "StarField.exr"
 PASS

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -14,6 +14,7 @@ Reading ../openexr-images/MultiResolution/Bonita.exr
     wrapmodes: "clamp,clamp"
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/Bonita.exr" and "Bonita.exr"
 PASS
@@ -33,6 +34,7 @@ Reading ../openexr-images/MultiResolution/ColorCodedLevels.exr
     wrapmodes: "periodic,periodic"
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/ColorCodedLevels.exr" and "ColorCodedLevels.exr"
 PASS
@@ -53,6 +55,7 @@ Reading ../openexr-images/MultiResolution/KernerEnvCube.exr
     oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/KernerEnvCube.exr" and "KernerEnvCube.exr"
 PASS
@@ -72,6 +75,7 @@ Reading ../openexr-images/MultiResolution/KernerEnvLatLong.exr
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/KernerEnvLatLong.exr" and "KernerEnvLatLong.exr"
 PASS
@@ -90,6 +94,7 @@ Reading ../openexr-images/MultiResolution/MirrorPattern.exr
     wrapmodes: "mirror,mirror"
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/MirrorPattern.exr" and "MirrorPattern.exr"
 PASS
@@ -110,6 +115,7 @@ Reading ../openexr-images/MultiResolution/OrientationCube.exr
     oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/OrientationCube.exr" and "OrientationCube.exr"
 PASS
@@ -129,6 +135,7 @@ Reading ../openexr-images/MultiResolution/OrientationLatLong.exr
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/OrientationLatLong.exr" and "OrientationLatLong.exr"
 PASS
@@ -147,6 +154,7 @@ Reading ../openexr-images/MultiResolution/PeriodicPattern.exr
     wrapmodes: "periodic,periodic"
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/PeriodicPattern.exr" and "PeriodicPattern.exr"
 PASS
@@ -167,6 +175,7 @@ Reading ../openexr-images/MultiResolution/StageEnvCube.exr
     oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/StageEnvCube.exr" and "StageEnvCube.exr"
 PASS
@@ -186,6 +195,7 @@ Reading ../openexr-images/MultiResolution/StageEnvLatLong.exr
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 1
 Comparing "../openexr-images/MultiResolution/StageEnvLatLong.exr" and "StageEnvLatLong.exr"
 PASS
@@ -206,6 +216,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesCube.exr
     oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/WavyLinesCube.exr" and "WavyLinesCube.exr"
 PASS
@@ -225,6 +236,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesLatLong.exr
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiResolution/WavyLinesLatLong.exr" and "WavyLinesLatLong.exr"
 PASS
@@ -239,6 +251,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesSphere.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"
 PASS
 Reading ../openexr-images/MultiView/Adjuster.exr
@@ -256,6 +269,7 @@ Reading ../openexr-images/MultiView/Adjuster.exr
     YResolution: 100
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Adjuster.exr" and "Adjuster.exr"
 PASS
 Reading ../openexr-images/MultiView/Balls.exr
@@ -272,6 +286,7 @@ Reading ../openexr-images/MultiView/Balls.exr
     YResolution: 100
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Balls.exr" and "Balls.exr"
 PASS
 Reading ../openexr-images/MultiView/Fog.exr
@@ -291,6 +306,7 @@ Reading ../openexr-images/MultiView/Fog.exr
     XResolution: 100
     YResolution: 100
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Fog.exr" and "Fog.exr"
 PASS
 Reading ../openexr-images/MultiView/Impact.exr
@@ -313,6 +329,7 @@ Reading ../openexr-images/MultiView/Impact.exr
     YResolution: 100
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
 Comparing "../openexr-images/MultiView/Impact.exr" and "Impact.exr"
 PASS
@@ -333,5 +350,6 @@ Reading ../openexr-images/MultiView/LosPadres.exr
     YResolution: 100
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/LosPadres.exr" and "LosPadres.exr"
 PASS

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -16,6 +16,7 @@ Reading ../openexr-images/ScanLines/Blobbies.exr
     whiteLuminance: 50
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "decreasingY"
 Comparing "../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
 PASS
 Reading ../openexr-images/ScanLines/CandleGlass.exr
@@ -33,6 +34,7 @@ Reading ../openexr-images/ScanLines/CandleGlass.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/CandleGlass.exr" and "CandleGlass.exr"
 PASS
 Reading ../openexr-images/ScanLines/Cannon.exr
@@ -46,6 +48,7 @@ Reading ../openexr-images/ScanLines/Cannon.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
 PASS
 Reading ../openexr-images/ScanLines/Desk.exr
@@ -58,6 +61,7 @@ Reading ../openexr-images/ScanLines/Desk.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Desk.exr" and "Desk.exr"
 PASS
 Reading ../openexr-images/ScanLines/MtTamWest.exr
@@ -77,6 +81,7 @@ Reading ../openexr-images/ScanLines/MtTamWest.exr
     utcOffset: 25200
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/MtTamWest.exr" and "MtTamWest.exr"
 PASS
 Reading ../openexr-images/ScanLines/PrismsLenses.exr
@@ -94,6 +99,7 @@ Reading ../openexr-images/ScanLines/PrismsLenses.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/PrismsLenses.exr" and "PrismsLenses.exr"
 PASS
 Reading ../openexr-images/ScanLines/StillLife.exr
@@ -109,6 +115,7 @@ Reading ../openexr-images/ScanLines/StillLife.exr
     utcOffset: 25200
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/StillLife.exr" and "StillLife.exr"
 PASS
 Reading ../openexr-images/ScanLines/Tree.exr
@@ -127,6 +134,7 @@ Reading ../openexr-images/ScanLines/Tree.exr
     whiteLuminance: 621
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Tree.exr" and "Tree.exr"
 PASS
 Reading ../openexr-images/TestImages/AllHalfValues.exr
@@ -139,6 +147,7 @@ Reading ../openexr-images/TestImages/AllHalfValues.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/AllHalfValues.exr" and "AllHalfValues.exr"
 PASS
 Reading ../openexr-images/TestImages/BrightRings.exr
@@ -151,6 +160,7 @@ Reading ../openexr-images/TestImages/BrightRings.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/BrightRings.exr" and "BrightRings.exr"
 PASS
 Reading ../openexr-images/TestImages/BrightRingsNanInf.exr
@@ -163,6 +173,7 @@ Reading ../openexr-images/TestImages/BrightRingsNanInf.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/BrightRingsNanInf.exr" and "BrightRingsNanInf.exr"
 PASS
 Reading ../openexr-images/TestImages/GammaChart.exr
@@ -175,6 +186,7 @@ Reading ../openexr-images/TestImages/GammaChart.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/GammaChart.exr" and "GammaChart.exr"
 PASS
 Reading ../openexr-images/TestImages/GrayRampsDiagonal.exr
@@ -186,6 +198,7 @@ Reading ../openexr-images/TestImages/GrayRampsDiagonal.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/GrayRampsDiagonal.exr" and "GrayRampsDiagonal.exr"
 PASS
 Reading ../openexr-images/TestImages/GrayRampsHorizontal.exr
@@ -197,6 +210,7 @@ Reading ../openexr-images/TestImages/GrayRampsHorizontal.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/GrayRampsHorizontal.exr" and "GrayRampsHorizontal.exr"
 PASS
 Reading ../openexr-images/TestImages/RgbRampsDiagonal.exr
@@ -209,6 +223,7 @@ Reading ../openexr-images/TestImages/RgbRampsDiagonal.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/RgbRampsDiagonal.exr" and "RgbRampsDiagonal.exr"
 PASS
 Reading ../openexr-images/TestImages/SquaresSwirls.exr
@@ -221,6 +236,7 @@ Reading ../openexr-images/TestImages/SquaresSwirls.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/SquaresSwirls.exr" and "SquaresSwirls.exr"
 PASS
 Reading ../openexr-images/TestImages/WideColorGamut.exr
@@ -234,6 +250,7 @@ Reading ../openexr-images/TestImages/WideColorGamut.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/WideColorGamut.exr" and "WideColorGamut.exr"
 PASS
 Reading ../openexr-images/TestImages/WideFloatRange.exr
@@ -245,6 +262,7 @@ Reading ../openexr-images/TestImages/WideFloatRange.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/WideFloatRange.exr" and "WideFloatRange.exr"
 PASS
 Reading ../openexr-images/Tiles/GoldenGate.exr
@@ -269,6 +287,7 @@ Reading ../openexr-images/Tiles/GoldenGate.exr
     utcOffset: 28800
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/GoldenGate.exr" and "GoldenGate.exr"
 PASS
 Reading ../openexr-images/Tiles/Ocean.exr
@@ -284,6 +303,7 @@ Reading ../openexr-images/Tiles/Ocean.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
 PASS
 Reading ../openexr-images/Tiles/Spirals.exr
@@ -305,6 +325,7 @@ Reading ../openexr-images/Tiles/Spirals.exr
     whiteLuminance: 90
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
 PASS
 Reading ../openexr-images/Beachball/singlepart.0001.exr
@@ -323,5 +344,6 @@ Reading ../openexr-images/Beachball/singlepart.0001.exr
     oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Beachball/singlepart.0001.exr" and "singlepart.0001.exr"
 PASS

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -19,7 +19,8 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     oiio:subimagename: "rgba.left"
     oiio:subimages: 4
     openexr:chunkCount: 1078
- subimage  1: 1918 x 1078, 1 channel, half openexr
+    openexr:lineOrder: "increasingY"
+subimage  1: 1918 x 1078, 1 channel, half openexr
     SHA-1: 5FAE17E1E8BDB2E7C3A6B3EBCA8E0CA15A07B80A
     channel list: Z
     pixel data origin: x=1, y=1
@@ -35,6 +36,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     oiio:subimagename: "depth.left"
     oiio:subimages: 4
     openexr:chunkCount: 1078
+    openexr:lineOrder: "increasingY"
  subimage  2: 1918 x 1078, 4 channel, half openexr
     SHA-1: 3CC2362892007C6AACABE356DF93F87408C988B3
     channel list: R, G, B, A
@@ -52,6 +54,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     oiio:subimagename: "rgba.right"
     oiio:subimages: 4
     openexr:chunkCount: 1078
+    openexr:lineOrder: "increasingY"
  subimage  3: 1918 x 1078, 1 channel, half openexr
     SHA-1: FBB31FC1CD9EC4759703F033C8D0E14E5806AE92
     channel list: Z
@@ -68,6 +71,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     oiio:subimagename: "depth.right"
     oiio:subimages: 4
     openexr:chunkCount: 1078
+    openexr:lineOrder: "increasingY"
 ../openexr-images/v2/Stereo/composited.exr : 1918 x 1078, 4 channel, half openexr (4 subimages)
     Stats Min: 0.000000 0.000000 0.000000 0.000000 (float)
     Stats Max: 0.600586 0.593262 0.344971 1.000000 (float)
@@ -101,6 +105,7 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 761
+    openexr:lineOrder: "increasingY"
  subimage  1: 1452 x  761, 5 channel, deep half/half/half/half/float openexr
     SHA-1: 23D591E3BE032257729B30F078D62F6A16D40377
     channel list: R (half), G (half), B (half), A (half), Z (float)
@@ -119,6 +124,7 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 761
+    openexr:lineOrder: "increasingY"
 ../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000169 0.000083 0.000092 0.015625 127.872681 (float)
     Stats Max: 0.622070 0.265625 0.267822 1.000000 738.560669 (float)
@@ -160,6 +166,7 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 1080
+    openexr:lineOrder: "increasingY"
  subimage  1: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     SHA-1: B0B52A15E0E25796832E4C25BD835C3F3B970BC0
     channel list: R (half), G (half), B (half), A (half), Z (float)
@@ -175,6 +182,7 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 1080
+    openexr:lineOrder: "increasingY"
 ../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000099 0.000341 0.000152 0.015625 72.493698 (float)
     Stats Max: 0.403564 0.593262 0.345215 1.000000 954.392700 (float)
@@ -217,6 +225,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "rgba_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  1:  877 x  876, 1 channel, half openexr
     SHA-1: 464AC3E30615481DB6F60B0D90E46B44868EF541
     channel list: Z
@@ -232,6 +241,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "depth_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  2:  877 x  876, 2 channel, half openexr
     SHA-1: 3F41E3E55E1549C689E41624DDF76FDD387E6C06
     channel list: forward.u, forward.v
@@ -247,6 +257,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "forward_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  3:  385 x  769, 1 channel, half openexr
     SHA-1: 07435B6A85DCB4DBC15B8D3CC7B15496A29F7B65
     channel list: whitebarmask.mask
@@ -262,6 +273,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "whitebarmask_left"
     oiio:subimages: 10
     openexr:chunkCount: 769
+    openexr:lineOrder: "increasingY"
  subimage  4:  877 x  876, 4 channel, half openexr
     SHA-1: D7866F11339F2EB9C8D9DB432D0EC6AA22872DD1
     channel list: R, G, B, A
@@ -278,6 +290,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "rgba_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  5:  877 x  876, 1 channel, half openexr
     SHA-1: E8A3A031B7043016F0BDFD450E684587536E5571
     channel list: Z
@@ -293,6 +306,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "depth_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  6:  877 x  876, 2 channel, half openexr
     SHA-1: AF0F404B734D696163E2B175AD423AF637394DE6
     channel list: forward.u, forward.v
@@ -308,6 +322,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "forward_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  7:  911 x  876, 2 channel, half openexr
     SHA-1: 246B79EF99645956E5315E8C7726431FA82A5BC4
     channel list: disparityL.x, disparityL.y
@@ -322,6 +337,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "disparityL"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  8:  911 x  876, 2 channel, half openexr
     SHA-1: 538EEB9BDE9ABD3672892052B67773BBF1BCA31B
     channel list: disparityR.x, disparityR.y
@@ -336,6 +352,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "disparityR"
     oiio:subimages: 10
     openexr:chunkCount: 876
+    openexr:lineOrder: "increasingY"
  subimage  9:  386 x  769, 1 channel, half openexr
     SHA-1: 110206AA3541F5FF372F9A0A0940F2572C81DCEB
     channel list: whitebarmask.mask
@@ -351,5 +368,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     oiio:subimagename: "whitebarmask_right"
     oiio:subimages: 10
     openexr:chunkCount: 769
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Beachball/multipart.0001.exr" and "multipart.0001.exr"
 PASS

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -20,7 +20,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     oiio:subimages: 4
     openexr:chunkCount: 1078
     openexr:lineOrder: "increasingY"
-subimage  1: 1918 x 1078, 1 channel, half openexr
+ subimage  1: 1918 x 1078, 1 channel, half openexr
     SHA-1: 5FAE17E1E8BDB2E7C3A6B3EBCA8E0CA15A07B80A
     channel list: Z
     pixel data origin: x=1, y=1

--- a/testsuite/openexr-window/ref/out.txt
+++ b/testsuite/openexr-window/ref/out.txt
@@ -8,6 +8,7 @@ Reading ../openexr-images/DisplayWindow/t01.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t01.exr" and "t01.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t02.exr
@@ -22,6 +23,7 @@ Reading ../openexr-images/DisplayWindow/t02.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t02.exr" and "t02.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t03.exr
@@ -36,6 +38,7 @@ Reading ../openexr-images/DisplayWindow/t03.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t03.exr" and "t03.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t04.exr
@@ -50,6 +53,7 @@ Reading ../openexr-images/DisplayWindow/t04.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t04.exr" and "t04.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t05.exr
@@ -64,6 +68,7 @@ Reading ../openexr-images/DisplayWindow/t05.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t05.exr" and "t05.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t06.exr
@@ -78,6 +83,7 @@ Reading ../openexr-images/DisplayWindow/t06.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t06.exr" and "t06.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t07.exr
@@ -92,6 +98,7 @@ Reading ../openexr-images/DisplayWindow/t07.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t07.exr" and "t07.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t08.exr
@@ -107,6 +114,7 @@ Reading ../openexr-images/DisplayWindow/t08.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t08.exr" and "t08.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t09.exr
@@ -121,6 +129,7 @@ Reading ../openexr-images/DisplayWindow/t09.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t09.exr" and "t09.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t10.exr
@@ -135,6 +144,7 @@ Reading ../openexr-images/DisplayWindow/t10.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t10.exr" and "t10.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t11.exr
@@ -149,6 +159,7 @@ Reading ../openexr-images/DisplayWindow/t11.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t11.exr" and "t11.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t12.exr
@@ -163,6 +174,7 @@ Reading ../openexr-images/DisplayWindow/t12.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t12.exr" and "t12.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t13.exr
@@ -177,6 +189,7 @@ Reading ../openexr-images/DisplayWindow/t13.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t13.exr" and "t13.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t14.exr
@@ -191,6 +204,7 @@ Reading ../openexr-images/DisplayWindow/t14.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t14.exr" and "t14.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t15.exr
@@ -205,6 +219,7 @@ Reading ../openexr-images/DisplayWindow/t15.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t15.exr" and "t15.exr"
 PASS
 Reading ../openexr-images/DisplayWindow/t16.exr
@@ -219,5 +234,6 @@ Reading ../openexr-images/DisplayWindow/t16.exr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t16.exr" and "t16.exr"
 PASS

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -64,6 +64,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
     smpte:TimeCode: 01:18:19:06
 Comparing "src/test.exr" and "test.exr"
 PASS
@@ -78,3 +79,4 @@ rat2.exr             :   64 x   64, 3 channel, float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
+    openexr:lineOrder: "increasingY"


### PR DESCRIPTION
## Description
Fill in OpenEXR lineOrder attribute when parsing the header in OpenEXRCoreInput::PartInfo::parse_header()

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
