### PR TITLE
ci: Move away from soon-to-be-deprecated ubuntu-20.04 GHA runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,28 +453,25 @@ jobs:
                             PUGIXML_VERSION=v1.14
                             WEBP_VERSION=v1.4.0
 
-          - desc: clang14 C++20 avx2 exr3.1 ocio2.1
+          - desc: clang15 C++17 avx2 exr3.1 ocio2.2
             nametag: linux-clang14
-            runner: ubuntu-20.04
-            cxx_compiler: clang++
-            cc_compiler: clang
-            cxx_std: 20
+            runner: ubuntu-22.04
+            cxx_compiler: clang++-15
+            cc_compiler: clang-15
+            cxx_std: 17
             fmt_ver: 10.1.1
             opencolorio_ver: v2.2.1
             openexr_ver: v3.1.13
             pybind11_ver: v2.12.0
-            python_ver: 3.8
+            python_ver: "3.10"
             simd: avx2,f16c
-            setenvs: export LLVM_VERSION=14.0.0
-                            USE_OPENVDB=0
-                            # The installed OpenVDB has a TLS conflict with Python 3.8
           - desc: debug gcc9/C++17, sse4.2, exr3.1
             nametag: linux-gcc9-cpp17-debug
-            runner: ubuntu-20.04
+            runner: ubuntu-22.04
             cxx_compiler: g++-9
             cxx_std: 17
             build_type: Debug
-            python_ver: 3.8
+            python_ver: "3.10"
             simd: sse4.2
             openexr_ver: v3.1.13
             pybind11_ver: v2.7.0
@@ -482,11 +479,11 @@ jobs:
             setenvs: export PUGIXML_VERSION=v1.9
           - desc: static libs gcc9 C++17 exr3.1
             nametag: linux-static
-            runner: ubuntu-20.04
+            runner: ubuntu-22.04
             cxx_compiler: g++-9
             cxx_std: 17
             openexr_ver: v3.1.13
-            python_ver: 3.8
+            python_ver: "3.10"
             pybind11_ver: v2.7.0
             setenvs: export BUILD_SHARED_LIBS=OFF
             depcmds: |

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -12,10 +12,11 @@ set -ex
 echo "Building LLVM"
 uname
 
+: ${LLVM_VERSION:=18.1.8}
+: ${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
+mkdir -p $LLVM_INSTALL_DIR || true
 
 if [[ `uname` == "Linux" ]] ; then
-    : ${LLVM_VERSION:=13.0.0}
-    : ${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
     : ${LLVM_DISTRO_NAME:=ubuntu-18.04}
     LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
     echo LLVMTAR = $LLVMTAR
@@ -23,11 +24,24 @@ if [[ `uname` == "Linux" ]] ; then
     ls -l $LLVMTAR
     tar xf $LLVMTAR
     rm -f $LLVMTAR
-    echo "Installed LLVM ${LLVM_VERSION} in ${LLVM_INSTALL_DIR}"
-    mkdir -p $LLVM_INSTALL_DIR && true
     mv clang+llvm*/* $LLVM_INSTALL_DIR
-    export LLVM_DIRECTORY=$LLVM_INSTALL_DIR
-    export PATH=${LLVM_INSTALL_DIR}/bin:$PATH
-    export LLVM_ROOT=${LLVM_INSTALL_DIR}
-    # ls -a $LLVM_DIRECTORY
+elif [[ `uname -s` == "Windows" || "${RUNNER_OS}" == "Windows" ]] ; then
+    echo "Installing Windows LLVM"
+    : ${LLVM_DISTRO_NAME:=ubuntu-18.04}
+    LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-pc-windows-msvc.tar.xz
+    echo LLVMTAR = $LLVMTAR
+    curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
+    ls -l $LLVMTAR
+    tar xf $LLVMTAR
+    rm -f $LLVMTAR
+    mv clang+llvm*/* $LLVM_INSTALL_DIR
+else
+    echo Bad uname `uname`
 fi
+
+echo "Installed LLVM ${LLVM_VERSION} in ${LLVM_INSTALL_DIR}"
+ls -a $LLVM_INSTALL_DIR || true
+ls -a $LLVM_INSTALL_DIR/* || true
+export LLVM_DIRECTORY=$LLVM_INSTALL_DIR
+export PATH=${LLVM_INSTALL_DIR}/bin:$PATH
+export LLVM_ROOT=${LLVM_INSTALL_DIR}

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -148,7 +148,7 @@ cmake --version
 # If we're using clang to compile on native Ubuntu, we need to install it.
 # If on an ASWF CentOS docker container, it already is installed.
 #
-if [[ ("$CXX" == "clang++" && "$ASWF_ORG" == "") || "$LLVM_VERSION" != "" ]] ; then
+if [[ "$LLVM_VERSION" != "" ]] ; then
     source src/build-scripts/build_llvm.bash
 fi
 

--- a/testsuite/raw/ref/out-libraw-0.20.2-gh.txt
+++ b/testsuite/raw/ref/out-libraw-0.20.2-gh.txt
@@ -546,7 +546,7 @@
     Sony:ImageStabilization: 1
     Sony:LensID: 40
     Sony:LensMount: 25
-Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2-libraw0.20.0.tif"
+Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2.tif"
 PASS
 Comparing "RAW_NIKON_D3X.NEF.tif" and "ref/RAW_NIKON_D3X.NEF.tif"
 PASS


### PR DESCRIPTION
In the process, port a more modern build_llvm.bash from osl.
