### PR TITLE
admin: Set up .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+# Helpful documentation:
+# - https://github.com/github-linguist/linguist/blob/main/docs/overrides.md
+# - https://github.com/github-linguist/linguist/blob/main/docs/troubleshooting.md
+
+
+*.h linguist-language=C++
+src/libOpenImageIO/bluenoise.inc -linguist-detectable


### PR DESCRIPTION
Starter purpose is giving hints to GitHub's language analysis.
