### PR TITLE
imagecache: remove redundant ImageSpec from ImageCache internals

### DIFF
--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -202,7 +202,7 @@ convention is dictated by OpenEXR.
 OIIO_NAMESPACE_BEGIN
 using namespace pvt;
 using namespace simd;
-
+using LevelInfo = ImageCacheFile::LevelInfo;
 
 bool
 TextureSystem::environment(ustring filename, TextureOpt& options, V3fParam R,
@@ -352,7 +352,7 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
         return missing_texture(options, nchannels, result, dresultds,
                                dresultdt);
     }
-    const ImageSpec& spec(texturefile->spec(options.subimage, 0));
+    const ImageSpec& spec(texturefile->get_subimage_spec(options.subimage));
 
     // Environment maps dictate particular wrap modes
     options.swrap = texturefile->m_sample_border
@@ -478,7 +478,7 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
             // Filters are in radians, and the vertical resolution of a
             // latlong map is PI radians.  So to compute the raster size of
             // our filter width...
-            float filtwidth_ras = subinfo.spec(m).full_height * filtwidth
+            float filtwidth_ras = subinfo.levels[m].get_full_height() * filtwidth
                                   * M_1_PI;
             // Once the filter width is smaller than one texel at this level,
             // we've gone too far, so we know that we want to interpolate the
