### PR TITLE
ci: for docs workflow, lock down versions and speed up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,6 +385,7 @@ jobs:
                             LLVM_VERSION=17.0.6 LLVM_DISTRO_NAME=ubuntu-22.04
                             SKIP_SYSTEM_DEPS_INSTALL=1 QT_VERSION=0
                             OpenImageIO_OPTIONAL_DEPS=ALL
+                            EXTRA_DEP_PACKAGES="git cmake ninja-build g++"
 
           - desc: latest releases gcc13 C++20 py3.12 avx2 exr3.3 ocio2.4
             nametag: linux-latest-releases

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,10 +56,6 @@ jobs:
       build_type: ${{ matrix.build_type || 'Release' }}
       depcmds: ${{ matrix.depcmds }}
       extra_artifacts: ${{ matrix.extra_artifacts }}
-      fmt_ver: ${{ matrix.fmt_ver }}
-      opencolorio_ver: ${{ matrix.opencolorio_ver }}
-      openexr_ver: ${{ matrix.openexr_ver }}
-      pybind11_ver: ${{ matrix.pybind11_ver }}
       python_ver: ${{ matrix.python_ver }}
       setenvs: ${{ matrix.setenvs }}
       simd: ${{ matrix.simd }}
@@ -68,10 +64,6 @@ jobs:
       abi_check: ${{ matrix.abi_check }}
       build_docs: ${{ matrix.build_docs }}
       generator: ${{ matrix.generator }}
-      ctest_args: ${{ matrix.ctest_args }}
-      ctest_test_timeout: ${{ matrix.ctest_test_timeout }}
-      coverage: ${{ matrix.coverage || '0' }}
-      sonar: ${{ matrix.sonar || '0' }}
 
     strategy:
       fail-fast: false
@@ -80,12 +72,13 @@ jobs:
           - desc: docs
             nametag: docslinux
             runner: ubuntu-latest
-            container: aswftesting/ci-openexr:2024
-            vfxyear: 2024
             cxx_std: 17
             python_ver: "3.11"
             build_docs: 1
             skip_build: 1
             skip_tests: 1
             setenvs: export EXTRA_DEP_PACKAGES="doxygen sphinx-doc"
-                            PIP_INSTALLS="sphinx breathe sphinx-tabs furo"
+                            PIP_INSTALLS="sphinx breathe==4.34.0 sphinx-tabs furo==2022.6.21"
+                            SKIP_SYSTEM_DEPS_INSTALL=1
+                            USE_OPENCV=0 USE_FFMPEG=0 USE_FREETYPE=0
+                            USE_LIBHEIF=0 QT_VERSION=0 PYBIND11_VERSION=0

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -86,12 +86,11 @@ else
         time sudo apt-get update
     fi
 
-    time sudo apt-get -q install -y \
-        git cmake ninja-build ccache g++ \
-        libilmbase-dev libopenexr-dev \
-        libtiff-dev libgif-dev libpng-dev
     if [[ "${SKIP_SYSTEM_DEPS_INSTALL}" != "1" ]] ; then
         time sudo apt-get -q install -y --fix-missing \
+            git cmake ninja-build ccache g++ \
+            libilmbase-dev libopenexr-dev \
+            libtiff-dev libgif-dev libpng-dev \
             libraw-dev libwebp-dev \
             libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
             dcmtk libopenvdb-dev \
@@ -158,7 +157,9 @@ fi
 # Packages we need to build from scratch.
 #
 
-source src/build-scripts/build_pybind11.bash
+if [[ "$PYBIND11_VERSION" != "0" ]] ; then
+    source src/build-scripts/build_pybind11.bash
+fi
 
 if [[ "$OPENEXR_VERSION" != "" ]] ; then
     source src/build-scripts/build_openexr.bash


### PR DESCRIPTION
When test building the docs, lock down breathe and furo versions to exactly what we use on RTD.

Also, to speed up the workflow: run on native Ubuntu rather than on an ASWF container (eliminates needless container download), and make sure that we don't waste time installing dependencies that we don't need.

These changes speed up the docs workflow from around 3:40 to around 2:00.
