### PR TITLE
api(span.h): OIIO::span improvements

### DIFF
--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -19,6 +19,13 @@
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/detail/fmt.h>
 
+// Span notes and helpful links:
+// - cppreference on std::span:
+//   https://en.cppreference.com/w/cpp/container/span
+// - Another implementation, for reference:
+//   https://github.com/tcbrindle/span/blob/master/include/tcb/span.hpp
+
+
 OIIO_NAMESPACE_BEGIN
 
 // Our pre-3.0 implementation had span::size() as a signed value, because we
@@ -86,11 +93,17 @@ public:
     constexpr span () noexcept = default;
 
     /// Copy constructor (copies the span pointer and length, NOT the data).
-    template<class U, span_size_t N>
+    constexpr span (const span &copy) noexcept = default;
+
+    /// Copy constructor from a different extent (copies the span pointer and
+    /// length, NOT the data). This allows for construction of `span<const T>`
+    /// from `span<T>`, and for converting fixed extent to dynamic extent.
+    /// It does not allow for converting to an incompatible data type.
+    template<class U, span_size_t N,
+             OIIO_ENABLE_IF(std::is_same_v<std::remove_cv_t<T>, std::remove_cv_t<U>>
+                             && (extent == dynamic_extent || extent == N))>
     constexpr span (const span<U,N> &copy) noexcept
         : m_data(copy.data()), m_size(copy.size()) { }
-    /// Copy constructor (copies the span pointer and length, NOT the data).
-    constexpr span (const span &copy) noexcept = default;
 
     /// Construct from T* and length.
     constexpr span (pointer data, size_type size) noexcept
@@ -155,20 +168,26 @@ public:
         return { m_data + Offset, Count != dynamic_extent ? Count : (Extent != dynamic_extent ? Extent - Offset : m_size - Offset) };
     }
 
-    /// Subspan containing just the first element.
+    /// Subspan containing just the first `count` elements. The count will be
+    /// clamped to be no more than the current size.
     constexpr span<element_type, dynamic_extent> first (size_type count) const {
-        return { m_data, count };
+        return { m_data, std::min(count, m_size) };
     }
 
-    /// Subspan containing just the last element.
+    /// Subspan containing just the last `count` elements. The count will be
+    /// clamped to be no more than the current size.
     constexpr span<element_type, dynamic_extent> last (size_type count) const {
+        count = std::min(count, m_size);
         return { m_data + ( m_size - count ), count };
     }
 
-    /// Subspan starting atoOffset and containing count elements.
+    /// Subspan starting at offset and containing count elements. The range
+    /// requested will be clamped to the current size of the span.
     constexpr span<element_type, dynamic_extent>
     subspan (size_type offset, size_type count = dynamic_extent) const {
-        return { m_data + offset, count == dynamic_extent ? m_size - offset : count };
+        offset = std::min(offset, m_size);
+        count = std::min(count, m_size - offset);
+        return { m_data + offset, count };
     }
 
     /// Return the number of elements in the span.
@@ -200,9 +219,15 @@ public:
     }
 
     /// The first element of the span.
-    constexpr reference front() const noexcept { return m_data[0]; }
+    constexpr reference front() const noexcept {
+        OIIO_DASSERT(m_size >= 1);
+        return m_data[0];
+    }
     /// The last element of the span.
-    constexpr reference back() const noexcept { return m_data[size()-1]; }
+    constexpr reference back() const noexcept {
+        OIIO_DASSERT(m_size >= 1);
+        return m_data[size() - 1];
+    }
 
     /// Iterator pointing to the beginning of the span.
     constexpr iterator begin() const noexcept { return m_data; }
@@ -481,6 +506,20 @@ make_cspan(const T* data, span_size_t size)  // cspan from ptr + size
 
 
 
+/// Convert a span of any type to a span of a differing type covering the same
+/// memory. If the sizes are not identical, it will truncate length if
+/// necessary to not spill past the bounds of the input span. Use with
+/// caution!
+template<class T, class S = std::byte, span_size_t Extent>
+span<T>
+span_cast(const span<S, Extent>& s) noexcept
+{
+    return make_span(reinterpret_cast<T*>(s.data()),
+                     s.size_bytes() / sizeof(T));
+}
+
+
+
 /// Convert a span of any type to a span of bytes covering the same range of
 /// memory.
 template<typename T, span_size_t Extent>
