### PR TITLE
Bump libdeflate to 1.23 in local building cmake to avoid AVX512 not available errors

### DIFF
--- a/src/cmake/build_libdeflate.cmake
+++ b/src/cmake/build_libdeflate.cmake
@@ -6,7 +6,7 @@
 # libdeflate by hand!
 ######################################################################
 
-set_cache (libdeflate_BUILD_VERSION 1.20 "libdeflate version for local builds")
+set_cache (libdeflate_BUILD_VERSION 1.23 "libdeflate version for local builds")
 set (libdeflate_GIT_REPOSITORY "https://github.com/ebiggers/libdeflate")
 set (libdeflate_GIT_TAG "v${libdeflate_BUILD_VERSION}")
 set_cache (libdeflate_BUILD_SHARED_LIBS OFF # ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

When using `OpenImageIO_BUILD_LOCAL_DEPS` environment variable to build all OIIO's dependency locally, OIIO's build script specifies a set of default versions of the dependent libraries. In particular, `ebiggers/libdeflate` is set to `1.20`.

This 1.20 version of libdeflate fails to build on platforms where AVX512 is not available and the make tool chain did not correctly tell the C compiler about it. 

```
-- Building package TIFF  locally
--         Building package libdeflate  locally
--                 Building local libdeflate 1.20 from https://github.com/ebiggers/libdeflate
/usr/tmp/ccCelbo5.s: Assembler messages:
/usr/tmp/ccCelbo5.s:649: Error: unsupported instruction `vpdpbusd'
/usr/tmp/ccCelbo5.s:650: Error: unsupported instruction `vpdpbusd'
```

This issue is fixed in libdeflate Merge Request 389 https://github.com/ebiggers/libdeflate/pull/389, by explicitly calling CMake facilities to detect whether AVX512 is present, and set compiler preprocessor flags accordingly in the cmake file. This libdeflate MR is after version 1.20.

To fix OIIO's build error when building this dependency locally, one can either set `libdeflate_BUILD_VERSION` to include this patch, (for example `export libdeflate_BUILD_VERSION=1.23`) or change the default version in OIIO's local dependency build script to 1.23. This PR makes the change in OIIO's local dependency build script.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

Assembler build error resolved after using libdeflate v1.23 for local TIFF build.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
