### PR TITLE
Docs: correct the type for BMP x/y density

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -42,10 +42,10 @@ tiles.
      - The compression of the BMP file (``"rle4"`` or ``"rle8"``, if
        RLE compression is used).
    * - ``XResolution``
-     - float
+     - int
      - hres
    * - ``YResolution``
-     - float
+     - int
      - vres
    * - ``ResolutionUnit``
      - string


### PR DESCRIPTION
These values are read & written as integers
and don't work unless they are accessed using int accessors.

<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->

m_dib_header.hres = m_spec.get_int_attribute("XResolution");
## Description

Correct documentation.

BMP uses integer access:
- `./src/bmp.imageio/bmpinput.cpp:`, `m_spec.attribute("XResolution", (int)m_dib_header.hres);`
- `./src/bmp.imageio/bmpoutput.cpp`, `m_dib_header.hres = m_spec.get_int_attribute("XResolution");`


