### PR TITLE
Bug fix: Updated tags for psb

### DIFF
--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -509,7 +509,7 @@ const PSDInput::ResourceLoader PSDInput::resource_loaders[]
 
 const char* PSDInput::additional_info_psb[]
     = { "LMsk", "Lr16", "Lr32", "Layr", "Mt16", "Mt32", "Mtrn",
-        "Alph", "FMsk", "Ink2", "FEid", "FXid", "PxSD", "cinf" };
+        "Alph", "FMsk", "lnk2", "FEid", "FXid", "PxSD", "cinf", "lnkE", "pths" };
 
 const unsigned int PSDInput::additional_info_psb_count
     = sizeof(additional_info_psb) / sizeof(additional_info_psb[0]);

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -508,8 +508,8 @@ const PSDInput::ResourceLoader PSDInput::resource_loaders[]
 
 
 const char* PSDInput::additional_info_psb[]
-    = { "LMsk", "Lr16", "Lr32", "Layr", "Mt16", "Mt32", "Mtrn",
-        "Alph", "FMsk", "lnk2", "FEid", "FXid", "PxSD", "cinf", "lnkE", "pths" };
+    = { "LMsk", "Lr16", "Lr32", "Layr", "Mt16", "Mt32", "Mtrn", "Alph",
+        "FMsk", "lnk2", "FEid", "FXid", "PxSD", "cinf", "lnkE", "pths" };
 
 const unsigned int PSDInput::additional_info_psb_count
     = sizeof(additional_info_psb) / sizeof(additional_info_psb[0]);


### PR DESCRIPTION
## Description

There were some psb files that were not opening with oiiotool, failing on the signature.
Some keys were missing for the additional layer information, leading to the pointer to misalign when reading the file, expecting the next 4 bytes rather than 8 bytes where needed for parsing.

## Tests

No additional test suites added.

After deliberating, it is unclear if we should have a strict mode, or keep parsing the rest of the file after a failed signature, given that in this case the signature is not the part that's actually causing the issue. Might be useful as a future feature, if there is an use case for that?


## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
