### PR TITLE
build: Include Windows version information on produced binaries

### DIFF
--- a/src/build-scripts/version_win32.rc.in
+++ b/src/build-scripts/version_win32.rc.in
@@ -1,0 +1,48 @@
+#include <winver.h>
+
+#define VER_FILEVERSION             @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+#define VER_FILEVERSION_STR         "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.0\0"
+
+#define VER_PRODUCTVERSION          @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+#define VER_PRODUCTVERSION_STR      "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@\0"
+
+#ifndef DEBUG
+#define VER_DEBUG                   0
+#else
+#define VER_DEBUG                   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       (VER_DEBUG)
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "FileDescription",  "OpenImageIO"
+            VALUE "FileVersion",      VER_FILEVERSION_STR
+            VALUE "InternalName",     "OpenImageIO"
+            VALUE "ProductName",      "OpenImageIO"
+            VALUE "ProductVersion",   VER_PRODUCTVERSION_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        /* The following line should only be modified for localized versions.     */
+        /* It consists of any number of WORD,WORD pairs, with each pair           */
+        /* describing a language,codepage combination supported by the file.      */
+        /*                                                                        */
+        /* For example, a file might have values "0x409,1252" indicating that it  */
+        /* supports English language (0x409) in the Windows ANSI codepage (1252). */
+
+        VALUE "Translation", 0x409, 1252
+
+    END
+END

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -78,8 +78,12 @@ set (libOpenImageIO_srcs
                           ${libOpenImageIO_hdrs}
                          )
 
-
-add_library (OpenImageIO ${libOpenImageIO_srcs})
+if (WIN32)
+    configure_file(../build-scripts/version_win32.rc.in "${CMAKE_CURRENT_BINARY_DIR}/version_win32.rc" @ONLY)
+    add_library (OpenImageIO ${libOpenImageIO_srcs} ${CMAKE_CURRENT_BINARY_DIR}/version_win32.rc)
+else ()
+    add_library (OpenImageIO ${libOpenImageIO_srcs})
+endif ()
 
 # If the 'EMBEDPLUGINS' option is set, we want to compile the source for
 # all the plugins into libOpenImageIO.

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -36,7 +36,13 @@ function (setup_oiio_util_library targetname)
     else ()
         set (libtype STATIC)
     endif ()
-    add_library (${targetname} ${libtype} ${libOpenImageIO_Util_srcs})
+    
+    if (WIN32)
+        configure_file(../build-scripts/version_win32.rc.in "${CMAKE_CURRENT_BINARY_DIR}/version_win32.rc" @ONLY)
+        add_library (${targetname} ${libtype} ${libOpenImageIO_Util_srcs} ${CMAKE_CURRENT_BINARY_DIR}/version_win32.rc)
+    else ()
+        add_library (${targetname} ${libtype} ${libOpenImageIO_Util_srcs})
+    endif ()
 
     target_compile_definitions(${targetname} PRIVATE
                                ${${PROJECT_NAME}_compile_definitions})


### PR DESCRIPTION
## Description

This change embeds version information into our Windows binaries. This is done by ways of a `version_win32.rc` resource file[1] populated at CMake configure time with our major.minor.patch version information.

This not only allows at a glance to discover what version a particular OIIO binary is (see screenshot), but it also impacts certain MSI installer behaviors. If this is a MSI install which updates a prior installation, and the shared libs/dlls don't have version information, then the installer assumes the binaries are equal and just skips them. This can be problematic for applications that package OIIO etc.

Old on left, New on right:
![old-vs-new](https://github.com/user-attachments/assets/2ff354ab-54a9-4dfb-8d97-90b138472bd7)

[1] https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
