### PR TITLE
build: Better disabling of work when USE_PYTHON=0

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -113,7 +113,9 @@ else ()
 endif()
 
 # From pythonutils.cmake
-find_python()
+if (USE_PYTHON)
+    find_python()
+endif ()
 if (USE_PYTHON)
     checked_find_package (pybind11 REQUIRED VERSION_MIN 2.7)
 endif ()


### PR DESCRIPTION
When USE_PYTHON is disabled, don't even bother looking for python.
