### PR TITLE
fix(wheels): Ensure python-based builds use maj.min.patch SO versioning

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -617,7 +617,7 @@ set (EXTRA_DSO_LINK_ARGS "" CACHE STRING "Extra command line definitions when bu
 ###########################################################################
 # Set the versioning for shared libraries.
 #
-if (${PROJECT_NAME}_SUPPORTED_RELEASE)
+if (${PROJECT_NAME}_SUPPORTED_RELEASE AND NOT SKBUILD)
     # Supported releases guarantee ABI back-compatibility within the release
     # family, so SO versioning is major.minor.
     set (SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}


### PR DESCRIPTION
Always use patch-specific SO versioning for scikit-build-core-based builds, even when OpenImageIO_SUPPORTED_RELEASE=ON.

Fixes #4621


## Description

Ensures that Python-based builds only bundle a single copy each of libOpenImageIO and libOpenImageIO_Util shared libraries. 

## Tests

Previously, `$ uv sync -v --reinstall -Ccmake.define.OpenImageIO_SUPPORTED_RELEASE=1` would bundle both .so.3.0 and .so.3.0.3 copies of libraries when installing to a local virtual environment. 

With this fix, only .so.3.0.3 copies of libraries are installed.

