### PR TITLE
fix(tiff): the default value for bitspersample should be 1

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1023,8 +1023,7 @@ TIFFInput::readspec(bool read_meta)
         m_spec.tile_depth  = 0;
     }
 
-    m_bitspersample = 8;
-    TIFFGetField(m_tif, TIFFTAG_BITSPERSAMPLE, &m_bitspersample);
+    TIFFGetFieldDefaulted(m_tif, TIFFTAG_BITSPERSAMPLE, &m_bitspersample);
     m_spec.attribute("oiio:BitsPerSample", (int)m_bitspersample);
 
     unsigned short sampleformat = SAMPLEFORMAT_UINT;


### PR DESCRIPTION
## Description
The default value for m_bitspersample should be 1 when TIFFTAG_BITSPERSAMPLE is not present in the directory.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
