### PR TITLE
fix: Partial reversion to fix ABI checker false positive

### DIFF
--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -333,14 +333,7 @@ make_pv(string_view name, T* val)
 /// methods.
 class OIIO_UTIL_API ParamValueList : public std::vector<ParamValue> {
 public:
-    // Default constructor
     ParamValueList() {}
-
-    // Construct from a span of ParamValue items
-    ParamValueList(cspan<ParamValue> params)
-    {
-        assign(params.begin(), params.end());
-    }
 
     /// Add space for one more ParamValue to the list, and return a
     /// reference to its slot.

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -788,8 +788,9 @@ public:
         , m_nimages(ninputs + 1)
         , m_setup_func(setup_func)
         , m_impl_func(impl_func)
-        , m_control_options(control_options)
     {
+        m_control_options.assign(control_options.begin(),
+                                 control_options.end());
         if (Strutil::starts_with(opname, "--"))
             opname.remove_prefix(1);  // canonicalize to one dash
         m_opname = opname.substr(0, opname.find_first_of(':'));  // and no :


### PR DESCRIPTION
I still think that the "abi break" is a false positive. But I really didn't need the new constructor that seemed to confuse the abi checker, so just to be extra sure that there is no break that I simply misunderstand, change to make abicheck happy.
