### PR TITLE
api(span.h): Only allow span-from-array if array for compatible size

### DIFF
--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -105,7 +105,7 @@ public:
 
     /// Construct from a fixed-length C array.  Template magic automatically
     /// finds the length from the declared type of the array.
-    template<size_t N>
+    template<size_t N, OIIO_ENABLE_IF(Extent == dynamic_extent || Extent == N)>
     constexpr span (T (&data)[N]) noexcept : m_data(data), m_size(N) { }
 
     /// Construct from std::vector<T>.


### PR DESCRIPTION
From an array of known size, we can implicitly construct a span of dynamic length, or of fixed length equal to the array length.  Use template enable_if trick to restrict to these cases.

Previously, the constructor would have allowed a fixed-length span to be constructed from an array of differing length, which should obviously have been disallowed.
