### PR TITLE
fix(sysutil): improve the implementation of Sysutil::put_in_background on macOS

### DIFF
--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -75,11 +75,10 @@ OIIO_UTIL_API void
 usleep(unsigned long useconds);
 
 /// Try to put the process into the background so it doesn't continue to
-/// tie up any shell that it was launched from.  The arguments are the
-/// argc/argv that describe the program and its command line arguments.
+/// tie up any shell that it was launched from.
 /// Return true if successful, false if it was unable to do so.
 OIIO_UTIL_API bool
-put_in_background(int argc, char* argv[]);
+put_in_background();
 
 /// Number of virtual cores available on this platform (including
 /// hyperthreads). Note that this is just a wrapper/synonym for C++

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -74,10 +74,18 @@ getenv(string_view name, string_view defaultval = {});
 OIIO_UTIL_API void
 usleep(unsigned long useconds);
 
+/// Puts the process into the background, detaching it from the shell
+/// to prevent it from occupying the terminal or blocking the shell
+/// it was launched from. This allows the process to continue running
+/// independently in the background.
+OIIO_UTIL_API bool
+put_in_background();
+
 /// Try to put the process into the background so it doesn't continue to
 /// tie up any shell that it was launched from.  The arguments are the
 /// argc/argv that describe the program and its command line arguments.
 /// Return true if successful, false if it was unable to do so.
+/// DEPRECATED(3.0) old API.
 OIIO_UTIL_API bool
 put_in_background(int argc, char* argv[]);
 

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -75,10 +75,11 @@ OIIO_UTIL_API void
 usleep(unsigned long useconds);
 
 /// Try to put the process into the background so it doesn't continue to
-/// tie up any shell that it was launched from.
+/// tie up any shell that it was launched from.  The arguments are the
+/// argc/argv that describe the program and its command line arguments.
 /// Return true if successful, false if it was unable to do so.
 OIIO_UTIL_API bool
-put_in_background();
+put_in_background(int argc, char* argv[]);
 
 /// Number of virtual cores available on this platform (including
 /// hyperthreads). Note that this is just a wrapper/synonym for C++

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -78,13 +78,13 @@ usleep(unsigned long useconds);
 /// to prevent it from occupying the terminal or blocking the shell
 /// it was launched from. This allows the process to continue running
 /// independently in the background.
+/// Return true if successful, false if it was unable to do so.
 OIIO_UTIL_API bool
 put_in_background();
 
-/// Try to put the process into the background so it doesn't continue to
-/// tie up any shell that it was launched from.  The arguments are the
-/// argc/argv that describe the program and its command line arguments.
-/// Return true if successful, false if it was unable to do so.
+/// Obsolete version. The argc, argv parameters are not used. We suggest
+/// switching to the version of `put_in_background()` that takes no
+/// arguments.
 /// DEPRECATED(3.0) old API.
 OIIO_UTIL_API bool
 put_in_background(int argc, char* argv[]);

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -103,7 +103,7 @@ main(int argc, char* argv[])
     ArgParse ap = getargs(argc, argv);
 
     if (!ap["foreground_mode"].get<int>())
-        Sysutil::put_in_background(argc, argv);
+        Sysutil::put_in_background();
 
     // LG
     //    Q_INIT_RESOURCE(iv);

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -103,7 +103,7 @@ main(int argc, char* argv[])
     ArgParse ap = getargs(argc, argv);
 
     if (!ap["foreground_mode"].get<int>())
-        Sysutil::put_in_background();
+        Sysutil::put_in_background(argc, argv);
 
     // LG
     //    Q_INIT_RESOURCE(iv);

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -565,11 +565,7 @@ Sysutil::put_in_background()
 
 
 bool
-#ifdef _WIN32
-Sysutil::put_in_background(int, char*[])
-#else
 Sysutil::put_in_background(int argc, char* argv[])
-#endif
 {
     return put_in_background();
 }

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -529,9 +529,9 @@ Term::ansi_bgcolor(int r, int g, int b)
 
 bool
 #ifdef _WIN32
-Sysutil::put_in_background()
+Sysutil::put_in_background(int, char*[])
 #else
-Sysutil::put_in_background()
+Sysutil::put_in_background(int argc, char* argv[])
 #endif
 {
 #if defined(__linux__) || defined(__GLIBC__)
@@ -547,9 +547,9 @@ Sysutil::put_in_background()
     posix_spawnattr_t attr;
     posix_spawnattr_init(&attr);
     posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSID);
-    char** argv    = *_NSGetArgv();
     char** environ = *_NSGetEnviron();
-    int status     = posix_spawn(&pid, argv[0], nullptr, &attr, argv, environ);
+    int status = posix_spawn(&pid, argv[0], nullptr, &attr, argv,
+                             environ);
     posix_spawnattr_destroy(&attr);
     if (status == 0)
         exit(0);

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -34,13 +34,13 @@
 
 #ifdef __APPLE__
 #    include <TargetConditionals.h>
+#    include <crt_externs.h>
 #    include <mach-o/dyld.h>
 #    include <mach/mach_init.h>
 #    include <mach/task.h>
-#    include <crt_externs.h>
+#    include <spawn.h>
 #    include <sys/ioctl.h>
 #    include <sys/sysctl.h>
-#    include <spawn.h>
 #    include <unistd.h>
 #endif
 
@@ -560,7 +560,7 @@ Sysutil::put_in_background(int argc, char* argv[])
     posix_spawnattr_t attr;
     posix_spawnattr_init(&attr);
     posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSID);
-    char **environ = *_NSGetEnviron();
+    char** environ = *_NSGetEnviron();
 
     std::vector<char*> newargv;
     newargv.push_back(argv[0]);
@@ -570,13 +570,14 @@ Sysutil::put_in_background(int argc, char* argv[])
     }
     newargv.push_back(nullptr);
 
-    int status = posix_spawn(&pid, argv[0], nullptr, &attr, newargv.data(), environ);
+    int status = posix_spawn(&pid, argv[0], nullptr, &attr, newargv.data(),
+                             environ);
     posix_spawnattr_destroy(&attr);
     if (status == 0)
         exit(0);
 
     return true;
-    
+
 #elif defined(_WIN32)
     return true;
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -548,8 +548,7 @@ Sysutil::put_in_background(int argc, char* argv[])
     posix_spawnattr_init(&attr);
     posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSID);
     char** environ = *_NSGetEnviron();
-    int status = posix_spawn(&pid, argv[0], nullptr, &attr, argv,
-                             environ);
+    int status     = posix_spawn(&pid, argv[0], nullptr, &attr, argv, environ);
     posix_spawnattr_destroy(&attr);
     if (status == 0)
         exit(0);


### PR DESCRIPTION
## Description

Replaces the system() call with posix_spawn() on macOS to preserve environment variables. This is essential for Debug builds using DYLD_IMAGE_SUFFIX=_debug to prevent Qt from loading mixed configurations.

## Tests

Run the iv application in background mode on macOS without the -F flag, using a Debug configuration. Previously, the system() call did not inherit the parent environment variables, causing a mix of Debug and Release versions of Qt to be loaded.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
