### PR TITLE
fix: eliminate needless definitions of std::size

### DIFF
--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -630,21 +630,6 @@ OIIO_NAMESPACE_END
 // Declare std::size and std::ssize for our span.
 namespace std {
 
-template<class T, OIIO::span_size_t E = OIIO::dynamic_extent>
-constexpr size_t
-size(const OIIO::span<T, E>& c)
-{
-    return static_cast<size_t>(c.size());
-}
-
-template<class T, OIIO::span_size_t E = OIIO::dynamic_extent>
-constexpr size_t
-size(const OIIO::span_strided<T, E>& c)
-{
-    return static_cast<size_t>(c.size());
-}
-
-
 #if OIIO_CPLUSPLUS_VERSION < 20
 // C++20 and beyond already have these declared.
 template<class T, OIIO::span_size_t E = OIIO::dynamic_extent>

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -532,13 +532,6 @@ FMT_END_NAMESPACE
 // Declare std::size and std::ssize for our string_view.
 namespace std {
 
-#if OIIO_CPLUSPLUS_VERSION < 17
-template<class CharT, class Traits = std::char_traits<CharT>>
-constexpr size_t size(const OIIO::basic_string_view<CharT, Traits>& c) {
-    return c.size();
-}
-#endif
-
 #if OIIO_CPLUSPLUS_VERSION < 20
 template<class CharT, class Traits = std::char_traits<CharT>>
 constexpr ptrdiff_t ssize(const OIIO::basic_string_view<CharT, Traits>& c) {


### PR DESCRIPTION
Since C++17 defines std::size(C) (defaulting to returning C.size()), we don't need to define our own now that C++17 is our minimum.

It seemed harmless to define it anyway for quite a while...  but then a few days ago, the GitHub Windows CI runners upgraded their version of MSVS, and we started getting some very odd test failures that I was able to trace to std::size somehow returning the wrong size in some cases, and printf debugging revealed that the one we supplied wasn't even the one being called.

I can't say I understand exactly what was going wrong. I was debugging by repeatedly submitting small changes with debugging scaffolding to GH to see how it works in a CI run, since I have no access to a local Windows machine (at about 1/2 hour turnaround time for each iteration!).  Once I discovered that not supplying the redundant definition somehow fixes the problem, I couldn't justify spending more of my weekend on this to find out why. "Because MSVS" is a sufficient explanation for a lot of weirdness in the computing world. 
