### PR TITLE
build: fix recently broken rpath to restore python wheel building

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -14,21 +14,25 @@ permissions:
 on:
   push:
     # Workflow run on tags for v3 only, or pre-tagged pushes of release, or
-    # dev-3.* branches.
+    # dev-3.* branches. Also if the branch name itself contains the substrings
+    # 'wheel' or 'python'.
     tags:
       - v3.*
     branches:
       - release
       - dev-3.*
+      - "*wheel*"
+      - "*python*"
   pull_request:
-    # Workflow run on pull_request only when related files change.
+    # Workflow run on pull_request only when related files change, or when the
+    # branch name itself contains the substrings 'wheel' or 'python'.
     paths:
       - .github/workflows/wheel.yml
       - pyproject.toml
       - src/python/*.py
       - src/python/*.h
       - src/python/*.cpp
-      - src/cmake/pythonutils.cmake
+      - src/cmake/*.cmake
   schedule:
     # Nightly build
     - cron:  "0 8 * * *"

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -691,6 +691,7 @@ else ()
             set(BASEPOINT $ORIGIN)
         endif()
         set (CMAKE_INSTALL_RPATH ${BASEPOINT}
+                                 ${BASEPOINT}/${CMAKE_INSTALL_LIBDIR}
                                  ${BASEPOINT}/../${CMAKE_INSTALL_LIBDIR})
     endif ()
     # add the automatically determined parts of the RPATH that


### PR DESCRIPTION
Also, make the wheel workflow work on pushes when the branch name
contains the substring "python" or "wheel", and when any of the cmake
build files in src/cmake (which control building of dependencies,
among other things), even if none of the python bindings themselves
are touched. This means that if you suspect your work might cause a
wheel to break even though you're not modifying the python bindings
directly, you can ensure that the wheel workflow will run on CI simply
by naming your branch to contain one of those words.

