### PR TITLE
feat(oiiotool): add --render_text modifiers measure= and render=

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -4203,6 +4203,16 @@ current top image.
       `shadow=` *size*
         if nonzero, will make a dark shadow halo to make the text more clear
         on bright backgrounds.
+      `measure=` *int*
+        if nonzero, will compute the rendered size of the text and store its
+        dimensions in the "user variables" (as if by `--set`) `TEXT_X`,
+        `TEXT_Y`, `TEXT_WIDTH`, `TEXT_HEIGHT`. (This modifier was added
+        in OpenImageIO 3.0.5.0.)
+      `render=` *int*
+        if zero, will not actually draw the text into the image (the
+        default is 1, meaning that the text will draw). Suppressing the
+        drawing is primarily useful in conjunction with `measure=1`.
+        (This modifier was added in OpenImageIO 3.0.5.0.)
       `:subimages=` *indices-or-names*
         Include/exclude subimages (see :ref:`sec-oiiotool-subimage-modifier`).
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5141,9 +5141,21 @@ OIIOTOOL_INPLACE_OP(text, 1, [&](OiiotoolOp& op, span<ImageBuf*> img) {
         aligny = TextAlignY::Bottom;
     if (Strutil::iequals(ay, "center") || Strutil::iequals(ay, "c"))
         aligny = TextAlignY::Center;
-    int shadow = op.options().get_int("shadow");
-    return ImageBufAlgo::render_text(*img[0], x, y, op.args(1), fontsize, font,
-                                     textcolor, alignx, aligny, shadow);
+    int shadow  = op.options().get_int("shadow");
+    int measure = op.options().get_int("measure");
+    int render  = op.options().get_int("render", 1);
+    if (measure) {
+        ROI roi = ImageBufAlgo::text_size(op.args(1), fontsize, font);
+        ot.uservars["TEXT_X"]      = roi.xbegin;
+        ot.uservars["TEXT_Y"]      = roi.ybegin;
+        ot.uservars["TEXT_WIDTH"]  = roi.width();
+        ot.uservars["TEXT_HEIGHT"] = roi.height();
+    }
+    if (render)
+        return ImageBufAlgo::render_text(*img[0], x, y, op.args(1), fontsize,
+                                         font, textcolor, alignx, aligny,
+                                         shadow);
+    return true;
 });
 
 

--- a/testsuite/oiiotool-text/ref/out.txt
+++ b/testsuite/oiiotool-text/ref/out.txt
@@ -1,3 +1,4 @@
+Text size: xy 1 -30 wh 251 37
 Comparing "text.tif" and "ref/text-freetype2.7.tif"
 PASS
 Comparing "aligned.tif" and "ref/aligned.tif"

--- a/testsuite/oiiotool-text/run.py
+++ b/testsuite/oiiotool-text/run.py
@@ -43,6 +43,11 @@ command += oiiotool ("--create 320x240 3 "
             "\"--text:x=25:y=120:font=Droid Serif Bold:size=40\" \"Hello, world\" "
             "-d uint8 -o fontbyfamily.tif")
 
+# test size
+command += oiiotool ("--create 320x240 3 "
+            "\"--text:measure=1:render=0:font=Droid Serif Bold:size=40\" \"Hello, world\" "
+            "--echo \"Text size: xy {TEXT_X} {TEXT_Y} wh {TEXT_WIDTH} {TEXT_HEIGHT}\" ")
+
 # Outputs to check against references
 outputs = [ "text.tif", "aligned.tif", "textshadowed.tif", "textalpha.tif", "fontbyfamily.tif" ]
 


### PR DESCRIPTION
`--render_text:measure=1` causes the render_text command to set user variables `TEXT_X`, `TEXT_Y`, `TEXT_WIDTH`, and `TEXT_HEIGHT` (as if set by `--set`) to the origin offset and dimensions of the rendered text size. These can then be accessed in subsequent expression evaluation.

`--render_text:render=0` causes the text to not actually be rendered into the image. (The default is 1.) This is primarily of use in conjunction with `measure=1` if you want to measure the size that text would have taken, then use the variables for subsequent commands, but not actually draw the text.

