### PR TITLE
ci: bump dependencies for "latest versions" CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,16 +397,16 @@ jobs:
             cc_compiler: gcc-13
             cxx_compiler: g++-13
             cxx_std: 20
-            fmt_ver: 11.1.2
-            opencolorio_ver: v2.4.0
-            openexr_ver: v3.3.0
-            pybind11_ver: v2.13.5
+            fmt_ver: 11.1.4
+            opencolorio_ver: v2.4.2
+            openexr_ver: v3.3.3
+            pybind11_ver: v2.13.6
             python_ver: "3.12"
             simd: avx2,f16c
-            setenvs: export LIBJPEGTURBO_VERSION=3.0.3
-                            LIBRAW_VERSION=0.21.2
+            setenvs: export LIBJPEGTURBO_VERSION=3.1.0
+                            LIBRAW_VERSION=0.21.3
                             LIBTIFF_VERSION=v4.7.0
-                            OPENJPEG_VERSION=v2.5.2
+                            OPENJPEG_VERSION=v2.5.3
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.5.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * **libTIFF >= 4.0** (tested through 4.7)
  * **OpenColorIO >= 2.2** (tested through 2.4 and main)
  * libjpeg >= 8 (tested through jpeg9e), or **libjpeg-turbo >= 2.1** (tested
-   through 3.0)
+   through 3.1)
  * **[fmtlib](https://github.com/fmtlib/fmt) >= 7.0** (tested through 11.1).
    If not found at build time, this will be automatically downloaded unless
    the build sets `-DBUILD_MISSING_FMT=OFF`.
@@ -33,12 +33,12 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 ### Optional dependencies -- features may be disabled if not found
  * If you are building the `iv` viewer (which will be disabled if any of
    these are not found):
-     * Qt5 >= 5.6 (tested through 5.15) or Qt6 (tested through 6.7)
+     * Qt5 >= 5.6 (tested through 5.15) or Qt6 (tested through 6.8)
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
      * **Python >= 3.7** (tested through 3.13)
-     * **pybind11 >= 2.7** (tested through 2.12)
-     * NumPy
+     * **pybind11 >= 2.7** (tested through 2.13)
+     * NumPy (tested through 2.2.4)
  * If you want support for PNG files:
      * **libPNG >= 1.6.0** (tested though 1.6.47)
  * If you want support for camera "RAW" formats:
@@ -49,25 +49,25 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * OpenJpeg >= 2.0 (tested through 2.5; we recommend 2.4 or higher
        for multithreading support)
  * If you want support for OpenVDB files:
-     * OpenVDB >= 9.0 (tested through 11.0). Note that using OpenVDB >= 10.0
+     * OpenVDB >= 9.0 (tested through 12.0). Note that using OpenVDB >= 10.0
        requires that you compile OIIO with C++17 or higher.
  * If you want to use TBB as the thread pool:
      * TBB >= 2018 (tested through 2021 and OneTBB)
  * If you want support for converting to and from OpenCV data structures,
    or for capturing images from a camera:
-     * **OpenCV 4.x** (tested through 4.10)
+     * **OpenCV 4.x** (tested through 4.11)
  * If you want support for GIF images:
-     * **giflib >= 5.0** (tested through 5.2)
+     * **giflib >= 5.0** (tested through 5.2.2)
  * If you want support for HEIF/HEIC or AVIF images:
      * **libheif >= 1.11** (1.16 required for correct orientation support,
-       tested through 1.18.2)
+       tested through 1.19.7)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.
  * If you want support for DICOM medical image files:
      * DCMTK >= 3.6.1 (tested through 3.6.8)
  * If you want support for WebP images:
      * **WebP >= 1.1** (tested through 1.5)
  * If you want support for Ptex:
-     * Ptex >= 2.3.1 (probably works for older; tested through 2.4.2)
+     * Ptex >= 2.3.1 (probably works for older; tested through 2.4.3)
  * If you want to be able to do font rendering into images:
      * **Freetype >= 2.10.0** (tested through 2.13)
  * We use PugiXML for XML parsing. There is a version embedded in the OIIO


### PR DESCRIPTION
Bump to the latest in several cases. Also make sure the INSTALL.md is in line with what we support and/or test.
