### PR TITLE
feat: ImageBuf::merge_metadata and oiiotool --mergemeta

### DIFF
--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -149,8 +149,9 @@ Copying ImageBuf's and blocks of pixels
 .. doxygenfunction:: OIIO::ImageBuf::operator=(ImageBuf &&src)
 .. doxygenfunction:: OIIO::ImageBuf::copy(const ImageBuf &src, TypeDesc format = TypeUnknown)
 .. doxygenfunction:: OIIO::ImageBuf::copy(TypeDesc format) const
-.. doxygenfunction:: OIIO::ImageBuf::copy_metadata
 .. doxygenfunction:: OIIO::ImageBuf::copy_pixels
+.. doxygenfunction:: OIIO::ImageBuf::copy_metadata
+.. doxygenfunction:: OIIO::ImageBuf::merge_metadata
 .. doxygenfunction:: OIIO::ImageBuf::swap
 
 

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -2998,18 +2998,45 @@ current top image.
 
     Takes two images -- the first will be a source of metadata only, and the
     second the source of pixels -- and produces a new copy of the second
-    image with the metadata from the first image added.
+    image with the metadata from the first image.
 
-    The output image's pixels will come only from the second input. Metadata
-    from the second input will be preserved if no identically-named metadata
-    was present in the first input image.
-
-    Examples::
+    Example::
 
         # Add all the metadata from meta.exr to pixels.exr and write the
         # combined image to out.exr.
         oiiotool meta.exr pixels.exr --pastemeta -o out.exr
 
+
+.. option:: --mergemeta <location>
+
+    Takes two images -- the first will be a source of metadata only, and the
+    second the source of pixels -- and produces a new copy of the second
+    image with the metadata from the first image added added to the second
+    image, item by item (i.e. not wholly removing the metadata that was
+    there before).
+
+    Optional appended modifiers include:
+
+    - `override=` *int* : If zero (the default), no
+      existing metadata in the destination will be altered, i.e., the only
+      metadata copied from source to destination will be those that did not
+      previously exist in the destination. If the override value is nonzero,
+      then all metadata items in the source will *replace* any existing
+      correspondingly named items in the destination.
+
+    - `pattern=` *regex* : If supplied, only copies metadata whose name
+      matches has a substring matching the regular expression. The special
+      character `^` indicates the beginning of the string and `$` indicates
+      the end of the string. 
+
+    Example::
+
+        # Add all of meta.exr's metadata whose name begins with "camera:"
+        # to pixels.exr, replacing any similarly named items, and write
+        # the combined image to out.exr.
+        oiiotool meta.exr pixels.exr --pastemeta:pattern="^camera:override=1" -o out.exr
+
+    The `--mergemeta` command  was added in OIIO 3.0.4.
 
 .. option:: --mosaic <size>
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -1966,19 +1966,6 @@ awaiting a call to `reset()` or `copy()` before it is useful.
     the ImageBuf.
 
 
