### PR TITLE
ci: Fix wheel building on Mac ARM (continuation of #4668)

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -328,6 +328,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CMAKE_GENERATOR: "Unix Makefiles"
 
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:


### PR DESCRIPTION
The Intel Macs had this problem last week and #4668 fixed it. Now suddenly the ARM Macs had it this week. Seems to be something changing on the skbuild side.
