### PR TITLE
fix(ImageBuf): Fix bug in ImageBuf construction from ptr + neg strides

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -99,20 +99,20 @@ span_from_buffer(void* data, TypeDesc format, int nchannels, int width,
     if (xstride >= 0) {
         bufend += xstride * (width - 1);
     } else {
-        bufstart -= xstride * (width - 1);
+        bufstart += xstride * (width - 1);
     }
     // Expand to the span range for a whole image plane.
     if (ystride >= 0) {
         bufend += ystride * (height - 1);
     } else {
-        bufstart -= ystride * (height - 1);
+        bufstart += ystride * (height - 1);
     }
     // Expand to the span range for a whole volume.
     if (depth > 1 && zstride != 0) {
         if (zstride >= 0) {
             bufend += zstride * (depth - 1);
         } else {
-            bufstart -= zstride * (depth - 1);
+            bufstart += zstride * (depth - 1);
         }
     }
     return { bufstart, size_t(bufend - bufstart) };
@@ -905,7 +905,7 @@ ImageBufImpl::set_bufspan_localpixels(span<std::byte> bufspan,
     }
     m_bufspan     = bufspan;
     m_localpixels = (char*)buforigin;
-    OIIO_DASSERT(check_span(m_bufspan, m_localpixels, spec().format));
+    OIIO_ASSERT(check_span(m_bufspan, m_localpixels, spec().format));
 }
 
 

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -303,10 +303,12 @@ ImageBuf_test_appbuffer_strided()
 
     // Test negative strides by filling with yellow, backwards
     {
+        ImageBufAlgo::fill(wrapped, cspan<float>(green));
         // Use the ImageBuf constructor from a pointer to the last pixel and
-        // negative strides.
-        ImageBuf neg(ImageSpec(res, res, nchans, TypeFloat),
-                     &mem[res - 1][res - 1][0] /* point to last pixel */,
+        // negative strides. But don't include the edge pixels of the original
+        // buffer.
+        ImageBuf neg(ImageSpec(res - 2, res - 2, nchans, TypeFloat),
+                     &mem[res - 2][res - 2][0] /* point to last pixel */,
                      -nchans * sizeof(float) /* negative x stride */,
                      -res * nchans * sizeof(float) /* negative y stride*/);
         const float yellow[nchans] = { 1.0f, 1.0f, 0.0f };
@@ -314,8 +316,12 @@ ImageBuf_test_appbuffer_strided()
 
         for (int y = 0; y < res; ++y) {
             for (int x = 0; x < res; ++x) {
-                OIIO_CHECK_ASSERT(make_cspan(mem[y][x], nchans)
-                                  == make_cspan(yellow));
+                if (x == 0 || x == res - 1 || y == 0 || y == res - 1)
+                    OIIO_CHECK_ASSERT(make_cspan(mem[y][x], nchans)
+                                      == make_cspan(green));
+                else
+                    OIIO_CHECK_ASSERT(make_cspan(mem[y][x], nchans)
+                                      == make_cspan(yellow));
             }
         }
     }

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -300,6 +300,25 @@ ImageBuf_test_appbuffer_strided()
             }
         }
     }
+
+    // Test negative strides by filling with yellow, backwards
+    {
+        // Use the ImageBuf constructor from a pointer to the last pixel and
+        // negative strides.
+        ImageBuf neg(ImageSpec(res, res, nchans, TypeFloat),
+                     &mem[res - 1][res - 1][0] /* point to last pixel */,
+                     -nchans * sizeof(float) /* negative x stride */,
+                     -res * nchans * sizeof(float) /* negative y stride*/);
+        const float yellow[nchans] = { 1.0f, 1.0f, 0.0f };
+        ImageBufAlgo::fill(neg, cspan<float>(yellow));
+
+        for (int y = 0; y < res; ++y) {
+            for (int x = 0; x < res; ++x) {
+                OIIO_CHECK_ASSERT(make_cspan(mem[y][x], nchans)
+                                  == make_cspan(yellow));
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
There was a bug in span_from_buffer when strides were negative (basically, we were subtracting, when adding was correct since those strides were negative values).

Also added a negative stride test to imagebuf_test.cpp. Embarrassed that we didn't already have this, since it would have caught the problem.