-.. py:method:: ImageBuf.copy_metadata (other_imagebuf)
-
-    Replaces the metadata (all ImageSpec items, except for the data format
-    and pixel data window size) with the corresponding metadata from the
-    other ImageBuf.
-
-
-.. py:method:: ImageBuf.copy_pixels (other_imagebuf)
-
-    Replace the pixels in this ImageBuf with the values from the other
-    ImageBuf.
-
-
 .. py:method:: ImageBuf ImageBuf.copy (format=TypeUnknown)
 
     Return a full copy of this ImageBuf (with optional data format
@@ -2018,6 +2005,40 @@ awaiting a call to `reset()` or `copy()` before it is useful.
         C = ImageBuf()
         C.copy (A, oiio.FLOAT)
 
+
+
+.. py:method:: ImageBuf.copy_pixels (other_imagebuf)
+
+    Replace the pixels in this ImageBuf with the values from the other
+    ImageBuf.
+
+
+.. py:method:: ImageBuf.copy_metadata (other_imagebuf)
+
+    Replace the metadata of `Self` (all ImageSpec items, except for the data
+    format and pixel data window size) with the metadata from the other
+    ImageBuf.
+
+
+.. py:method:: ImageBuf.merge_metadata (src, override : bool = False, pattern : str = "")
+
+    Merge metadata from `src` into the metadata of `Self` (except for the data
+    format and pixel data window size). Metadata in `Self` that is not in
+    `src` will not be altered. Metadata in `Self` that also is in `src` will
+    be replaced only if `override` is True. If `pattern` is not empty, only
+    metadata having a substring that matches the regex pattern will be merged.
+
+    @version 3.0.5+
+
+    Example:
+
+    .. code-block:: python
+
+        A = ImageBuf("A.exr")
+        B = ImageBuf("B.exr")
+        A.merge_metadata(B, True, "^camera:")
+        # Now A contains all of B's metadata whose name starts with the
+        # substring "camera:"
 
 
 .. py:method:: ImageBuf.swap (other_imagebuf)

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -669,9 +669,35 @@ public:
     /// Move assignment.
     const ImageBuf& operator=(ImageBuf&& src);
 
-    /// Copy all the metadata from `src` to `*this` (except for pixel data
-    /// resolution, channel types and names, and data format).
+    /// Copy all the metadata from `src` to `*this`, replacing all named
+    /// metadata that was previously in `*this`. The "full" size and desired
+    /// tile size will also be replaced by the corresponding values from
+    /// `src`, but the pixel data resolution, channel types and names, and
+    /// data format of `*this` will not be altered.
     void copy_metadata(const ImageBuf& src);
+
+    /// Merge metadata from `src` into the metadata of `*this` (except for the
+    /// data format and pixel data window size). Metadata in `*this` that is
+    /// not in `src` will not be altered. Metadata in `*this` that also is in
+    /// `src` will be replaced only if `override` is True. If `pattern` is not
+    /// empty, only metadata having a substring that matches the regex pattern
+    /// will be merged.
+    ///
+    /// @param src
+    ///     The source ImageBuf supplying the metadata (but not pixel
+    ///     values).
+    /// @param override
+    ///     If true, `src` attributes will replace any identically-named
+    ///     attributes already in `*this`. If false (the default), only
+    ///     attributes whose names are not already in this list will be
+    ///     appended.
+    /// @param pattern
+    ///     If not empty, only copy metadata from `src` whose name contains
+    ///     a substring matching the regex `pattern`.
+    ///
+    /// @version 3.0.5+
+    void merge_metadata(const ImageBuf& src, bool override = false,
+                        string_view pattern = {});
 
     /// Copy the pixel data from `src` to `*this`, automatically converting
     /// to the existing data format of `*this`.  It only copies pixels in

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4765,6 +4765,18 @@ OIIOTOOL_OP(pastemeta, 2, [&](OiiotoolOp& op, span<ImageBuf*> img) {
 
 
 
+// --mergemeta
+OIIOTOOL_OP(mergemeta, 2, [&](OiiotoolOp& op, span<ImageBuf*> img) {
+    std::string pattern = op.options("pattern");
+    bool override       = op.options("override").get<int>();
+
+    *img[0] = *img[2];
+    img[0]->merge_metadata(*img[1], override, pattern);
+    return true;
+});
+
+
+
 // --mosaic
 static void
 action_mosaic(Oiiotool& ot, cspan<const char*> argv)
@@ -6787,8 +6799,11 @@ Oiiotool::getargs(int argc, char* argv[])
       .help("Paste fg over bg at the given position (e.g., +100+50; '-' or 'auto' indicates using the data window position as-is; options: all=%d, mergeroi=%d)")
       .OTACTION(action_paste);
     ap.arg("--pastemeta")
-      .help("Copy the metadata from the first image to the second image and write the combined result.")
+      .help("Copy the metadata from the first image to the second image and keep the combined result")
       .OTACTION(action_pastemeta);
+    ap.arg("--mergemeta")
+      .help("Merge the metadata from the first image into the second image and keep the combined result (options: pattern=REGEX, override=%d)")
+      .OTACTION(action_mergemeta);
     ap.arg("--mosaic %s:WxH")
       .help("Assemble images into a mosaic (arg: WxH; options: pad=0, fit=WxH)")
       .OTACTION(action_mosaic);

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -426,8 +426,6 @@ declare_imagebuf(py::module& m)
 
         .def("pixelindex", &ImageBuf::pixelindex, "x"_a, "y"_a, "z"_a,
              "check_range"_a = false)
-        .def("copy_metadata", &ImageBuf::copy_metadata)
-        .def("copy_pixels", &ImageBuf::copy_pixels)
         .def(
             "copy",
             [](ImageBuf& self, const ImageBuf& src, TypeDesc format) {
@@ -442,6 +440,15 @@ declare_imagebuf(py::module& m)
                 return src.copy(format);
             },
             "format"_a = TypeUnknown)
+        .def("copy_pixels", &ImageBuf::copy_pixels)
+        .def("copy_metadata", &ImageBuf::copy_metadata)
+        .def(
+            "merge_metadata",
+            [](ImageBuf& self, const ImageBuf& src, bool override,
+               const std::string& pattern) {
+                self.merge_metadata(src, override, pattern);
+            },
+            "src"_a, "override"_a = false, "pattern"_a = "")
         .def("swap", &ImageBuf::swap)
         .def("getchannel", &ImageBuf::getchannel, "x"_a, "y"_a, "z"_a, "c"_a,
              "wrap"_a = "black")

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -76,6 +76,7 @@ green.exr            :   64 x   64, 3 channel, half openexr
     SHA-1: 8B61993247469F3C208CA894D71856727B11606A
     channel list: R, G, B
     compression: "zip"
+    hair: "black"
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
@@ -93,6 +94,54 @@ greenmeta.exr        :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     weight: 20.5
+    camera:lens: "AX30"
+    camera:shutter: 0.0125
+    oiio:ColorSpace: "lin_rec709"
+    oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
+Reading greenmeta-merge.exr
+greenmeta-merge.exr  :   64 x   64, 3 channel, half openexr
+    SHA-1: 8B61993247469F3C208CA894D71856727B11606A
+    channel list: R, G, B
+    compression: "zip"
+    eyes: 2
+    hair: "black"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    weight: 20.5
+    camera:lens: "AX30"
+    camera:shutter: 0.0125
+    oiio:ColorSpace: "lin_rec709"
+    oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
+Reading greenmeta-merge-override.exr
+greenmeta-merge-override.exr :   64 x   64, 3 channel, half openexr
+    SHA-1: 8B61993247469F3C208CA894D71856727B11606A
+    channel list: R, G, B
+    compression: "zip"
+    eyes: 2
+    hair: "brown"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    weight: 20.5
+    camera:lens: "AX30"
+    camera:shutter: 0.0125
+    oiio:ColorSpace: "lin_rec709"
+    oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
+Reading greenmeta-merge-camera.exr
+greenmeta-merge-camera.exr :   64 x   64, 3 channel, half openexr
+    SHA-1: 8B61993247469F3C208CA894D71856727B11606A
+    channel list: R, G, B
+    compression: "zip"
+    hair: "black"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    camera:lens: "AX30"
+    camera:shutter: 0.0125
     oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-copy/run.py
+++ b/testsuite/oiiotool-copy/run.py
@@ -93,11 +93,17 @@ command += oiiotool ("../common/grid.tif "
             + "--pattern checker 256x256 3 --paste +150+75 -o pasted.tif")
 
 # test --pastemeta
-command += oiiotool ("--pattern:type=half constant:color=0,1,0 64x64 3 -o green.exr")
-command += oiiotool ("--pattern:type=half constant:color=1,0,0 64x64 3 -attrib hair brown -attrib eyes 2 -attrib weight 20.5 -o redmeta.exr")
-command += oiiotool ("redmeta.exr green.exr --pastemeta -o greenmeta.exr")
+command += oiiotool ("--pattern:type=half constant:color=0,1,0 64x64 3 -attrib hair black -o green.exr")
+command += oiiotool ("--pattern:type=half constant:color=1,0,0 64x64 3 -attrib hair brown -attrib eyes 2 -attrib weight 20.5 -attrib camera:lens AX30 --attrib camera:shutter 0.0125  -o meta.exr")
+command += oiiotool ("meta.exr green.exr --pastemeta -o greenmeta.exr")
+command += oiiotool ("meta.exr green.exr --mergemeta -o greenmeta-merge.exr")
+command += oiiotool ("meta.exr green.exr --mergemeta:override=1 -o greenmeta-merge-override.exr")
+command += oiiotool ("meta.exr green.exr --mergemeta:pattern=\"^camera:\" -o greenmeta-merge-camera.exr")
 command += info_command ("green.exr", safematch=True)
 command += info_command ("greenmeta.exr", safematch=True)
+command += info_command ("greenmeta-merge.exr", safematch=True)
+command += info_command ("greenmeta-merge-override.exr", safematch=True)
+command += info_command ("greenmeta-merge-camera.exr", safematch=True)
 
 # test mosaic
 # Purposely test with fewer images than the mosaic array size

--- a/testsuite/python-imagebuf/ref/out-alt-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-alt-python3.txt
@@ -149,6 +149,91 @@ Writing multi-image file
 Testing uninitialized bufs
   empty nchannels: 0
 
+Testing metadata copying
+ A's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ B's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A full copy of A should have abc and def as A does:
+ result of C = A.copy():
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ A.copy_metadata(B) should be identical to B
+ result of A.copy_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B) should have abc, def from A, camera from B
+ result of A.merge_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,True) should have abc from A, def and camera from B
+ result of A.merge_metadata(B, override=True):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,pattern) should have abc,def from A, camera from B
+ result of A.merge_metadata(B, pattern='^camera:'):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+
 Done.
 Comparing "out.tif" and "ref/out.tif"
 PASS

