### PR TITLE
ci: Update libPNG address and version for ci & autobuild

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * **pybind11 >= 2.7** (tested through 2.12)
      * NumPy
  * If you want support for PNG files:
-     * **libPNG >= 1.6.0** (tested though 1.6.43)
+     * **libPNG >= 1.6.0** (tested though 1.6.47)
  * If you want support for camera "RAW" formats:
      * **LibRaw >= 0.20** (tested though 0.21.3 and master)
  * If you want support for a wide variety of video formats:

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -10,8 +10,8 @@
 set -ex
 
 # Repo and branch/tag/commit of libpng to download if we don't have it yet
-LIBPNG_REPO=${LIBPNG_REPO:=https://github.com/glennrp/libpng.git}
-LIBPNG_VERSION=${LIBPNG_VERSION:=v1.6.35}
+LIBPNG_REPO=${LIBPNG_REPO:=https://github.com/pnggroup/libpng.git}
+LIBPNG_VERSION=${LIBPNG_VERSION:=v1.6.47}
 
 # Where to put libpng repo source (default to the ext area)
 LIBPNG_SRC_DIR=${LIBPNG_SRC_DIR:=${PWD}/ext/libpng}

--- a/src/cmake/build_PNG.cmake
+++ b/src/cmake/build_PNG.cmake
@@ -6,8 +6,8 @@
 # PNG by hand!
 ######################################################################
 
-set_cache (PNG_BUILD_VERSION 1.6.44 "PNG version for local builds")
-set (PNG_GIT_REPOSITORY "https://github.com/glennrp/libpng")
+set_cache (PNG_BUILD_VERSION 1.6.47 "PNG version for local builds")
+set (PNG_GIT_REPOSITORY "https://github.com/pnggroup/libpng")
 set (PNG_GIT_TAG "v${PNG_BUILD_VERSION}")
 
 set_cache (PNG_BUILD_SHARED_LIBS OFF


### PR DESCRIPTION
* The GitHub account has changed (the old one redirects, but still, let's update to the current canonical name).
* Update the version we use in CI and for "autobuild" to the latest tagged release instead of one that's years old.
