### PR TITLE
fix: invalid loop bound when appending mipmap textures using oiiotool

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2982,7 +2982,7 @@ action_subimage_append_n(Oiiotool& ot, int n, string_view command)
     for (int i = 0; i < n; ++i) {
         ImageRecRef A = images[i];
         for (int s = 0; s < A->subimages(); ++s, ++sub) {
-            for (int m = 0; m < A->miplevels(s); ++m) {
+            for (int m = 0; m < allmiplevels[s]; ++m) {
                 bool ok = (*R)(sub, m).copy((*A)(s, m));
                 if (!ok) {
                     ot.error(command, (*R)(sub, m).geterror());


### PR DESCRIPTION
The following command fails for images with mip map levels due to a bug:
```
oiiotool mipmap_images.*.exr --siappendall -o all_images.exr
```

If the option `-a` is not appended to the command, mip levels higher than 0 should be ignored, instead it just segfault due to out of bound access; I just fixed the it in the PR cf. [my comment below](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4671#discussion_r1999705885).
