### PR TITLE
fix: Add arm_neon.h include on Windows ARM64 with clang-cl

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -115,6 +115,11 @@
     // Cuda -- don't include any of these headers
 #elif defined(_WIN32)
 #  include <intrin.h>
+// MSVC's intrin.h includes arm_neon.h, clang (and by extension clang-cl)
+// has a version without this inclusion, so we need to manually add it
+#  if defined(__ARM_NEON__) && !defined(OIIO_NO_NEON)
+#    include <arm_neon.h>
+#  endif
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)) || defined(__e2k__)
 #  include <x86intrin.h>
 #elif defined(__GNUC__) && defined(__ARM_NEON__) && !defined(OIIO_NO_NEON)


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

On Windows ARM64, when building with `clang-cl`, LLVM can sometimes use it's own built-in `intrin.h` file, located in `<LLVM INSTALL PATH>\lib\clang\20\include`.

This file, as opposed to the built-in one that ships with the Windows SDK that MSVC uses, doesn't have an inclusion of `arm_neon.h`. This PR adds a small check to the `simd.h` file to include this header.

I didn't add an extra check to specifically only do this for clang, as it seemed a little messy - I can do this, but it's relatively harmless for MSVC given `intrin.h` includes it anyway for that compiler.

This change has already been in place for some time in Blender, this is just an upstreaming PR for that change: https://projects.blender.org/blender/blender/src/commit/ea604b6b80e49adb51d12df4e4edd5af1c51f446/build_files/build_environment/patches/oiio_windows_arm64.diff

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

n/a


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- ~~[ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)~~
- ~~[ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).~~
- ~~[ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).~~
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