--- a/testsuite/python-imagebuf/ref/out-alt.txt
+++ b/testsuite/python-imagebuf/ref/out-alt.txt
@@ -149,6 +149,91 @@ Writing multi-image file
 Testing uninitialized bufs
   empty nchannels: 0
 
+Testing metadata copying
+ A's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ B's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A full copy of A should have abc and def as A does:
+ result of C = A.copy():
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ A.copy_metadata(B) should be identical to B
+ result of A.copy_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B) should have abc, def from A, camera from B
+ result of A.merge_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,True) should have abc from A, def and camera from B
+ result of A.merge_metadata(B, override=True):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,pattern) should have abc,def from A, camera from B
+ result of A.merge_metadata(B, pattern='^camera:'):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+
 Done.
 Comparing "out.tif" and "ref/out.tif"
 PASS

--- a/testsuite/python-imagebuf/ref/out-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-python3.txt
@@ -149,6 +149,91 @@ Writing multi-image file
 Testing uninitialized bufs
   empty nchannels: 0
 
+Testing metadata copying
+ A's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ B's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A full copy of A should have abc and def as A does:
+ result of C = A.copy():
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ A.copy_metadata(B) should be identical to B
+ result of A.copy_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B) should have abc, def from A, camera from B
+ result of A.merge_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,True) should have abc from A, def and camera from B
+ result of A.merge_metadata(B, override=True):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,pattern) should have abc,def from A, camera from B
+ result of A.merge_metadata(B, pattern='^camera:'):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+
 Done.
 Comparing "out.tif" and "ref/out.tif"
 PASS

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -149,6 +149,91 @@ Writing multi-image file
 Testing uninitialized bufs
   empty nchannels: 0
 
