### PR TITLE
ICC profile reading improvements, especially for PSD

### DIFF
--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -355,10 +355,10 @@ Jpeg2000Input::open(const std::string& name, ImageSpec& p_spec)
             cspan<uint8_t>((const uint8_t*)m_image->icc_profile_buf,
                            m_image->icc_profile_len),
             m_spec, errormsg);
-        if (!ok) {
-            // errorfmt("Could not decode ICC profile: {}\n", errormsg);
-            // return false;
-            // Nah, just skip an ICC specific error?
+        if (!ok && OIIO::get_int_attribute("imageinput:strict")) {
+            errorfmt("Possible corrupt file, could not decode ICC profile: {}\n",
+                     errormsg);
+            return false;
         }
     }
 

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -250,14 +250,12 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
                            TypeDesc(TypeDesc::UINT8, profile_length),
                            profile_data);
             std::string errormsg;
-            bool ok = decode_icc_profile(
-                cspan<uint8_t>((const uint8_t*)profile_data,
-                               span_size_t(profile_length)),
-                spec, errormsg);
-            if (!ok) {
-                // errorfmt("Could not decode ICC profile: {}\n", errormsg);
-                // return false;
-                // Nah, just skip an ICC specific error?
+            bool ok
+                = decode_icc_profile(make_cspan(profile_data, profile_length),
+                                     spec, errormsg);
+            if (!ok && OIIO::get_int_attribute("imageinput:strict")) {
+                errorfmt("Could not decode ICC profile: {}\n", errormsg);
+                return false;
             }
         }
     }

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1245,8 +1245,15 @@ PSDInput::load_resource_1039(uint32_t length)
     TypeDesc type(TypeDesc::UINT8, length);
     common_attribute("ICCProfile", type, icc_buf.get());
     std::string errormsg;
-    decode_icc_profile(cspan<uint8_t>(icc_buf.get(), length), m_common_attribs,
-                       errormsg);
+    bool ok = decode_icc_profile(cspan<uint8_t>(icc_buf.get(), length),
+                                 m_common_attribs, errormsg)
+              && decode_icc_profile(cspan<uint8_t>(icc_buf.get(), length),
+                                    m_composite_attribs, errormsg);
+    if (!ok && OIIO::get_int_attribute("imageinput:strict")) {
+        errorfmt("Possible corrupt file, could not decode ICC profile: {}\n",
+                 errormsg);
+        return false;
+    }
     return true;
 }
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -209,7 +209,9 @@ private:
     // Read tags from the current directory of m_tif and fill out spec.
     // If read_meta is false, assume that m_spec already contains valid
     // metadata and should not be cleared or rewritten.
-    void readspec(bool read_meta = true);
+    // Return true if all is fine, false if something really bad happens,
+    // like we think the file is hopelessly corrupted.
+    bool readspec(bool read_meta = true);
 
     // Figure out all the photometric-related aspects of the header
     void readspec_photometric();