@@ -501,6 +540,37 @@ span<std::byte,
 as_writable_bytes(span<T, Extent> s) noexcept
 {
     return { reinterpret_cast<std::byte*>(s.data()), s.size_bytes() };
+}
+
+
+
+/// Convert a raw `const T*` ptr + length to a span of const bytes covering
+/// the same range of memory. For non-void pointers, the length is in the
+/// number of elements of T; for void pointers, the length is measured in
+/// bytes.
+template<typename T>
+span<const std::byte>
+as_bytes(const T* ptr, size_t len) noexcept
+{
+    size_t nbytes = len;
+    if constexpr (!std::is_void_v<T>)
+        nbytes *= sizeof(T);
+    return make_cspan(reinterpret_cast<const std::byte*>(ptr), nbytes);
+}
+
+
+
+/// Convert a raw `T*` ptr + length to a span of mutable bytes covering the
+/// same range of memory. For non-void pointers, the length is in the number
+/// of elements of T; for void pointers, the length is measured in bytes.
+template<class T, OIIO_ENABLE_IF(!std::is_const_v<T>)>
+span<std::byte>
+as_writable_bytes(T* ptr, size_t len) noexcept
+{
+    size_t nbytes = len;
+    if constexpr (!std::is_void_v<T>)
+        nbytes *= sizeof(T);
+    return make_span(reinterpret_cast<std::byte*>(ptr), nbytes);
 }
 
 

--- a/src/libutil/span_test.cpp
+++ b/src/libutil/span_test.cpp
@@ -346,6 +346,44 @@ test_make_span()
 
 
 void
+test_as_bytes()
+{
+    print("testing as_bytes, as_writable_bytes\n");
+
+    float c_arr[] = { 1, 2.5, 3, 4 };
+    span<float> aspan(c_arr);
+    OIIO_CHECK_ASSERT(aspan.size() == 4 && aspan[1] == 2.5f);
+
+    auto ab  = as_bytes(aspan);
+    auto awb = as_writable_bytes(aspan);
+    OIIO_CHECK_EQUAL(ab.size(), aspan.size() * sizeof(float));
+    OIIO_CHECK_EQUAL(ab.size_bytes(), aspan.size_bytes());
+    OIIO_CHECK_EQUAL(ab.data(), reinterpret_cast<std::byte*>(aspan.data()));
+    OIIO_CHECK_EQUAL(awb.size(), aspan.size() * sizeof(float));
+    OIIO_CHECK_EQUAL(awb.size_bytes(), aspan.size_bytes());
+    OIIO_CHECK_EQUAL(awb.data(), reinterpret_cast<std::byte*>(aspan.data()));
+}
+
+
+
+void
+test_span_cast()
+{
+    print("testing span_cast\n");
+
+    float c_arr[] = { 1, 2.5, 3, 4 };
+    span<float> aspan(c_arr);
+    OIIO_CHECK_ASSERT(aspan.size() == 4 && aspan[1] == 2.5f);
+
+    auto cast = span_cast<uint16_t>(aspan);
+    OIIO_CHECK_EQUAL(cast.size_bytes(), aspan.size_bytes());
+    OIIO_CHECK_EQUAL(cast.size(), 8);
+    OIIO_CHECK_EQUAL(cast.data(), reinterpret_cast<uint16_t*>(aspan.data()));
+}
+
+
+
+void
 test_spancpy()
 {
     print("testing spancpy\n");
@@ -488,6 +526,8 @@ main(int /*argc*/, char* /*argv*/[])
     test_image_view();
     test_image_view_mutable();
     test_make_span();
+    test_as_bytes();
+    test_span_cast();
     test_spancpy();
     test_spanset();
     test_spanzero();


### PR DESCRIPTION
Additions to `OIIO::span<>`:

* New flavors of `as_bytes()`, `as_writable_bytes()` that take a raw pointer + length, turning them into `cspan<byte>` and `span<byte>`, respectively.
* `span_cast<T>()`: "cast" a span of one type into a span of a different type covering the same memory. Use with caution!

Safety improvements to existing functionality:

* front(), back(): Add a debug assertion to validate that there is at least one element.
* first(), last(), subspan(): clamp offsets and counts so that the result can't possibly return a span referencing memory that wasn't inside the original bounds.
* The copy constructor that takes a non-matching span was much too flexible. Now it uses enable_if to ensure that it can't be used to change data types or lengths, it can only turn span of non-const into span of const, and span of fixed extent into span of dynamic extent.