+Testing metadata copying
+ A's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ B's spec
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A full copy of A should have abc and def as A does:
+ result of C = A.copy():
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+ A.copy_metadata(B) should be identical to B
+ result of A.copy_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B) should have abc, def from A, camera from B
+ result of A.merge_metadata(B):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,True) should have abc from A, def and camera from B
+ result of A.merge_metadata(B, override=True):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = "Bfoo"
+  camera:x = "Bx"
+  camera:y = "By"
+ A.merge_metadata(B,pattern) should have abc,def from A, camera from B
+ result of A.merge_metadata(B, pattern='^camera:'):
+  resolution 64x64+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  abc = 1
+  def = 3.140000104904175
+  camera:x = "Bx"
+  camera:y = "By"
+
 Done.
 Comparing "out.tif" and "ref/out.tif"
 PASS

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -149,6 +149,43 @@ def ftupstr(tup) :
     return "(" + ", ".join(["{:.5}".format(x) for x in tup]) + ")"
 
 
+# Test the functionality of metadata copying and merging
+def test_copy_metadata() :
+    print ("\nTesting metadata copying")
+    # specA has numerical abc and def
+    specA = oiio.ImageSpec(64, 64, 3, "uint8")
+    specA.attribute("abc", 1)
+    specA.attribute("def", 3.14)
+    A = oiio.ImageBuf(specA)
+    print_imagespec (A.spec(), msg=" A's spec")
+    # specB has no abc, string def, and two camera attribs
+    specFull = oiio.ImageSpec(64, 64, 3, "uint8")
+    specFull.attribute("def", "Bfoo")
+    specFull.attribute("camera:x", "Bx")
+    specFull.attribute("camera:y", "By")
+    B = oiio.ImageBuf(specFull)
+    print_imagespec (B.spec(), msg=" B's spec")
+    print(" A full copy of A should have abc and def as A does:")
+    C = A.copy()
+    print_imagespec (C.spec(), msg=" result of C = A.copy():")
+    print(" A.copy_metadata(B) should be identical to B")
+    C = A.copy()
+    C.copy_metadata (B)
+    print_imagespec (C.spec(), msg=" result of A.copy_metadata(B):")
+    print(" A.merge_metadata(B) should have abc, def from A, camera from B")
+    C = A.copy()
+    C.merge_metadata (B)
+    print_imagespec (C.spec(), msg=" result of A.merge_metadata(B):")
+    print(" A.merge_metadata(B,True) should have abc from A, def and camera from B")
+    C = A.copy()
+    C.merge_metadata (B, override=True)
+    print_imagespec (C.spec(), msg=" result of A.merge_metadata(B, override=True):")
+    print(" A.merge_metadata(B,pattern) should have abc,def from A, camera from B")
+    C = A.copy()
+    C.merge_metadata (B, pattern="^camera:")
+    print_imagespec (C.spec(), msg=" result of A.merge_metadata(B, pattern='^camera:'):")
+
+
 
 ######################################################################
 # main test starts here
@@ -258,6 +295,7 @@ try:
     test_deep ()
     test_multiimage ()
     test_uninitialized ()
+    test_copy_metadata ()
 
     print ("\nDone.")
 except Exception as detail:


### PR DESCRIPTION
Clarify that IB::copy_metadata and oiiotool --pastemea fully replace all existing metadata with that of the other IB.

Add a new IB::merge_metadata() and oiiotool --mergemeta that merges in metadata from the other IB, preserving metadata in `this` that was not in the other IB.  Optionally, metadata that existed in both can be overridden.  Optionally, a subset of metadata to be merged can be selected via a regex.
