### PR TITLE
build: cmake 4.0 compatibility

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -383,6 +383,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
-cmake_minimum_required (VERSION 3.18.2)
+cmake_minimum_required (VERSION 3.18.2...4.0)
 
 set (OpenImageIO_VERSION "3.1.1.0")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=20`, etc.
  * Compilers: **gcc 9.3** - 14.2, **clang 5** - 19, MSVS 2017 - 2019 (**v19.14
    and up**), **Intel icc 19+**, Intel OneAPI C++ compiler 2022+.
- * **CMake >= 3.18.2** (tested through 3.31)
+ * **CMake >= 3.18.2** (tested through 4.0)
  * **Imath >= 3.1** (tested through 3.1.x and main)
  * **OpenEXR >= 3.1** (tested through 3.3 and main)
  * **libTIFF >= 4.0** (tested through 4.7)

--- a/src/build-scripts/build_Freetype.bash
+++ b/src/build-scripts/build_Freetype.bash
@@ -20,6 +20,10 @@ FREETYPE_BUILD_DIR=${FREETYPE_BUILD_DIR:=${FREETYPE_SRC_DIR}/build}
 FREETYPE_INSTALL_DIR=${FREETYPE_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 FREETYPE_BUILD_TYPE=${FREETYPE_BUILD_TYPE:=Release}
 
+# Fix for freetype breaking against cmake 4.0 because of too-old cmake min.
+# Remove when freetype is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 pwd
 echo "Freetype install dir will be: ${FREETYPE_INSTALL_DIR}"
 

--- a/src/build-scripts/build_OpenJPEG.bash
+++ b/src/build-scripts/build_OpenJPEG.bash
@@ -20,6 +20,10 @@ OPENJPEG_BUILD_DIR=${OPENJPEG_BUILD_DIR:=${OPENJPEG_SRC_DIR}/build}
 OPENJPEG_INSTALL_DIR=${OPENJPEG_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 #OPENJPEG_CONFIG_OPTS=${OPENJPEG_CONFIG_OPTS:=}
 
+# Fix for openjpeg breaking against cmake 4.0 because of too-old cmake min.
+# Remove when openjpeg is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 pwd
 echo "OpenJPEG install dir will be: ${OPENJPEG_INSTALL_DIR}"
 

--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -28,6 +28,11 @@ OPENCOLORIO_BUILDOPTS="-DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
                        -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
                        -DOCIO_BUILD_JAVA=OFF \
                        -DBUILD_SHARED_LIBS=${OPENCOLORIO_BUILD_SHARED_LIBS:=ON}"
+
+# Fix yaml-cpp which breaks against cmake 4.0 because of too-old cmake min.
+# Remove when yaml-cpp is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 BASEDIR=`pwd`
 pwd
 echo "OpenColorIO install dir will be: ${OPENCOLORIO_INSTALL_DIR}"

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -22,6 +22,10 @@ LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 PYBIND11_INSTALL_DIR=${PYBIND11_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 #PYBIND11_BUILD_OPTS=${PYBIND11_BUILD_OPTS:=}
 
+# Fix for pybind11 breaking against cmake 4.0 because of too-old cmake min.
+# Remove when pybind11 is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 if [[ "${PYTHON_VERSION}" != "" ]] ; then
     PYBIND11_BUILD_OPTS+=" -DPYBIND11_PYTHON_VERSION=${PYTHON_VERSION}"
 fi

--- a/src/cmake/build_Freetype.cmake
+++ b/src/cmake/build_Freetype.cmake
@@ -32,6 +32,9 @@ build_dependency_with_cmake(Freetype
         -D CMAKE_POSITION_INDEPENDENT_CODE=ON
         -D CMAKE_INSTALL_LIBDIR=lib
         ${_freetype_EXTRA_CMAKE_ARGS}
+        # Fix for freetype breaking against cmake 4.0.
+        # Remove when freetype is fixed to declare its own minimum high enough.
+        -D CMAKE_POLICY_VERSION_MINIMUM=3.5
 )
 
 # Set some things up that we'll need for a subsequent find_package to work

--- a/src/cmake/build_OpenColorIO.cmake
+++ b/src/cmake/build_OpenColorIO.cmake
@@ -51,6 +51,9 @@ build_dependency_with_cmake(OpenColorIO
         # conflict with any others in the system or linked into the same app.
         # -D OCIO_NAMESPACE=${OpenColorIO_VERSION_IDENT}_${PROJ_NAME}
         -D OCIO_LIBNAME_SUFFIX=_v${OpenColorIO_VERSION_IDENT}_${PROJ_NAME}
+        # Fix for yaml-cpp breaking against cmake 4.0.
+        # Remove when yaml-cpp is fixed to declare its own minimum high enough.
+        -D CMAKE_POLICY_VERSION_MINIMUM=3.5
     )
 
 # Set some things up that we'll need for a subsequent find_package to work

--- a/src/cmake/build_pybind11.cmake
+++ b/src/cmake/build_pybind11.cmake
@@ -23,6 +23,9 @@ build_dependency_with_cmake(pybind11
         # Don't built unnecessary parts of Pybind11
         -D BUILD_TESTING=OFF
         -D PYBIND11_TEST=OFF
+        # Fix for pybind11 breaking against cmake 4.0.
+        # Remove when pybind11 is fixed to declare its own minimum high enough.
+        -D CMAKE_POLICY_VERSION_MINIMUM=3.5
     )
 
 


### PR DESCRIPTION
The latest cmake in some package repos is 4.0. CMake 4.0 drops support for compatibility with cmake < 3.5, and thus errors when building our own dependencies that happen to have their own cmake scripts asking for compatibility with something older than that.

Setting CMAKE_POLICY_VERSION_MINIMUM=3.5 environment and/or cmake variable seems like a hack that could hide true incompatibilities, but will get us past this for now.

Change our own minimum to the range of 3.18.2...4.0 to correctly reflect the range of versions that we believe will work.
