### PR TITLE
int: Experimental default_init_allocator and default_init_vector

### DIFF
--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -223,67 +223,6 @@ print_stats(std::ostream& out, string_view indent, const ImageBuf& input,
 
 
 
-/// Allocator adaptor that interposes construct() calls to convert value
-/// initialization into default initialization.
-///
-/// This is a way to achieve a std::vector whose resize does not force a value
-/// initialization of every allocated element. Put in more plain terms, the
-/// following:
-///
-///     std::vector<int> v(Nlarge);
-///
-/// will zero-initialize the Nlarge elements, which may be a cost we do not
-/// wish to pay, particularly when allocating POD types that we are going to
-/// write over anyway. Sometimes we do the following instead:
-///
-///     std::unique_ptr<int[]> v (new int[Nlarge]);
-///
-/// which does not zero-initialize the elements. But it's more awkward, and
-/// lacks the methods you get automatically with vectors.
-///
-/// But you will get a lack of forced value initialization if you use a
-/// std::vector with a special allocator that does default initialization.
-/// This is such an allocator, so the following:
-///
-///    std::vector<T, default_init_allocator<T>> v(Nlarge);
-///
-/// will have the same performance characteristics as the new[] version.
-///
-/// For details:
-/// https://stackoverflow.com/questions/21028299/is-this-behavior-of-vectorresizesize-type-n-under-c11-and-boost-container/21028912#21028912
-
-template<typename T, typename A = std::allocator<T>>
-class default_init_allocator : public A {
-    typedef std::allocator_traits<A> a_t;
-
-public:
-    template<typename U> struct rebind {
-        using other
-            = default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
-    };
-
-    using A::A;
-
-    template<typename U>
-    void
-    construct(U* ptr) noexcept(std::is_nothrow_default_constructible<U>::value)
-    {
-        ::new (static_cast<void*>(ptr)) U;
-    }
-    template<typename U, typename... Args>
-    void construct(U* ptr, Args&&... args)
-    {
-        a_t::construct(static_cast<A&>(*this), ptr,
-                       std::forward<Args>(args)...);
-    }
-};
-
-
-/// Type alias for a std::vector that uses the default_init_allocator.
-template<typename T> using divector = std::vector<T, default_init_allocator<T>>;
-
-
-
 enum class ComputeDevice : int {
     CPU  = 0,
     CUDA = 1,
@@ -331,6 +270,82 @@ OIIO_API void
 device_free(void* mem);
 
 }  // namespace pvt
+
+
+
+/// Allocator adaptor that interposes construct() calls to convert value
+/// initialization into default initialization.
+///
+/// This is a way to achieve a std::vector whose resize does not force a value
+/// initialization of every allocated element. Put in more plain terms, the
+/// following:
+///
+///     std::vector<int> v(Nlarge);
+///
+/// will zero-initialize the Nlarge elements, which may be a cost we do not
+/// wish to pay, particularly when allocating POD types that we are going to
+/// write over anyway. Sometimes we do the following instead:
+///
+///     std::unique_ptr<int[]> v (new int[Nlarge]);
+///
+/// which does not zero-initialize the elements. But it's more awkward, and
+/// lacks the methods you get automatically with vectors.
+///
+/// But you will get a lack of forced value initialization if you use a
+/// std::vector with a special allocator that does default initialization.
+/// This is such an allocator, so the following:
+///
+///    std::vector<T, default_init_allocator<T>> v(Nlarge);
+///
+/// will have the same performance characteristics as the new[] version.
+///
+/// For details:
+/// https://stackoverflow.com/questions/21028299/is-this-behavior-of-vectorresizesize-type-n-under-c11-and-boost-container/21028912#21028912
+///
+template<typename T, typename A = std::allocator<T>>
+class default_init_allocator : public A {
+    typedef std::allocator_traits<A> a_t;
+
+public:
+    template<typename U> struct rebind {
+        using other
+            = default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
+    };
+
+    using A::A;
+
+    template<typename U>
+    void
+    construct(U* ptr) noexcept(std::is_nothrow_default_constructible<U>::value)
+    {
+        ::new (static_cast<void*>(ptr)) U;
+    }
+    template<typename U, typename... Args>
+    void construct(U* ptr, Args&&... args)
+    {
+        a_t::construct(static_cast<A&>(*this), ptr,
+                       std::forward<Args>(args)...);
+    }
+};
+
+
+/// Type alias for a std::vector that uses the default_init_allocator.
+///
+/// Consider using a `default_init_vector<T>` instead of `std::vector<T>` when
+/// all of the following are true:
+///
+/// * The use is entirely internal to OIIO (since at present, this type is
+///   not defined in any public header files).
+/// * The type T is POD (plain old data) or trivially constructible.
+/// * The vector is likely to be large enough that the cost of default
+///   initialization is worth trying to avoid.
+/// * After allocation, the vector will be filled with data before any reads
+///   are attempted, so the default initialization is not needed.
+///
+template<typename T>
+using default_init_vector = std::vector<T, default_init_allocator<T>>;
+
+
 
 OIIO_NAMESPACE_END
 

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -222,6 +222,68 @@ print_stats(std::ostream& out, string_view indent, const ImageBuf& input,
             const ImageSpec& spec, ROI roi, std::string& err);
 
 
+
+/// Allocator adaptor that interposes construct() calls to convert value
+/// initialization into default initialization.
+///
+/// This is a way to achieve a std::vector whose resize does not force a value
+/// initialization of every allocated element. Put in more plain terms, the
+/// following:
+///
+///     std::vector<int> v(Nlarge);
+///
+/// will zero-initialize the Nlarge elements, which may be a cost we do not
+/// wish to pay, particularly when allocating POD types that we are going to
+/// write over anyway. Sometimes we do the following instead:
+///
+///     std::unique_ptr<int[]> v (new int[Nlarge]);
+///
+/// which does not zero-initialize the elements. But it's more awkward, and
+/// lacks the methods you get automatically with vectors.
+///
+/// But you will get a lack of forced value initialization if you use a
+/// std::vector with a special allocator that does default initialization.
+/// This is such an allocator, so the following:
+///
+///    std::vector<T, default_init_allocator<T>> v(Nlarge);
+///
+/// will have the same performance characteristics as the new[] version.
+///
+/// For details:
+/// https://stackoverflow.com/questions/21028299/is-this-behavior-of-vectorresizesize-type-n-under-c11-and-boost-container/21028912#21028912
+
+template<typename T, typename A = std::allocator<T>>
+class default_init_allocator : public A {
+    typedef std::allocator_traits<A> a_t;
+
+public:
+    template<typename U> struct rebind {
+        using other
+            = default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
+    };
+
+    using A::A;
+
+    template<typename U>
+    void
+    construct(U* ptr) noexcept(std::is_nothrow_default_constructible<U>::value)
+    {
+        ::new (static_cast<void*>(ptr)) U;
+    }
+    template<typename U, typename... Args>
+    void construct(U* ptr, Args&&... args)
+    {
+        a_t::construct(static_cast<A&>(*this), ptr,
+                       std::forward<Args>(args)...);
+    }
+};
+
+
+/// Type alias for a std::vector that uses the default_init_allocator.
+template<typename T> using divector = std::vector<T, default_init_allocator<T>>;
+
+
+
 enum class ComputeDevice : int {
     CPU  = 0,
     CUDA = 1,

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1343,7 +1343,7 @@ OpenEXRInput::read_native_tiles(int subimage, int miplevel, int xbegin,
     int whole_width  = nxtiles * m_spec.tile_width;
     int whole_height = nytiles * m_spec.tile_height;
 
-    pvt::divector<char> tmpbuf;
+    default_init_vector<char> tmpbuf;
     void* origdata = data;
     if (whole_width != (xend - xbegin) || whole_height != (yend - ybegin)) {
         // Deal with the case of reading not a whole number of tiles --

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -23,6 +23,7 @@
 #include <OpenEXR/ImfTiledInputFile.h>
 
 #include "exr_pvt.h"
+#include "imageio_pvt.h"
 
 // The way that OpenEXR uses dynamic casting for attributes requires
 // temporarily suspending "hidden" symbol visibility mode.
@@ -1342,13 +1343,13 @@ OpenEXRInput::read_native_tiles(int subimage, int miplevel, int xbegin,
     int whole_width  = nxtiles * m_spec.tile_width;
     int whole_height = nytiles * m_spec.tile_height;
 
-    std::unique_ptr<char[]> tmpbuf;
+    pvt::divector<char> tmpbuf;
     void* origdata = data;
     if (whole_width != (xend - xbegin) || whole_height != (yend - ybegin)) {
         // Deal with the case of reading not a whole number of tiles --
         // OpenEXR will happily overwrite user memory in this case.
-        tmpbuf.reset(new char[nxtiles * nytiles * m_spec.tile_bytes(true)]);
-        data = &tmpbuf[0];
+        tmpbuf.resize(nxtiles * nytiles * m_spec.tile_bytes(true));
+        data = tmpbuf.data();
     }
     char* buf = (char*)data - xbegin * pixelbytes
                 - ybegin * pixelbytes * m_spec.tile_width * nxtiles;

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -1212,7 +1212,7 @@ OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             int y             = std::max(int(yb), ybegin);
             uint8_t* linedata = static_cast<uint8_t*>(data)
                                 + scanlinebytes * (y - ybegin);
-            pvt::divector<uint8_t> fullchunk;
+            default_init_vector<uint8_t> fullchunk;
             int nlines = scansperchunk;
             exr_chunk_info_t cinfo;
             exr_decode_pipeline_t decoder = EXR_DECODE_PIPELINE_INITIALIZER;

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -1212,7 +1212,7 @@ OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             int y             = std::max(int(yb), ybegin);
             uint8_t* linedata = static_cast<uint8_t*>(data)
                                 + scanlinebytes * (y - ybegin);
-            std::unique_ptr<uint8_t[]> fullchunk;
+            pvt::divector<uint8_t> fullchunk;
             int nlines = scansperchunk;
             exr_chunk_info_t cinfo;
             exr_decode_pipeline_t decoder = EXR_DECODE_PIPELINE_INITIALIZER;
@@ -1225,18 +1225,18 @@ OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             if (invalid != 0) {
                 // Our first scanline, ybegin, is not on a chunk boundary.
                 // We'll need to "back up" and read a whole chunk.
-                fullchunk.reset(new uint8_t[scanlinebytes * scansperchunk]);
+                fullchunk.resize(scanlinebytes * scansperchunk);
+                cdata  = fullchunk.data();
                 nlines = scansperchunk - invalid;
-                cdata  = fullchunk.get();
                 y      = y - invalid;
             } else if ((y + scansperchunk) > yend && yend < endy) {
                 // ybegin is at a chunk boundary, but yend is not (and isn't
                 // the special case of it encompassing the end of the image,
                 // which is not at a chunk boundary). We'll need to read a
                 // full chunk and use only part of it.
-                fullchunk.reset(new uint8_t[scanlinebytes * scansperchunk]);
+                fullchunk.resize(scanlinebytes * scansperchunk);
+                cdata  = fullchunk.data();
                 nlines = yend - y;
-                cdata  = fullchunk.get();
             } else {
                 // We need a full aligned chunk. Everything is already set up.
             }


### PR DESCRIPTION
Inspired by a link from EmilDohne in an unrelated PR, this introduces `default_init_allocator`, an experimental custom allocator that default initializes, rather than value-0-initializes, POD/non-class types.

This is useful for being able to make a std::vector with this allocator (`default_init_vector`), thus having the property of not incurring a large cost of needlessly initializing the elements when they are allocated, as a default std::vector does.

I picked two spots sort of randomly, in which we previously avoided using std::vector and instead did a unique_ptr / new[] dance to do scoped heap allocation without paying the vector initialization tax. By using default_init_vector, we avoid the extra cost while still using the much more convenient vector type.

These two places are just to prove it works. There's no particular need to proactively root out every use of the unique_ptr trick. But for future development, we can use now use std::vector without the construction cost when we allocate.
