### PR TITLE
fix(sgi): Fix valid_file to properly swap bytes on little-endian platforms

### DIFF
--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -89,6 +89,9 @@ SgiInput::valid_file(Filesystem::IOProxy* ioproxy) const
 
     int16_t magic {};
     const size_t numRead = ioproxy->pread(&magic, sizeof(magic), 0);
+    if (littleendian()) {
+        swap_endian(&magic);
+    }
     return numRead == sizeof(magic) && magic == sgi_pvt::SGI_MAGIC;
 }
 


### PR DESCRIPTION
## Description

The SGI IRIS format is big-endian so incoming multi-byte fields need to be swapped. This wasn't being done in the `valid_file` call so the magic test would always fail on little-endian platforms.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
