### PR TITLE
fix(python): fix handle leak

### DIFF
--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -196,10 +196,8 @@ declare_imageoutput(py::module& m)
     py::class_<ImageOutput>(m, "ImageOutput")
         .def_static(
             "create",
-            [](const std::string& filename,
-               const std::string& searchpath) -> py::object {
-                auto out(ImageOutput::create(filename, nullptr, searchpath));
-                return out ? py::cast(out.release()) : py::none();
+            [](const std::string& filename, const std::string& searchpath) {
+                return ImageOutput::create(filename, nullptr, searchpath);
             },
             "filename"_a, "plugin_searchpath"_a = "")
         .def("format_name", &ImageOutput::format_name)


### PR DESCRIPTION
Seems that for quite some time, there have been particular circumstances in which the Python bindings have leaked ImageInput or ImageOutput objects.  That's bad enough on its own, but it also leaves file handles open if code was depending on the fact that the ImageInput and ImageOutput destructors close the files if they haven't already been closed.

I think the offending part is that the `unique_ptr<ImageInput>` extracts its raw pointer and gives it to Python, on the mistaken assumption that it would be reference counted as a python object.  But apparently, it's not. Oops.

Leaving it as a unique_ptr turns out to be fine, as far as pybind11 is concerned! And on top of that, if you give an uninitialized unique_ptr to pybind11, it considers that a Python `None`, which means we can further simplify some places where we explicitly had to return a py::object and figure out if it should be None or not, but actually it's all ok to just give the unique_ptr and pybind11 figures the whole thing out for us.
