### PR TITLE
build: Address Robin-map vs CMake 4.0 compatibility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,6 +29,10 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * **[fmtlib](https://github.com/fmtlib/fmt) >= 7.0** (tested through 11.1).
    If not found at build time, this will be automatically downloaded unless
    the build sets `-DBUILD_MISSING_FMT=OFF`.
+ * [Robin-map](https://github.com/Tessil/robin-map) (unknown minimum, tested
+   through 1.4, which is the recommended version). If not found at build time,
+   this will be automatically downloaded unless the build sets
+   `-DBUILD_MISSING_FMT=OFF`.
 
 ### Optional dependencies -- features may be disabled if not found
  * If you are building the `iv` viewer (which will be disabled if any of

--- a/src/cmake/build_Robinmap.cmake
+++ b/src/cmake/build_Robinmap.cmake
@@ -6,7 +6,7 @@
 # Robinmap by hand!
 ######################################################################
 
-set_cache (Robinmap_BUILD_VERSION 1.3.0 "Robinmap version for local builds")
+set_cache (Robinmap_BUILD_VERSION 1.4.0 "Robinmap version for local builds")
 set (Robinmap_GIT_REPOSITORY "https://github.com/Tessil/robin-map")
 set (Robinmap_GIT_TAG "v${Robinmap_BUILD_VERSION}")
 
@@ -14,7 +14,10 @@ build_dependency_with_cmake(Robinmap
     VERSION         ${Robinmap_BUILD_VERSION}
     GIT_REPOSITORY  ${Robinmap_GIT_REPOSITORY}
     GIT_TAG         ${Robinmap_GIT_TAG}
-    # CMAKE_ARGS
+    CMAKE_ARGS
+        # Fix for pybind11 breaking against cmake 4.0.
+        # Remove when pybind11 is fixed to declare its own minimum high enough.
+        -D CMAKE_POLICY_VERSION_MINIMUM=3.5
     )
 
 # Set some things up that we'll need for a subsequent find_package to work


### PR DESCRIPTION
* Raise auto-build version of Robinmap to 1.4.
* Add the magic CMAKE_POLICY_VERSION_MINIMUM to our auto-build of Robinmap in case an older version is selected for auto-build. (Mimicking the fix we did for other packages.)
* Add Robin-map to the INSTALL.md list of dependencies, somehow it had been overlooked before.