@@ -524,7 +524,7 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
             int lev = miplevel[level];
             if (options.interpmode == TextureOpt::InterpSmartBicubic) {
                 if (lev == 0
-                    || (texturefile->spec(options.subimage, lev).full_height
+                    || (texturefile->levelinfo(options.subimage, lev).get_full_height()
                         < naturalres / 2)) {
                     sampler = &TextureSystemImpl::sample_bicubic;
                     ++stats.cubic_interps;

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -478,8 +478,8 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
             // Filters are in radians, and the vertical resolution of a
             // latlong map is PI radians.  So to compute the raster size of
             // our filter width...
-            float filtwidth_ras = subinfo.levels[m].get_full_height() * filtwidth
-                                  * M_1_PI;
+            float filtwidth_ras = subinfo.levels[m].get_full_height()
+                                  * filtwidth * M_1_PI;
             // Once the filter width is smaller than one texel at this level,
             // we've gone too far, so we know that we want to interpolate the
             // previous level and the current level.  Note that filtwidth_ras
@@ -524,7 +524,8 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
             int lev = miplevel[level];
             if (options.interpmode == TextureOpt::InterpSmartBicubic) {
                 if (lev == 0
-                    || (texturefile->levelinfo(options.subimage, lev).get_full_height()
+                    || (texturefile->levelinfo(options.subimage, lev)
+                            .get_full_height()
                         < naturalres / 2)) {
                     sampler = &TextureSystemImpl::sample_bicubic;
                     ++stats.cubic_interps;

--- a/src/libtexture/imagecache_memory_print.h
+++ b/src/libtexture/imagecache_memory_print.h
@@ -30,10 +30,6 @@ enum FileFootprintEnty : uint8_t {
     kSubImageCount,
     kLevelInfoMem,
     kLevelInfoCount,
-    kLevelInfoSpecMem,
-    kLevelInfoSpecMembMem,
-    kLevelInfoSpecParmsMem,
-    kLevelInfoSpecChanMem,
     kFootprintEntrySize
 };
 
@@ -139,19 +135,6 @@ printImageCacheMemory(std::ostream& out, const ImageCacheImpl& ic)
             print(out, "          Level infos : {}, count : {}\n",
                   Strutil::memformat(t.value()[kLevelInfoMem]),
                   t.value()[kLevelInfoCount]);
-        if (t.value()[kLevelInfoSpecMem] > 0ul)
-            print(out, "            Image specs : {}, count : {}\n",
-                  Strutil::memformat(t.value()[kLevelInfoSpecMem]),
-                  t.value()[kLevelInfoCount] * 2);
-        if (t.value()[kLevelInfoSpecMembMem] > 0ul)
-            print(out, "              Members : {}\n",
-                  Strutil::memformat(t.value()[kLevelInfoSpecMembMem]));
-        if (t.value()[kLevelInfoSpecParmsMem] > 0ul)
-            print(out, "              Extra attributes : {}\n",
-                  Strutil::memformat(t.value()[kLevelInfoSpecParmsMem]));
-        if (t.value()[kLevelInfoSpecChanMem] > 0ul)
-            print(out, "              Channel names : {}\n",
-                  Strutil::memformat(t.value()[kLevelInfoSpecChanMem]));
     }
 }
 

--- a/src/libtexture/imagecache_memory_pvt.h
+++ b/src/libtexture/imagecache_memory_pvt.h
@@ -23,9 +23,11 @@ template<>
 inline size_t
 heapsize<ImageCacheFile::LevelInfo>(const ImageCacheFile::LevelInfo& lvl)
 {
-    size_t size = heapsize(lvl.polecolor);
-    size += heapsize(lvl.m_spec);
-    size += heapsize(lvl.nativespec);
+    //! NOTE: we don't count the memory allocated for the shared_ptr m_spec,
+    // i.e. the associated subimage spec here, we account for it in the subimage heapsize once.
+    // We only account for the LevelSpec diff structure.
+    size_t size = heapsize(lvl.m_levelspec);
+    size += heapsize(lvl.polecolor);
     if (lvl.tiles_read) {
         const size_t total_tiles   = lvl.nxtiles * lvl.nytiles * lvl.nztiles;
         const size_t bitfield_size = round_to_multiple(total_tiles, 64) / 64;
@@ -41,6 +43,7 @@ heapsize<ImageCacheFile::SubimageInfo>(const ImageCacheFile::SubimageInfo& sub)
 {
     size_t size = heapsize(sub.levels);
     size += heapsize(sub.average_color);
+    size += heapsize(sub.m_spec);
     size += (sub.minwh ? sub.n_mip_levels * sizeof(int) : 0);
     size += (sub.Mlocal ? sizeof(Imath::M44f) : 0);
     return size;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -269,40 +269,33 @@ public:
     //! LevelSpec is a minified ImageSpec to describe a miplevel image in the ImageCache.
     //! It holds fields that can differ from the ImageSpec of the associated subimage.
     //! TODO: can we compress this even more with bitfield and dynamic alloc ?
-    //!     ideally we don't want to store any fields that are identical to the reference spec... 
-    struct LevelSpec
-    {
+    //!     ideally we don't want to store any fields that are identical to the reference spec...
+    struct LevelSpec {
         //! fields that can change for each miplevel
-        int x;                    ///< origin (upper left corner) of pixel data
-        int y;                    ///< origin (upper left corner) of pixel data
-        int z;                    ///< origin (upper left corner) of pixel data
-        int width;                ///< width of the pixel data window
-        int height;               ///< height of the pixel data window
-        int depth;                ///< depth of pixel data, >1 indicates a "volume"
-        int full_x;               ///< origin of the full (display) window
-        int full_y;               ///< origin of the full (display) window
-        int full_z;               ///< origin of the full (display) window
-        int full_width;           ///< width of the full (display) window
-        int full_height;          ///< height of the full (display) window
-        int full_depth;           ///< depth of the full (display) window
-        int tile_width;           ///< tile width (0 for a non-tiled image)
-        int tile_height;          ///< tile height (0 for a non-tiled image)
-        int tile_depth;           ///< tile depth (0 for a non-tiled image,
-                                  //<             1 for a non-volume image)
+        int x;            ///< origin (upper left corner) of pixel data
+        int y;            ///< origin (upper left corner) of pixel data
+        int z;            ///< origin (upper left corner) of pixel data
+        int width;        ///< width of the pixel data window
+        int height;       ///< height of the pixel data window
+        int depth;        ///< depth of pixel data, >1 indicates a "volume"
+        int full_x;       ///< origin of the full (display) window
+        int full_y;       ///< origin of the full (display) window
+        int full_z;       ///< origin of the full (display) window
+        int full_width;   ///< width of the full (display) window
+        int full_height;  ///< height of the full (display) window
+        int full_depth;   ///< depth of the full (display) window
+        int tile_width;   ///< tile width (0 for a non-tiled image)
+        int tile_height;  ///< tile height (0 for a non-tiled image)
+        int tile_depth;   ///< tile depth (0 for a non-tiled image,
+                          //<             1 for a non-volume image)
 
         //! Similar to ImageSpec
         LevelSpec();
         LevelSpec(const LevelSpec& other) = default;
-        LevelSpec(const ImageSpec& levelspec); /// copy members from ImageSpec
+        LevelSpec(const ImageSpec& levelspec);  /// copy members from ImageSpec
 
         //! Returns true iif all members are identical to the `spec` members of the same name.
         bool is_same(const ImageSpec& spec) const;
-
-        //! Tests if this LevelSpec describes a single tile
-        bool has_one_tile() const;
-
-        //! Tests if this LevelSpec describes a full image
-        bool has_full_pixel_range() const;
 
         //! The following methods are similar to the ones from ImageSpec
         //! evaluated with the LevelSpec members.
@@ -316,9 +309,10 @@ public:
     /// Info for each MIP level that isn't in the ImageSpec, or that we
     /// precompute.
     struct LevelInfo {
-        std::shared_ptr<ImageSpec> m_spec;        ///< ImageSpec for the subimage
-        std::unique_ptr<LevelSpec> m_levelspec;   ///< Extra level info in case they are
-            // different from the subimage spec
+        std::shared_ptr<ImageSpec> m_spec;  ///< ImageSpec for the subimage
+        std::unique_ptr<LevelSpec>
+            m_levelspec;  ///< Extra level info in case they are
+        // different from the subimage spec
         mutable std::unique_ptr<float[]> polecolor;  ///< Pole colors
         atomic_ll* tiles_read;  ///< Bitfield for tiles read at least once
         int nxtiles, nytiles, nztiles;  ///< Number of tiles in each dimension
@@ -424,11 +418,13 @@ public:
 
         ImageSpec& get_subimage_spec()
         {
-            OIIO_DASSERT(m_spec); return *m_spec;
+            OIIO_DASSERT(m_spec);
+            return *m_spec;
         }
         const ImageSpec& get_subimage_spec() const
         {
-            OIIO_DASSERT(m_spec); return *m_spec;
+            OIIO_DASSERT(m_spec);
+            return *m_spec;
         }
     };
 

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -308,13 +308,12 @@ TextureSystemImpl::accum3d_sample_closest(
     int actualchannels, float weight, float* accum, float* daccumds,
     float* daccumdt, float* daccumdr)
 {
-    const LevelInfo& levelinfo(
-        texturefile.levelinfo(options.subimage, miplevel));
+    const LevelInfo& lvl(texturefile.levelinfo(options.subimage, miplevel));
     TypeDesc::BASETYPE pixeltype = texturefile.pixeltype(options.subimage);
     // As passed in, (s,t) map the texture to (0,1).  Remap to texel coords.
-    float s = P.x * levelinfo.get_full_width() + levelinfo.get_full_x();
-    float t = P.y * levelinfo.get_full_height() + levelinfo.get_full_y();
-    float r = P.z * levelinfo.get_full_depth() + levelinfo.get_full_z();
+    float s = P.x * lvl.get_full_width() + lvl.get_full_x();
+    float t = P.y * lvl.get_full_height() + lvl.get_full_y();
+    float r = P.z * lvl.get_full_depth() + lvl.get_full_z();
     int stex, ttex, rtex;       // Texel coordinates
     (void)floorfrac(s, &stex);  // don't need fractional result
     (void)floorfrac(t, &ttex);
@@ -324,29 +323,31 @@ TextureSystemImpl::accum3d_sample_closest(
     wrap_impl twrap_func = wrap_functions[(int)options.twrap];
     wrap_impl rwrap_func = wrap_functions[(int)options.rwrap];
     bool svalid, tvalid, rvalid;  // Valid texels?  false means black border
-    svalid = swrap_func(stex, levelinfo.get_x(), levelinfo.get_width());
-    tvalid = twrap_func(ttex, levelinfo.get_y(), levelinfo.get_height());
-    rvalid = rwrap_func(rtex, levelinfo.get_z(), levelinfo.get_depth());
-    if (!levelinfo.full_pixel_range) {
-        svalid &= (stex >= levelinfo.get_x()
-                   && stex < (levelinfo.get_x() + levelinfo.get_width()));  // data window
-        tvalid &= (ttex >= levelinfo.get_y() && ttex < (levelinfo.get_y() + levelinfo.get_height()));
-        rvalid &= (rtex >= levelinfo.get_z() && rtex < (levelinfo.get_z() + levelinfo.get_depth()));
+    svalid = swrap_func(stex, lvl.get_x(), lvl.get_width());
+    tvalid = twrap_func(ttex, lvl.get_y(), lvl.get_height());
+    rvalid = rwrap_func(rtex, lvl.get_z(), lvl.get_depth());
+    if (!lvl.full_pixel_range) {
+        svalid &= (stex >= lvl.get_x()
+                   && stex < (lvl.get_x() + lvl.get_width()));  // data window
+        tvalid &= (ttex >= lvl.get_y()
+                   && ttex < (lvl.get_y() + lvl.get_height()));
+        rvalid &= (rtex >= lvl.get_z()
+                   && rtex < (lvl.get_z() + lvl.get_depth()));
     }
     if (!(svalid & tvalid & rvalid)) {
         // All texels we need were out of range and using 'black' wrap.
         return true;
     }
 
-    int tile_chbegin = 0, tile_chend = levelinfo.get_channels();
-    if (levelinfo.get_channels() > m_max_tile_channels) {
+    int tile_chbegin = 0, tile_chend = lvl.get_channels();
+    if (lvl.get_channels() > m_max_tile_channels) {
         // For files with many channels, narrow the range we cache
         tile_chbegin = options.firstchannel;
         tile_chend   = options.firstchannel + actualchannels;
     }
-    int tile_s = (stex - levelinfo.get_x()) % levelinfo.get_tile_width();
-    int tile_t = (ttex - levelinfo.get_y()) % levelinfo.get_tile_height();
-    int tile_r = (rtex - levelinfo.get_z()) % levelinfo.get_tile_depth();
+    int tile_s = (stex - lvl.get_x()) % lvl.get_tile_width();
+    int tile_t = (ttex - lvl.get_y()) % lvl.get_tile_height();
+    int tile_r = (rtex - lvl.get_z()) % lvl.get_tile_depth();
     TileID id(texturefile, options.subimage, miplevel, stex - tile_s,
               ttex - tile_t, rtex - tile_r, tile_chbegin, tile_chend,
               options.colortransformid);
@@ -356,12 +357,12 @@ TextureSystemImpl::accum3d_sample_closest(
     TileRef& tile(thread_info->tile);
     if (!tile || !ok)
         return false;
-    imagesize_t tilepel = (tile_r * levelinfo.get_tile_height() + imagesize_t(tile_t))
-                              * levelinfo.get_tile_width()
+    imagesize_t tilepel = (tile_r * lvl.get_tile_height() + imagesize_t(tile_t))
+                              * lvl.get_tile_width()
                           + tile_s;
     int startchan_in_tile = options.firstchannel - id.chbegin();
-    imagesize_t offset    = levelinfo.get_channels() * tilepel + startchan_in_tile;
-    OIIO_DASSERT((size_t)offset < levelinfo.get_channels() * levelinfo.get_tile_pixels());
+    imagesize_t offset    = lvl.get_channels() * tilepel + startchan_in_tile;
+    OIIO_DASSERT((size_t)offset < lvl.get_channels() * lvl.get_tile_pixels());
     if (pixeltype == TypeDesc::UINT8) {
         const unsigned char* texel = tile->bytedata() + offset;
         for (int c = 0; c < actualchannels; ++c)
@@ -471,14 +472,13 @@ TextureSystemImpl::accum3d_sample_bilinear(
     int actualchannels, float weight, float* accum, float* daccumds,
     float* daccumdt, float* daccumdr)
 {
-    const LevelInfo& levelinfo(
-        texturefile.levelinfo(options.subimage, miplevel));
+    const LevelInfo& lvl(texturefile.levelinfo(options.subimage, miplevel));
     TypeDesc::BASETYPE pixeltype = texturefile.pixeltype(options.subimage);
     // As passed in, (s,t) map the texture to (0,1).  Remap to texel coords
     // and subtract 0.5 because samples are at texel centers.
-    float s = P.x * levelinfo.get_full_width() + levelinfo.get_full_x() - 0.5f;
-    float t = P.y * levelinfo.get_full_height() + levelinfo.get_full_y() - 0.5f;
-    float r = P.z * levelinfo.get_full_depth() + levelinfo.get_full_z() - 0.5f;
+    float s = P.x * lvl.get_full_width() + lvl.get_full_x() - 0.5f;
+    float t = P.y * lvl.get_full_height() + lvl.get_full_y() - 0.5f;
+    float r = P.z * lvl.get_full_depth() + lvl.get_full_z() - 0.5f;
     int sint, tint, rint;
     float sfrac = floorfrac(s, &sint);
     float tfrac = floorfrac(t, &tint);
@@ -516,20 +516,26 @@ TextureSystemImpl::accum3d_sample_bilinear(
     bool* tvalid = valid_storage.bvalid + 2;
     bool* rvalid = valid_storage.bvalid + 4;
 
-    svalid[0] = swrap_func(stex[0], levelinfo.get_x(), levelinfo.get_width());
-    svalid[1] = swrap_func(stex[1], levelinfo.get_x(), levelinfo.get_width());
-    tvalid[0] = twrap_func(ttex[0], levelinfo.get_y(), levelinfo.get_height());
-    tvalid[1] = twrap_func(ttex[1], levelinfo.get_y(), levelinfo.get_height());
-    rvalid[0] = rwrap_func(rtex[0], levelinfo.get_z(), levelinfo.get_depth());
-    rvalid[1] = rwrap_func(rtex[1], levelinfo.get_z(), levelinfo.get_depth());
+    svalid[0] = swrap_func(stex[0], lvl.get_x(), lvl.get_width());
+    svalid[1] = swrap_func(stex[1], lvl.get_x(), lvl.get_width());
+    tvalid[0] = twrap_func(ttex[0], lvl.get_y(), lvl.get_height());
+    tvalid[1] = twrap_func(ttex[1], lvl.get_y(), lvl.get_height());
+    rvalid[0] = rwrap_func(rtex[0], lvl.get_z(), lvl.get_depth());
+    rvalid[1] = rwrap_func(rtex[1], lvl.get_z(), lvl.get_depth());
     // Account for crop windows
-    if (!levelinfo.full_pixel_range) {
-        svalid[0] &= (stex[0] >= levelinfo.get_x() && stex[0] < levelinfo.get_x() + levelinfo.get_width());
-        svalid[1] &= (stex[1] >= levelinfo.get_x() && stex[1] < levelinfo.get_x() + levelinfo.get_width());
-        tvalid[0] &= (ttex[0] >= levelinfo.get_y() && ttex[0] < levelinfo.get_y() + levelinfo.get_height());
-        tvalid[1] &= (ttex[1] >= levelinfo.get_y() && ttex[1] < levelinfo.get_y() + levelinfo.get_height());
-        rvalid[0] &= (rtex[0] >= levelinfo.get_z() && rtex[0] < levelinfo.get_z() + levelinfo.get_depth());
-        rvalid[1] &= (rtex[1] >= levelinfo.get_z() && rtex[1] < levelinfo.get_z() + levelinfo.get_depth());
+    if (!lvl.full_pixel_range) {
+        svalid[0] &= (stex[0] >= lvl.get_x()
+                      && stex[0] < lvl.get_x() + lvl.get_width());
+        svalid[1] &= (stex[1] >= lvl.get_x()
+                      && stex[1] < lvl.get_x() + lvl.get_width());
+        tvalid[0] &= (ttex[0] >= lvl.get_y()
+                      && ttex[0] < lvl.get_y() + lvl.get_height());
+        tvalid[1] &= (ttex[1] >= lvl.get_y()
+                      && ttex[1] < lvl.get_y() + lvl.get_height());
+        rvalid[0] &= (rtex[0] >= lvl.get_z()
+                      && rtex[0] < lvl.get_z() + lvl.get_depth());
+        rvalid[1] &= (rtex[1] >= lvl.get_z()
+                      && rtex[1] < lvl.get_z() + lvl.get_depth());
     }
     //    if (! (svalid[0] | svalid[1] | tvalid[0] | tvalid[1] | rvalid[0] | rvalid[1]))
     if (valid_storage.ivalid == none_valid)
@@ -556,23 +562,23 @@ TextureSystemImpl::accum3d_sample_bilinear(
         return true;
     }
 
-    int tilewidthmask  = levelinfo.get_tile_width() - 1;  // e.g. 63
-    int tileheightmask = levelinfo.get_tile_height() - 1;
-    int tiledepthmask  = levelinfo.get_tile_depth() - 1;
+    int tilewidthmask  = lvl.get_tile_width() - 1;  // e.g. 63
+    int tileheightmask = lvl.get_tile_height() - 1;
+    int tiledepthmask  = lvl.get_tile_depth() - 1;
     const unsigned char* texel[2][2][2];
     TileRef savetile[2][2][2];
     static float black[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-    int tile_s            = (stex[0] - levelinfo.get_x()) % levelinfo.get_tile_width();
-    int tile_t            = (ttex[0] - levelinfo.get_y()) % levelinfo.get_tile_height();
-    int tile_r            = (rtex[0] - levelinfo.get_z()) % levelinfo.get_tile_depth();
+    int tile_s            = (stex[0] - lvl.get_x()) % lvl.get_tile_width();
+    int tile_t            = (ttex[0] - lvl.get_y()) % lvl.get_tile_height();
+    int tile_r            = (rtex[0] - lvl.get_z()) % lvl.get_tile_depth();
     bool s_onetile     = (tile_s != tilewidthmask) & (stex[0] + 1 == stex[1]);
     bool t_onetile     = (tile_t != tileheightmask) & (ttex[0] + 1 == ttex[1]);
     bool r_onetile     = (tile_r != tiledepthmask) & (rtex[0] + 1 == rtex[1]);
     bool onetile       = (s_onetile & t_onetile & r_onetile);
     size_t channelsize = texturefile.channelsize(options.subimage);
     size_t pixelsize   = texturefile.pixelsize(options.subimage);
-    int tile_chbegin = 0, tile_chend = levelinfo.get_channels();
-    if (levelinfo.get_channels() > m_max_tile_channels) {
+    int tile_chbegin = 0, tile_chend = lvl.get_channels();
+    if (lvl.get_channels() > m_max_tile_channels) {
         // For files with many channels, narrow the range we cache
         tile_chbegin = options.firstchannel;
         tile_chend   = options.firstchannel + actualchannels;
@@ -590,23 +596,24 @@ TextureSystemImpl::accum3d_sample_bilinear(
         TileRef& tile(thread_info->tile);
         if (!tile->valid())
             return false;
-        imagesize_t tilepel = (tile_r * levelinfo.get_tile_height() + imagesize_t(tile_t))
-                                  * levelinfo.get_tile_width()
+        imagesize_t tilepel = (tile_r * lvl.get_tile_height()
+                               + imagesize_t(tile_t))
+                                  * lvl.get_tile_width()
                               + tile_s;
-        imagesize_t offset = (levelinfo.get_channels() * tilepel + startchan_in_tile)
+        imagesize_t offset = (lvl.get_channels() * tilepel + startchan_in_tile)
                              * channelsize;
-        OIIO_DASSERT(offset < levelinfo.get_tile_bytes());
+        OIIO_DASSERT(offset < lvl.get_tile_bytes());
 
         const unsigned char* b = tile->bytedata() + offset;
         texel[0][0][0]         = b;
         texel[0][0][1]         = b + pixelsize;
-        texel[0][1][0]         = b + pixelsize * levelinfo.get_tile_width();
-        texel[0][1][1]         = b + pixelsize * levelinfo.get_tile_width() + pixelsize;
-        b += pixelsize * levelinfo.get_tile_width() * levelinfo.get_tile_height();
+        texel[0][1][0]         = b + pixelsize * lvl.get_tile_width();
+        texel[0][1][1] = b + pixelsize * lvl.get_tile_width() + pixelsize;
+        b += pixelsize * lvl.get_tile_width() * lvl.get_tile_height();
         texel[1][0][0] = b;
         texel[1][0][1] = b + pixelsize;
-        texel[1][1][0] = b + pixelsize * levelinfo.get_tile_width();
-        texel[1][1][1] = b + pixelsize * levelinfo.get_tile_width() + pixelsize;
+        texel[1][1][0] = b + pixelsize * lvl.get_tile_width();
+        texel[1][1][1] = b + pixelsize * lvl.get_tile_width() + pixelsize;
     } else {
         bool firstsample = true;
         for (int k = 0; k < 2; ++k) {
@@ -616,9 +623,9 @@ TextureSystemImpl::accum3d_sample_bilinear(
                         texel[k][j][i] = (unsigned char*)black;
                         continue;
                     }
-                    tile_s = (stex[i] - levelinfo.get_x()) % levelinfo.get_tile_width();
-                    tile_t = (ttex[j] - levelinfo.get_y()) % levelinfo.get_tile_height();
-                    tile_r = (rtex[k] - levelinfo.get_z()) % levelinfo.get_tile_depth();
+                    tile_s = (stex[i] - lvl.get_x()) % lvl.get_tile_width();
+                    tile_t = (ttex[j] - lvl.get_y()) % lvl.get_tile_height();
+                    tile_r = (rtex[k] - lvl.get_z()) % lvl.get_tile_depth();
                     id.xyz(stex[i] - tile_s, ttex[j] - tile_t,
                            rtex[k] - tile_r);
                     bool ok = find_tile(id, thread_info, firstsample);
@@ -629,21 +636,22 @@ TextureSystemImpl::accum3d_sample_bilinear(
                     if (!tile->valid())
                         return false;
                     savetile[k][j][i]   = tile;
-                    imagesize_t tilepel = (tile_r * levelinfo.get_tile_height()
+                    imagesize_t tilepel = (tile_r * lvl.get_tile_height()
                                            + imagesize_t(tile_t))
-                                              * levelinfo.get_tile_width()
+                                              * lvl.get_tile_width()
                                           + tile_s;
-                    imagesize_t offset = (levelinfo.get_channels() * tilepel
+                    imagesize_t offset = (lvl.get_channels() * tilepel
                                           + startchan_in_tile)
                                          * channelsize;
 #ifndef NDEBUG
-                    if (offset >= levelinfo.get_tile_bytes())
+                    if (offset >= lvl.get_tile_bytes())
                         std::cerr << "offset=" << offset << ", whd "
-                                  << levelinfo.get_tile_width() << ' ' << levelinfo.get_tile_height()
-                                  << ' ' << levelinfo.get_tile_depth() << " pixsize "
+                                  << lvl.get_tile_width() << ' '
+                                  << lvl.get_tile_height() << ' '
+                                  << lvl.get_tile_depth() << " pixsize "
                                   << pixelsize << "\n";
 #endif
-                    OIIO_DASSERT((size_t)offset < levelinfo.get_tile_bytes());
+                    OIIO_DASSERT((size_t)offset < lvl.get_tile_bytes());
                     texel[k][j][i] = tile->bytedata() + offset;
                     OIIO_DASSERT(tile->id() == id);
                 }
@@ -654,20 +662,20 @@ TextureSystemImpl::accum3d_sample_bilinear(
 
     if (pixeltype == TypeDesc::UINT8) {
         trilerp_accum<uint8_t>(accum, daccumds, daccumdt, daccumdr, texel,
-                               sfrac, tfrac, rfrac, actualchannels, weight,
-                               levelinfo, uchar2float);
+                               sfrac, tfrac, rfrac, actualchannels, weight, lvl,
+                               uchar2float);
     } else if (pixeltype == TypeDesc::UINT16) {
         trilerp_accum<uint16_t>(accum, daccumds, daccumdt, daccumdr, texel,
                                 sfrac, tfrac, rfrac, actualchannels, weight,
-                                levelinfo, ushort2float);
+                                lvl, ushort2float);
     } else if (pixeltype == TypeDesc::HALF) {
         trilerp_accum<half>(accum, daccumds, daccumdt, daccumdr, texel, sfrac,
-                            tfrac, rfrac, actualchannels, weight, levelinfo,
+                            tfrac, rfrac, actualchannels, weight, lvl,
                             half2float);
     } else {
         // General case for float tiles
         trilerp_accum<float>(accum, daccumds, daccumdt, daccumdr, texel, sfrac,
-                             tfrac, rfrac, actualchannels, weight, levelinfo,
+                             tfrac, rfrac, actualchannels, weight, lvl,
                              float2float);
     }
 

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -401,8 +401,8 @@ public:
     /// portion of the way to the next texel to the right or down,
     /// respectively.
     void st_to_texel(float s, float t, TextureFile& texturefile,
-                     const TextureFile::LevelInfo& lvl, int& i, int& j, float& ifrac,
-                     float& jfrac);
+                     const TextureFile::LevelInfo& lvl, int& i, int& j,
+                     float& ifrac, float& jfrac);
 
     /// Called when the requested texture is missing, fills in the
     /// results.
@@ -526,8 +526,8 @@ TextureSystemImpl::anisotropic_aspect(float& majorlength, float& minorlength,
 
 inline void
 TextureSystemImpl::st_to_texel(float s, float t, TextureFile& texturefile,
-                               const TextureFile::LevelInfo& lvl, int& i, int& j,
-                               float& ifrac, float& jfrac)
+                               const TextureFile::LevelInfo& lvl, int& i,
+                               int& j, float& ifrac, float& jfrac)
 {
     // As passed in, (s,t) map the texture to (0,1).  Remap to texel coords.
     // Note that we have two modes, depending on the m_sample_border.

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -401,7 +401,7 @@ public:
     /// portion of the way to the next texel to the right or down,
     /// respectively.
     void st_to_texel(float s, float t, TextureFile& texturefile,
-                     const ImageSpec& spec, int& i, int& j, float& ifrac,
+                     const TextureFile::LevelInfo& lvl, int& i, int& j, float& ifrac,
                      float& jfrac);
 
     /// Called when the requested texture is missing, fills in the
@@ -526,20 +526,20 @@ TextureSystemImpl::anisotropic_aspect(float& majorlength, float& minorlength,
 
 inline void
 TextureSystemImpl::st_to_texel(float s, float t, TextureFile& texturefile,
-                               const ImageSpec& spec, int& i, int& j,
+                               const TextureFile::LevelInfo& lvl, int& i, int& j,
                                float& ifrac, float& jfrac)
 {
     // As passed in, (s,t) map the texture to (0,1).  Remap to texel coords.
     // Note that we have two modes, depending on the m_sample_border.
     if (texturefile.m_sample_border == 0) {
         // texel samples are at 0.5/res, 1.5/res, ..., (res-0.5)/res,
-        s = s * spec.width + spec.x - 0.5f;
-        t = t * spec.height + spec.y - 0.5f;
+        s = s * lvl.get_width() + lvl.get_x() - 0.5f;
+        t = t * lvl.get_height() + lvl.get_y() - 0.5f;
     } else {
         // first and last rows/columns are *exactly* on the boundary,
         // so samples are at 0, 1/(res-1), ..., 1.
-        s = s * (spec.width - 1) + spec.x;
-        t = t * (spec.height - 1) + spec.y;
+        s = s * (lvl.get_width() - 1) + lvl.get_x();
+        t = t * (lvl.get_height() - 1) + lvl.get_y();
     }
     ifrac = floorfrac(s, &i);
     jfrac = floorfrac(t, &j);


### PR DESCRIPTION
First draft of backend changes for issue https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4436.

## Description

- add `LevelSpec` struct to store only a subset of `ImageSpec` descriptors, which can be different per mip level.
   - currently stores all fields that could differ, we might want a more compact version ?
- add member `std::shared_ptr<ImageSpec> m_spec` in `SubimageInfo` to store the descriptors that are common across all mip level
- add member `std::shared_ptr<ImageSpec> m_spec` in `LevelInfo` to link to the associated subimage spec
- add member`std::unique_ptr<LevelSpec> m_spec` in `LevelInfo`, allocated only if some fields differ from `m_spec`
- add accessors to `LevelInfo` internals, such that it can be used in `ImageCache` and ` TextureSystem`

## Checklist:

- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