@@ -832,7 +834,8 @@ TIFFInput::seek_subimage(int subimage, int miplevel)
     m_next_scanline = 0;  // next scanline we'll read
     if (subimage == m_subimage || TIFFSetDirectory(m_tif, subimage)) {
         m_subimage = subimage;
-        readspec(read_meta);
+        if (!readspec(read_meta))
+            return false;
 
         char emsg[1024];
         if (m_use_rgba_interface && !TIFFRGBAImageOK(m_tif, emsg)) {
@@ -931,7 +934,7 @@ TIFFInput::spec_dimensions(int subimage, int miplevel)
 #define ICC_PROFILE_ATTR "ICCProfile"
 
 
-void
+bool
 TIFFInput::readspec(bool read_meta)
 {
     uint32_t width = 0, height = 0, depth = 0;
@@ -1201,7 +1204,7 @@ TIFFInput::readspec(bool read_meta)
     // assumed to be identical to what we already have in m_spec,
     // skip everything following.
     if (!read_meta)
-        return;
+        return true;
 
     short resunit = -1;
     TIFFGetField(m_tif, TIFFTAG_RESOLUTIONUNIT, &resunit);
@@ -1239,8 +1242,13 @@ TIFFInput::readspec(bool read_meta)
         m_spec.attribute(ICC_PROFILE_ATTR,
                          TypeDesc(TypeDesc::UINT8, icc_datasize), icc_buf);
         std::string errormsg;
-        decode_icc_profile(cspan<uint8_t>(icc_buf, icc_datasize), m_spec,
-                           errormsg);
+        bool ok = decode_icc_profile(cspan<uint8_t>(icc_buf, icc_datasize),
+                                     m_spec, errormsg);
+        if (!ok && OIIO::get_int_attribute("imageinput:strict")) {
+            errorfmt("Possible corrupt file, could not decode ICC profile: {}\n",
+                     errormsg);
+            return false;
+        }
     }
 
     // Search for an EXIF IFD in the TIFF file, and if found, rummage
@@ -1370,6 +1378,8 @@ TIFFInput::readspec(bool read_meta)
 
     if (m_testopenconfig)  // open-with-config debugging
         m_spec.attribute("oiio:DebugOpenConfig!", 42);
+
+    return true;
 }
 
 

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -18,6 +18,25 @@ Reading ../oiio-images/psd/psd_123.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
@@ -203,6 +222,25 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
@@ -493,6 +531,25 @@ Reading ../oiio-images/psd/psd_indexed_trans.psd
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
@@ -564,6 +621,25 @@ Reading ../oiio-images/psd/psd_rgb_8.psd
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:40-04:00"
@@ -635,6 +711,25 @@ Reading ../oiio-images/psd/psd_rgb_16.psd
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
@@ -706,6 +801,22 @@ Reading ../oiio-images/psd/psd_rgb_32.psd
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1094992453
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 2011 Adobe Systems Incorporated"
+    ICCProfile:creation_date: "2011:08:23 01:56:54"
+    ICCProfile:creator_signature: "41444245"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "6e6f6e65"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1 (Linear RGB Profile)"
+    ICCProfile:profile_size: 520
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:38-04:00"
@@ -743,6 +854,25 @@ Reading ../oiio-images/psd/psd_rgba_8.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
@@ -823,6 +953,22 @@ Reading ../oiio-images/psd/psd_rgb_16_rle.psd
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 3840
     Exif:PixelYDimension: 2160
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1094992453
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 1999 Adobe Systems Incorporated"
+    ICCProfile:creation_date: "1999:06:03 00:00:00"
+    ICCProfile:creator_signature: "41444245"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "6e6f6e65"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Adobe RGB (1998)"
+    ICCProfile:profile_size: 560
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
     IPTC:DocumentID: "xmp.did:9de7a004-9188-384a-a78b-5202a1f8a5ae"
     IPTC:InstanceID: "xmp.iid:9de7a004-9188-384a-a78b-5202a1f8a5ae"
     IPTC:MetadataDate: "2025-01-10T23:28:11+02:00"
@@ -855,6 +1001,25 @@ Reading ../oiio-images/psd/psd_123.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
@@ -1041,6 +1206,25 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
@@ -1314,6 +1498,25 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
     exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
     exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "adobe:docid:photoshop:a9aabed2-61e6-1c48-b9c0-22e2e6b3631a"
     IPTC:InstanceID: "xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
@@ -1508,6 +1711,25 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
     exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
     exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "adobe:docid:photoshop:d0b5fcf6-f464-234f-b5df-47c18ab8b898"
     IPTC:InstanceID: "xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
@@ -1702,6 +1924,22 @@ src/Layers_32bit_RGB.psd :   48 x   27, 3 channel, float psd
     exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
     exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
     exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1818455411
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "No copyright, use freely"
+    ICCProfile:creation_date: "2024:04:01 17:31:55"
+    ICCProfile:creator_signature: "6c636d73"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "RGB built-in"
+    ICCProfile:profile_size: 568
+    ICCProfile:profile_version: "4.3.0"
+    ICCProfile:rendering_intent: "Perceptual"
     IPTC:DocumentID: "adobe:docid:photoshop:c17239f3-0dba-274a-8b00-2c4bfa538ebe"
     IPTC:InstanceID: "xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
     IPTC:MetadataDate: "2024-04-01T19:35:16+02:00"


### PR DESCRIPTION
The main thing here is that it turns out that when trying to parse the ICC profiles from Photoshop PSD/PSB files, we weren't storing the attributes in the correct way. Everything else, we shoved in both the "common" and "composite" imagespecs, but we left ICC data out of the composite spec.

While I'm at it, I made two other ICC related changes:

* Among the several formats with ICC profiles, we were inconsistent about whether we report errors for corrupt ICC profiles and treat the whole image as broken, or just ignore the errors entirely. Fixed in various places to make a consistent policy of always checking the errors, and reporting/terminating if the "imageinput:strict" global attribute is true, allowing it to just ignore the broken ICC record if that attribute is false.

* Found a spot in JPEG handling of ICC where we were dangerously trusting of the sizes of things. Replace a risky memcpy with a safer spancpy that can't overrun the buffer bounds when copying.
