### PR TITLE
build: More changes to be robust for cmake 4.0

### DIFF
--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -21,6 +21,10 @@ ZLIB_BUILD_DIR=${ZLIB_BUILD_DIR:=${ZLIB_SRC_DIR}/build}
 ZLIB_INSTALL_DIR=${ZLIB_INSTALL_DIR:=${PWD}/ext/dist}
 #ZLIB_CONFIG_OPTS=${ZLIB_CONFIG_OPTS:=}
 
+# Fix zlib which breaks against cmake 4.0 because of too-old cmake min.
+# Remove when zlib is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 pwd
 echo "zlib install dir will be: ${ZLIB_INSTALL_DIR}"
 

--- a/src/cmake/build_ZLIB.cmake
+++ b/src/cmake/build_ZLIB.cmake
@@ -23,6 +23,9 @@ build_dependency_with_cmake(ZLIB
         -D BUILD_SHARED_LIBS=${ZLIB_BUILD_SHARED_LIBS}
         -D CMAKE_POSITION_INDEPENDENT_CODE=ON
         -D CMAKE_INSTALL_LIBDIR=lib
+        # Fix for zlib breaking against cmake 4.0.
+        # Remove when zlib is fixed to declare its own minimum high enough.
+        -D CMAKE_POLICY_VERSION_MINIMUM=3.5
     )
 
 # Set some things up that we'll need for a subsequent find_package to work


### PR DESCRIPTION
zlib needed the treatment, too.
