### PR TITLE
Docs: specify the units for DPX scanned size

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -425,10 +425,10 @@ the `set_ioproxy()` methods.
      - reference high quantity
    * - ``dpx:XScannedSize``
      - float
-     - X scanned size
+     - X scanned size in millimeters
    * - ``dpx:YScannedSize``
      - float
-     - Y scanned size
+     - Y scanned size in millimeters
    * - ``dpx:FramePosition``
      - int
      - frame position in sequence


### PR DESCRIPTION
From the PDF:
https://pub.smpte.org/doc/st268/20030505-pub/st0268-2003.pdf

3.31 X scanned size: Defines the horizontal size of the original scanned optical image in millimeters. [42.1]
3.32 Y scanned size: Defines the vertical size of the original scanned optical image in millimeters. [42.2]

----

This is a small PR that simply clarifies the units in the documentation.
