### PR TITLE
fix(png): increase allowed width/height limit

### DIFF
--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -165,7 +165,7 @@ PNGInput::open(const std::string& name, ImageSpec& newspec)
                                  m_interlace_type, m_bg, m_spec,
                                  m_keep_unassociated_alpha);
     if (!ok || m_err
-        || !check_open(m_spec, { 0, 1 << 16, 0, 1 << 16, 0, 1, 0, 4 })) {
+        || !check_open(m_spec, { 0, 1 << 20, 0, 1 << 20, 0, 1, 0, 4 })) {
         close();
         return false;
     }

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -135,7 +135,7 @@ bool
 PNGOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
-    if (!check_open(mode, userspec, { 0, 65535, 0, 65535, 0, 1, 0, 256 }))
+    if (!check_open(mode, userspec, { 0, 1 << 20, 0, 1 << 20, 0, 1, 0, 4 }))
         return false;
 
     // If not uint8 or uint16, default to uint8


### PR DESCRIPTION
## Description

The current width/height limit enforced by the `check_open` API is too low for PNG files. Each dimension can technically be up to `2^31 - 1` but using that value would defeat the purpose of the check here. Use `1 << 20` like what is used for TIFF and EXR instead.

The situation was triggered while trying to write an 85000x28400 px image, which is smaller than 65536*65536 but the dimensions are checked individually rather than as a total pixel count or similar.

Also looks like the PNG output was allowing too many channels so fix that too.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
