### PR TITLE
ci(wheels): Add `numpy` as a runtime requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">= 3.8"
+dependencies = [
+    "numpy>=1.19",
+]
 
 [project.urls]
 Homepage = "https://openimageio.org/"

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -39,6 +39,7 @@ with a feature set, scalability, and robustness needed for feature film
 production.
 """[1:-1]
 
+__version__ = VERSION_STRING # type: ignore # noqa: F405
 
 def _call_program(name, args):
     bin_dir = os.path.join(os.path.dirname(__file__), 'bin')


### PR DESCRIPTION
Adds "numpy" as a runtime requirement for the Python wheels.

Fixes #4637