### PR TITLE
api: add image_span, deprecate image_view

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -95,8 +95,8 @@ Efficient unique strings: ``ustring``
 
 .. _sec-span:
 
-Non-owning array views: ``span`` / ``cspan``
-============================================
+Non-owning contiguous array views: ``span`` / ``cspan``
+=======================================================
 
 .. doxygenclass:: OIIO::span
     :members:
@@ -107,6 +107,18 @@ Additionally, there is a convenience template:
 .. cpp:type:: template<typename T> cspan = span<const T>
 
     `cspan<T>` is a synonym for a non-mutable `span<const T>`.
+
+|
+
+
+.. _sec-span:
+
+Non-owning image array views: ``image_span``
+============================================
+
+.. doxygenclass:: OIIO::image_span
+    :members:
+
 
 |
 

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -757,7 +757,7 @@ scaled_conversion(const S& src, F scale, F min, F max)
 template<typename S, typename D>
 void convert_type (const S *src, D *dst, size_t n, D _min, D _max)
 {
-    if (std::is_same<S,D>::value) {
+    if constexpr (std::is_same<S,D>::value) {
         // They must be the same type.  Just memcpy.
         memcpy (dst, src, n*sizeof(D));
         return;
@@ -968,6 +968,25 @@ inline void convert_type (const S *src, D *dst, size_t n)
 
 
 
+/// Copy (type convert) consecutive values from the cspan `src` holding data
+/// of type S into the span `dst` holding the same number of elements of data
+/// of type D.
+///
+/// The conversion is not a simple cast, but correctly remaps the 0.0->1.0
+/// range from and to the full positive range of integral types. It's just a
+/// straight copy if both types are identical. Optional arguments `min` and
+/// `max` can give nonstandard quantizations.
+template<typename S, typename D>
+void convert_type (cspan<S> src, span<D> dst,
+                   D min = std::numeric_limits<D>::min(),
+                   D max = std::numeric_limits<D>::min())
+{
+    OIIO_DASSERT(src.size() == dst.size());
+    convert_type(src.data(), dst.data(), std::min(src.size(), dst.size()),
+                 min, max);
+}
+
+
 
 /// Convert a single value from the type of S to the type of D.
 /// The conversion is not a simple cast, but correctly remaps the
@@ -978,7 +997,7 @@ template<typename S, typename D>
 inline D
 convert_type (const S &src)
 {
-    if (std::is_same<S,D>::value) {
+    if constexpr (std::is_same<S,D>::value) {
         // They must be the same type.  Just return it.
         return (D)src;
     }

--- a/src/include/OpenImageIO/image_span.h
+++ b/src/include/OpenImageIO/image_span.h
@@ -225,7 +225,7 @@ public:
 
     /// Does this image_span represent contiguous pixels -- i.e. within each
     /// pixel, the channels directly follow each other in memory?
-    bool is_contiguous_pixel() const noexcept
+    constexpr bool is_contiguous_pixel() const noexcept
     {
         return chanstride() == m_chansize;
     }
@@ -233,7 +233,7 @@ public:
     /// Does this image_span represent contiguous scanlines -- i.e. channels
     /// contiguous within each pixel and pixels contiguous within each
     /// scanline?
-    bool is_contiguous_scanline() const noexcept
+    constexpr bool is_contiguous_scanline() const noexcept
     {
         return is_contiguous_pixel() && xstride() == chanstride() * nchannels();
     }
@@ -241,7 +241,7 @@ public:
     /// Does this image_span represent contiguous 2D image planes -- i.e.
     /// channels contiguous within each pixel, pixels contiguous within each
     /// scanline, scanlines contiguous within each 2D image plane?
-    bool is_contiguous_plane() const noexcept
+    constexpr bool is_contiguous_plane() const noexcept
     {
         return is_contiguous_scanline()
                && (Rank < 3 || ystride() == xstride() * width());
@@ -250,7 +250,7 @@ public:
     /// Does this image_span represent fully contiguous data in all
     /// dimensions, i.e., each channel, pixel, scanline, and image plane
     /// directly abuts its neighbour, with no gaps?
-    bool is_contiguous() const noexcept
+    constexpr bool is_contiguous() const noexcept
     {
         return is_contiguous_scanline()
                /* image plane is contiguous scanlines */
@@ -259,8 +259,14 @@ public:
                && (Rank < 4 || zstride() == ystride() * height());
     }
 
+    /// Return the total number of pixels in the span: `w * h * d`.
+    constexpr size_t npixels() const
+    {
+        return size_t(width()) * size_t(height()) * size_t(depth());
+    }
+
     /// Return the total number of values in the span: `c * w * h * d`.
-    size_t nvalues() const
+    constexpr size_t nvalues() const
     {
         return size_t(nchannels()) * size_t(width()) * size_t(height())
                * size_t(depth());
@@ -268,7 +274,7 @@ public:
 
     /// Return the total number of bytes of (c*w*h*d) values of the given type
     /// (but not counting space in any gaps).
-    size_t size_bytes() const { return nvalues() * chansize(); }
+    constexpr size_t size_bytes() const { return nvalues() * chansize(); }
 
     /// Return a reference to the value at channel c, pixel (x,y,z).
     inline T& get(int c, int x, int y = 0, int z = 0) const

--- a/src/include/OpenImageIO/image_span.h
+++ b/src/include/OpenImageIO/image_span.h
@@ -1,0 +1,384 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
+#pragma once
+
+#include <OpenImageIO/dassert.h>
+#include <OpenImageIO/oiioversion.h>
+#include <OpenImageIO/span.h>
+#include <OpenImageIO/strided_ptr.h>
+
+
+OIIO_NAMESPACE_BEGIN
+
+#ifndef OIIO_STRIDE_T_DEFINED
+#    define OIIO_STRIDE_T_DEFINED
+/// Type we use to express how many pixels (or bytes) constitute an image,
+/// tile, or scanline.
+using imagesize_t = uint64_t;
+
+/// Type we use for stride lengths between pixels, scanlines, or image
+/// planes.
+using stride_t = int64_t;
+
+/// Special value to indicate a stride length that should be
+/// auto-computed.
+inline constexpr stride_t AutoStride = std::numeric_limits<stride_t>::min();
+#endif
+
+
+
+/// image_span : a non-owning reference to an image-like n-D array having
+/// between 2 and 4 dimensions representing channel, x, y, z with each
+/// dimension having known size and optionally non-default strides (expressed
+/// in bytes) through the data.  An `image_span<T>` is mutable (the values in
+/// the image may be modified), whereas an `image_span<const T>` is not
+/// mutable.
+///
+/// Note that the optional template parameter `Rank` includes the channels as
+/// the first dimension.  When no Rank template parameter is provided, it
+/// defaults to 4, meaning it's an image span that can describe any choice of
+/// a scanline, 2D image, or volume.
+template<typename T, size_t Rank = 4> class image_span {
+    static_assert(Rank >= 2 && Rank <= 4, "Rank must be between 2 and 4");
+
+public:
+    using value_type      = T;
+    using reference       = T&;
+    using const_reference = const T&;
+    using stride_t        = int64_t;
+    using stride_type     = int64_t;
+    using size_type       = uint32_t;
+
+    /// Default ctr -- points to nothing
+    image_span() = default;
+
+    /// Copy constructor
+    image_span(const image_span& copy) = default;
+
+    /// Construct from T*, dimensions, and (possibly default) strides (in
+    /// bytes).
+    image_span(T* data, uint32_t nchannels, uint32_t width, uint32_t height,
+               uint32_t depth = 1, stride_t chanstride = AutoStride,
+               stride_t xstride = AutoStride, stride_t ystride = AutoStride,
+               stride_t zstride = AutoStride, uint32_t chansize = sizeof(T))
+        : m_data(data)
+        , m_chansize(chansize)
+    {
+        // Validations:
+        // - an image_span<byte> can have any chansize, but any other T must
+        //   have the chansize equal to the data type size.
+        OIIO_DASSERT(nchannels > 0 && width > 0 && height > 0 && depth > 0);
+        OIIO_DASSERT((std::is_same<std::remove_const_t<T>, std::byte>::value)
+                     || chansize == sizeof(T));
+
+        m_sizes[0] = nchannels;
+        m_sizes[1] = width;
+        if constexpr (Rank >= 3)
+            m_sizes[2] = height;
+        if constexpr (Rank >= 4)
+            m_sizes[3] = depth;
+
+        chanstride   = chanstride != AutoStride ? chanstride : chansize;
+        xstride      = xstride != AutoStride ? xstride : nchannels * chanstride;
+        m_strides[0] = chanstride;
+        m_strides[1] = xstride;
+        if constexpr (Rank >= 3) {
+            ystride      = ystride != AutoStride ? ystride : width * xstride;
+            m_strides[2] = ystride;
+        }
+        if constexpr (Rank >= 4) {
+            zstride      = zstride != AutoStride ? zstride : height * ystride;
+            m_strides[3] = zstride;
+        }
+    }
+
+    // clang-format off
+    /* clang_format gets confused by this */
+
+    /// Copy constructor from image_span<T> to image_span<const T>.
+    template<typename U, size_t R,
+             OIIO_ENABLE_IF((std::is_same_v<std::remove_const_t<T>, U>)
+                            && std::is_const_v<T> && !std::is_const_v<U>
+                            && R <= Rank)>
+    image_span(const image_span<U, R>& other)
+        : image_span(other.data(), other.nchannels(), other.width(),
+                     other.height(), other.depth(), other.chanstride(),
+                     other.xstride(), other.ystride(), other.zstride(),
+                     other.chansize())
+    {
+    }
+    // clang-format on
+
+    /// Construct from span<T> and dimensions, assume contiguous strides.
+    image_span(span<T> data, uint32_t nchannels, uint32_t width,
+               uint32_t height, uint32_t depth = 1)
+        : image_span(data.data(), nchannels, width, height, depth)
+    {
+        // Validations:
+        // - The full layout must fit within the original span size.
+        OIIO_DASSERT(nvalues() <= data.size());
+    }
+
+    /// assignments -- not a deep copy, just make this image_span point to the
+    /// same strided data as the operand.
+    image_span& operator=(const image_span& copy) = default;
+
+    /// image_span(x,y,z) returns a strided_ptr<T,1> for the pixel (x,y,z).
+    /// The z can be omitted for 2D images.  Note that the resulting
+    /// strided_ptr can then have individual channels accessed with
+    /// operator[]. This particular strided pointer has stride multiplier 1,
+    /// because this class uses bytes as strides, not sizeof(T).
+    strided_ptr<T, 1> operator()(uint32_t x, uint32_t y, uint32_t z = 0)
+    {
+        return strided_ptr<T, 1>(getptr(0, x, y, z), chanstride());
+    }
+
+    /// Return the number of dimensions of the image_span. Remember that a
+    /// Rank 2 image_span is one scanline, a Rank 3 image_span can be a 2D
+    /// image, and a Rank 4 image_span can be a volume.
+    static constexpr size_t rank() noexcept { return Rank; }
+
+    /// Return the number of channels.
+    constexpr size_type nchannels() const { return m_sizes[0]; }
+    /// Return the stride, in bytes, between channels within a pixel.
+    constexpr stride_type chanstride() const { return m_strides[0]; }
+
+    /// Return the width -- the number of pixels in the x dimension.
+    constexpr size_type width() const { return m_sizes[1]; }
+    /// Return the stride, in bytes, between pixels in the x dimension.
+    constexpr stride_type xstride() const { return m_strides[1]; }
+
+    /// Return the height -- the number of pixels in the y dimension. This
+    /// will be 1 for a Rank 2 (single scanline) `image_span<T,2>`.
+    constexpr size_type height() const
+    {
+        if constexpr (Rank >= 3)
+            return m_sizes[2];
+        else
+            return 1;
+    }
+    /// Return the stride, in bytes, between pixels in the y dimension. This
+    /// will be 0 for a Rank 2 (single scanline) `image_span<T,2>`.
+    constexpr stride_type ystride() const
+    {
+        if constexpr (Rank >= 3)
+            return m_strides[2];
+        else
+            return 0;
+    }
+
+    /// Return the depth -- the number of pixels in the z dimension. This will
+    /// be 1 if there are fewer than 3 spatial dimensions (i.e. a scanline
+    /// `image_span<T,2>` or 2D image `image_span<T,3>`).
+    constexpr size_type depth() const
+    {
+        if constexpr (Rank >= 4)
+            return m_sizes[3];
+        return 1;
+    }
+    /// Return the stride, in bytes, between pixels in the z dimension. This
+    /// will be 0 if there are fewer than 3 spatial dimensions (i.e. a
+    /// scanline `image_span<T,2>` or 2D image `image_span<T,3>`).
+    constexpr stride_type zstride() const
+    {
+        if constexpr (Rank >= 4)
+            return m_strides[3];
+        return 0;
+    }
+
+    /// Return the size of a channel, in bytes. For all element types except
+    /// for std::byte, this should always be the same as sizeof(T). For
+    /// std::byte, this may be different if the channels are another data type
+    /// but for the sake of this span, we are treating it as untyped memory.
+    /// The channel size is set by the constructor.
+    constexpr size_type chansize() const { return m_chansize; }
+
+    /// Return a raw pointer to the start of the data: channel=0, x=0, y=0,
+    /// z=0.
+    T* data() const { return m_data; }
+
+    /// Convert an `image_span<T>` to an `image_span<const std::byte>`
+    /// representing the same sized and strided memory pattern represented
+    /// un-typed memory.
+    image_span<const std::byte> as_bytes_image_span() const noexcept
+    {
+        return image_span<const std::byte>(static_cast<const std::byte*>(m_data),
+                                           nchannels(), width(), height(),
+                                           depth(), chanstride(), xstride(),
+                                           ystride(), zstride(), m_chansize);
+    }
+
+    /// Convert an image_span<T> to an image_span<std::byte> representing the
+    /// same sized and strided memory pattern represented un-typed memory.
+    /// Note that this will not work (be a compiler error) if T a const type.
+    image_span<std::byte> as_writable_bytes_image_span() const noexcept
+    {
+        return image_span<std::byte>(static_cast<std::byte*>(m_data),
+                                     nchannels(), width(), height(), depth(),
+                                     chanstride(), xstride(), ystride(),
+                                     zstride(), m_chansize);
+    }
+
+    /// Does this image_span represent contiguous pixels -- i.e. within each
+    /// pixel, the channels directly follow each other in memory?
+    bool is_contiguous_pixel() const noexcept
+    {
+        return chanstride() == m_chansize;
+    }
+
+    /// Does this image_span represent contiguous scanlines -- i.e. channels
+    /// contiguous within each pixel and pixels contiguous within each
+    /// scanline?
+    bool is_contiguous_scanline() const noexcept
+    {
+        return is_contiguous_pixel() && xstride() == chanstride() * nchannels();
+    }
+
+    /// Does this image_span represent contiguous 2D image planes -- i.e.
+    /// channels contiguous within each pixel, pixels contiguous within each
+    /// scanline, scanlines contiguous within each 2D image plane?
+    bool is_contiguous_plane() const noexcept
+    {
+        return is_contiguous_scanline()
+               && (Rank < 3 || ystride() == xstride() * width());
+    }
+
+    /// Does this image_span represent fully contiguous data in all
+    /// dimensions, i.e., each channel, pixel, scanline, and image plane
+    /// directly abuts its neighbour, with no gaps?
+    bool is_contiguous() const noexcept
+    {
+        return is_contiguous_scanline()
+               /* image plane is contiguous scanlines */
+               && (Rank < 3 || ystride() == xstride() * width())
+               /* volume is contiguous planes */
+               && (Rank < 4 || zstride() == ystride() * height());
+    }
+
+    /// Return the total number of values in the span: `c * w * h * d`.
+    size_t nvalues() const
+    {
+        return size_t(nchannels()) * size_t(width()) * size_t(height())
+               * size_t(depth());
+    }
+
+    /// Return the total number of bytes of (c*w*h*d) values of the given type
+    /// (but not counting space in any gaps).
+    size_t size_bytes() const { return nvalues() * chansize(); }
+
+    /// Return a reference to the value at channel c, pixel (x,y,z).
+    inline T& get(int c, int x, int y = 0, int z = 0) const
+    {
+        // Bounds check in done in getptr
+        return *getptr(c, x, y, z);
+    }
+
+    /// Return a pointer to the value at channel c, pixel (x,y,z).
+    inline T* getptr(int c, int x, int y, int z = 0) const
+    {
+        // Bounds check in debug mode
+        OIIO_DASSERT(unsigned(c) < unsigned(nchannels())
+                     && unsigned(x) < unsigned(width())
+                     && unsigned(y) < unsigned(height())
+                     && unsigned(z) < unsigned(depth()));
+        if constexpr (Rank == 2) {
+            OIIO_DASSERT(y == 0 && z == 0);
+        } else if constexpr (Rank == 3) {
+            OIIO_DASSERT(z == 0);
+        }
+        return (T*)((char*)data() + c * chanstride() + x * xstride()
+                    + y * ystride() + z * zstride());
+    }
+
+    /// Return a pointer to the value at channel 0, pixel (x,y,z).
+    inline T* getpixelptr(int x, int y = 0, int z = 0) const
+    {
+        return getptr(0, x, y, z);
+    }
+
+    /// Return a subspan in x, y, and z (but assume all channels are
+    /// included).
+    image_span subspan(uint32_t xbegin, uint32_t xend, uint32_t ybegin,
+                       uint32_t yend, uint32_t zbegin = 0,
+                       uint32_t zend = 1) const
+    {
+        // Bounds check in debug mode
+        OIIO_DASSERT(xbegin <= xend && xend <= width() && ybegin <= yend
+                     && yend <= height() && zbegin <= zend && zend <= depth());
+        return image_span(data() + xbegin * xstride() + ybegin * ystride()
+                              + zbegin * zstride(),
+                          nchannels(), xend - xbegin, yend - ybegin,
+                          zend - zbegin, chanstride(), xstride(), ystride(),
+                          zstride(), chansize());
+    }
+
+    /// Return a subspan in all dimensions: channel, x, y, and z.
+    image_span chansubspan(uint32_t chbegin, uint32_t chend, uint32_t xbegin,
+                           uint32_t xend, uint32_t ybegin, uint32_t yend,
+                           uint32_t zbegin = 0, uint32_t zend = 1) const
+    {
+        // Bounds check in debug mode
+        OIIO_DASSERT(chbegin <= chend && chend <= nchannels() && xbegin <= xend
+                     && xend <= width() && ybegin <= yend && yend <= height()
+                     && zbegin <= zend && zend <= depth());
+        return image_span(data() + chbegin * chanstride() + xbegin * xstride()
+                              + ybegin * ystride() + zbegin * zstride(),
+                          chend - chbegin, xend - xbegin, yend - ybegin,
+                          zend - zbegin, chanstride(), xstride(), ystride(),
+                          zstride(), chansize());
+    }
+
+private:
+    T* m_data { nullptr };  // pointer to the start of the data
+    std::array<stride_type, Rank> m_strides;  // byte strides for each dim
+    std::array<size_type, Rank> m_sizes;      // size for each dim
+    uint32_t m_chansize { sizeof(T) };  // size of a channel value, in bytes
+};
+
+
+
+/// Type alias for an image_span that can describe a 3D volumetric image with
+/// channels.
+template<typename T> using image3d_span = image_span<T, 4>;
+
+/// Type alias for an image_span that can describe a 2D image with channels,
+/// but cannot describe a 3D volume.
+template<typename T> using image2d_span = image_span<T, 3>;
+
+/// Type alias for an image_span that can describe a single scanline with
+/// channels, but cannot describe a full 2D image or a 3D volume.
+template<typename T> using image1d_span = image_span<T, 2>;
+
+
+
+/// Convert an image_span of any type to a non-mutable span of const bytes
+/// covering the same range of memory.
+template<typename T, size_t Rank>
+image_span<const std::byte>
+as_image_span_bytes(image_span<T, Rank> src) noexcept
+{
+    return image_span<const std::byte>(
+        reinterpret_cast<const std::byte*>(src.data()), src.nchannels(),
+        src.width(), src.height(), src.depth(), src.chanstride(), src.xstride(),
+        src.ystride(), src.zstride(), src.chansize());
+}
+
+
+/// Convert an image_span of any type to a mutable span of bytes covering
+/// the same range of memory.
+template<typename T, size_t Rank>
+image_span<std::byte>
+as_image_span_writable_bytes(image_span<T, Rank> src) noexcept
+{
+    return image_span<std::byte>(reinterpret_cast<std::byte*>(src.data()),
+                                 src.nchannels(), src.width(), src.height(),
+                                 src.depth(), src.chanstride(), src.xstride(),
+                                 src.ystride(), src.zstride(), src.chansize());
+}
+
+
+
+OIIO_NAMESPACE_END

--- a/src/include/OpenImageIO/image_span.h
+++ b/src/include/OpenImageIO/image_span.h
@@ -205,7 +205,8 @@ public:
     /// un-typed memory.
     image_span<const std::byte> as_bytes_image_span() const noexcept
     {
-        return image_span<const std::byte>(static_cast<const std::byte*>(m_data),
+        return image_span<const std::byte>(reinterpret_cast<const std::byte*>(
+                                               m_data),
                                            nchannels(), width(), height(),
                                            depth(), chanstride(), xstride(),
                                            ystride(), zstride(), m_chansize);
@@ -216,7 +217,7 @@ public:
     /// Note that this will not work (be a compiler error) if T a const type.
     image_span<std::byte> as_writable_bytes_image_span() const noexcept
     {
-        return image_span<std::byte>(static_cast<std::byte*>(m_data),
+        return image_span<std::byte>(reinterpret_cast<std::byte*>(m_data),
                                      nchannels(), width(), height(), depth(),
                                      chanstride(), xstride(), ystride(),
                                      zstride(), m_chansize);

--- a/src/include/OpenImageIO/image_span.h
+++ b/src/include/OpenImageIO/image_span.h
@@ -40,7 +40,7 @@ inline constexpr stride_t AutoStride = std::numeric_limits<stride_t>::min();
 /// Note that the optional template parameter `Rank` includes the channels as
 /// the first dimension.  When no Rank template parameter is provided, it
 /// defaults to 4, meaning it's an image span that can describe any choice of
-/// a scanline, 2D image, or volume.
+/// a scanline (Rank 2), 2D image (Rank 3), or volume (Rank 4).
 template<typename T, size_t Rank = 4> class image_span {
     static_assert(Rank >= 2 && Rank <= 4, "Rank must be between 2 and 4");
 

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -20,7 +20,9 @@ OIIO_NAMESPACE_BEGIN
 /// strides (expressed in bytes) through the data.  An image_view<T> is
 /// mutable (the values in the image may be modified), whereas an
 /// image_view<const T> is not mutable.
-template<typename T> class image_view {
+template<typename T>
+class OIIO_DEPRECATED("image_view is deprecated. Consider image_span.")
+    image_view {
 public:
     typedef T value_type;
     typedef T& reference;

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3418,6 +3418,25 @@ get_extension_map()
 OIIO_API bool convert_pixel_values (TypeDesc src_type, const void *src,
                                     TypeDesc dst_type, void *dst, int n = 1);
 
+/// Helper function: copy values from spans `src` to `dst`, converting between
+/// types as appropriate. Return true if ok, false if it didn't know how to do
+/// the conversion.
+///
+/// The conversion is of normalized (pixel-like) values -- for example 'UINT8'
+/// 255 will convert to float 1.0 and vice versa, not float 255.0. If you want
+/// a straight C-like data cast conversion (e.g., uint8 255 -> float 255.0),
+/// then you should prefer the un-normalized convert_type() utility function
+/// found in typedesc.h.
+template<typename SrcType, typename DstType>
+bool
+convert_pixel_values(cspan<SrcType> src, span<DstType> dst)
+{
+    OIIO_DASSERT(dst.size() >= src.size());
+    return convert_pixel_values(TypeDescFromC_v<SrcType>, src.data(),
+                                TypeDescFromC_v<DstType>, dst.data(),
+                                std::min(dst.size(), src.size()));
+}
+
 
 /// Helper routine for data conversion: Convert an image of nchannels x
 /// width x height x depth from src to dst.  The src and dst may have
@@ -3436,6 +3455,50 @@ OIIO_API bool convert_image (int nchannels, int width, int height, int depth,
                              stride_t dst_xstride, stride_t dst_ystride,
                              stride_t dst_zstride);
 
+/// Helper routine for data conversion: Convert an image described by
+/// image_span `src` into image_span `dst`, which must be the same dimensions
+/// but possibly differing data type and strides.  Clever use of this function
+/// can not only exchange data among different formats (e.g., half to 8-bit
+/// unsigned), but also can copy selective channels, copy subimages, etc.
+/// Return true if ok, false if it didn't know how to do the conversion.
+template<typename SrcType, typename DstType>
+bool
+convert_image(image_span<SrcType> src, image_span<DstType> dst)
+{
+    // For now, just implement by wrapping the pointer-based version.
+    OIIO_DASSERT(src.nchannels() == dst.nchannels()
+                 && src.width() == dst.width() && src.height() == dst.height()
+                 && src.depth() == dst.depth());
+    return convert_image(src.nchannels(), src.width(), src.height(),
+                         src.depth(), src.data(), TypeDescFromC_v<SrcType>,
+                         src.xstride(), src.ystride(), src.zstride(),
+                         dst.data(), TypeDescFromC_v<DstType>, dst.xstride(),
+                         dst.ystride(), dst.zstride());
+}
+
+
+/// Helper routine for data conversion: Convert an image described by
+/// image_span `src` into image_span `dst`, which must be the same dimensions
+/// but possibly differing data type and strides. The data types are passed as
+/// `TypeDesc`, and the spans are untyped bytes that provide the dimensions
+/// and memory layout.
+inline bool
+convert_image(image_span<const std::byte> src, TypeDesc src_type,
+              image_span<std::byte> dst, TypeDesc dst_type)
+{
+    // For now, just implement by wrapping the pointer-based version.
+    OIIO_DASSERT(src.nchannels() == dst.nchannels()
+                 && src.width() == dst.width() && src.height() == dst.height()
+                 && src.depth() == dst.depth());
+    OIIO_DASSERT(src_type.size() == src.chansize()
+                 && dst_type.size() == dst.chansize());
+    return convert_image(src.nchannels(), src.width(), src.height(),
+                         src.depth(), src.data(), src_type, src.xstride(),
+                         src.ystride(), src.zstride(), dst.data(), dst_type,
+                         dst.xstride(), dst.ystride(), dst.zstride());
+}
+
+
 
 /// A version of convert_image that will break up big jobs into multiple
 /// threads.
@@ -3447,6 +3510,48 @@ OIIO_API bool parallel_convert_image (
                void *dst, TypeDesc dst_type,
                stride_t dst_xstride, stride_t dst_ystride,
                stride_t dst_zstride, int nthreads=0);
+
+/// A version of convert_image that will break up big jobs into multiple
+/// threads. The data types are taken from the spans.
+template<typename SrcType, typename DstType>
+bool
+parallel_convert_image(image_span<SrcType> src, image_span<DstType> dst,
+                       int nthreads = 0)
+{
+    // For now, just implement by wrapping the pointer-based version.
+    OIIO_DASSERT(src.nchannels() == dst.nchannels()
+                 && src.width() == dst.width() && src.height() == dst.height()
+                 && src.depth() == dst.depth());
+    return parallel_convert_image(src.nchannels(), src.width(), src.height(),
+                                  src.depth(), src.data(),
+                                  TypeDescFromC_v<SrcType>, src.xstride(),
+                                  src.ystride(), src.zstride(), dst.data(),
+                                  TypeDescFromC_v<SrcType>, dst.xstride(),
+                                  dst.ystride(), dst.zstride(), nthreads);
+}
+
+/// A version of convert_image that will break up big jobs into multiple
+/// threads. The data types are passed as `TypeDesc`, and the spans are
+/// untyped bytes that provide the dimensions and memory layout.
+inline bool
+parallel_convert_image(image_span<const std::byte> src, TypeDesc src_type,
+                       image_span<std::byte> dst, TypeDesc dst_type,
+                       int nthreads = 0)
+{
+    // For now, just implement by wrapping the pointer-based version.
+    OIIO_DASSERT(src.nchannels() == dst.nchannels()
+                 && src.width() == dst.width() && src.height() == dst.height()
+                 && src.depth() == dst.depth());
+    OIIO_DASSERT(src_type.size() == src.chansize()
+                 && dst_type.size() == dst.chansize());
+    return parallel_convert_image(src.nchannels(), src.width(), src.height(),
+                                  src.depth(), src.data(),
+                                  src_type, src.xstride(),
+                                  src.ystride(), src.zstride(), dst.data(),
+                                  dst_type, dst.xstride(),
+                                  dst.ystride(), dst.zstride(), nthreads);
+}
+
 
 
 /// Add random [-ditheramplitude,ditheramplitude] dither to the color channels

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -83,12 +83,21 @@ get_default_quantize(TypeDesc format, long long& quant_min,
                      long long& quant_max) noexcept;
 
 /// Turn potentially non-contiguous-stride data (e.g. "RGBxRGBx") into
+/// contiguous-stride ("RGBRGB"), for any format or stride values (measured in
+/// bytes).  Caller must pass in a dst pointing to enough memory to hold the
+/// contiguous rectangle.  Return span where the contiguous data ended up,
+/// which is either dst or src (if the strides indicated that data were
+/// already contiguous).
+OIIO_API span<const std::byte>
+contiguize(image_span<const std::byte> src, span<std::byte> dst);
+
+/// Turn potentially non-contiguous-stride data (e.g. "RGBxRGBx") into
 /// contiguous-stride ("RGBRGB"), for any format or stride values
 /// (measured in bytes).  Caller must pass in a dst pointing to enough
 /// memory to hold the contiguous rectangle.  Return a ptr to where the
 /// contiguous data ended up, which is either dst or src (if the strides
 /// indicated that data were already contiguous).
-const void*
+OIIO_API const void*
 contiguize(const void* src, int nchannels, stride_t xstride, stride_t ystride,
            stride_t zstride, void* dst, int width, int height, int depth,
            TypeDesc format);

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -252,6 +252,11 @@ if (OIIO_BUILD_TESTS AND BUILD_TESTING)
                           FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_color ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/color_test)
 
+    fancy_add_executable (NAME image_span_test SRC image_span_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
+    add_test (unit_image_span ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/image_span_test)
+
     fancy_add_executable (NAME imagebuf_test SRC imagebuf_test.cpp
                           LINK_LIBRARIES OpenImageIO
                           FOLDER "Unit Tests" NO_INSTALL)

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -253,7 +253,7 @@ if (OIIO_BUILD_TESTS AND BUILD_TESTING)
     add_test (unit_color ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/color_test)
 
     fancy_add_executable (NAME image_span_test SRC image_span_test.cpp
-                          LINK_LIBRARIES OpenImageIO
+                          LINK_LIBRARIES OpenImageIO Imath::Imath
                           FOLDER "Unit Tests" NO_INSTALL)
     add_test (unit_image_span ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/image_span_test)
 

--- a/src/libOpenImageIO/image_span_test.cpp
+++ b/src/libOpenImageIO/image_span_test.cpp
@@ -1,0 +1,224 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
+#include <OpenImageIO/benchmark.h>
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/parallel.h>
+#include <OpenImageIO/unittest.h>
+
+#include "imageio_pvt.h"
+
+#include <iostream>
+
+using namespace OIIO;
+
+
+
+template<typename T>
+void
+test_image_span()
+{
+    print("testing image_span {}\n",
+          TypeDescFromC<std::remove_cv_t<T>>::value());
+
+    const int X = 4, Y = 3, C = 3, Z = 1;
+    static T IMG[Z][Y][X][C] = {
+        // 4x3 2D image with 3 channels
+        { { { 0, 0, 0 }, { 1, 0, 1 }, { 2, 0, 2 }, { 3, 0, 3 } },
+          { { 0, 1, 4 }, { 1, 1, 5 }, { 2, 1, 6 }, { 3, 1, 7 } },
+          { { 0, 2, 8 }, { 1, 2, 9 }, { 2, 2, 10 }, { 3, 2, 11 } } }
+    };
+
+    // Test a 2D image_span
+    {
+        image2d_span<T> I((T*)IMG, C, X, Y);
+        OIIO_CHECK_EQUAL(I.getptr(0, 0, 0), &IMG[0][0][0][0]);
+        OIIO_CHECK_EQUAL(I.getptr(1, 0, 0), &IMG[0][0][0][1]);
+        OIIO_CHECK_EQUAL(I.getptr(0, 1, 0), &IMG[0][0][1][0]);
+        for (int y = 0, i = 0; y < Y; ++y) {
+            for (int x = 0; x < X; ++x, ++i) {
+                OIIO_CHECK_EQUAL(I.get(0, x, y), x);
+                OIIO_CHECK_EQUAL(I.get(1, x, y), y);
+                OIIO_CHECK_EQUAL(I.get(2, x, y), i);
+                OIIO_CHECK_EQUAL(I(x, y)[0], x);
+                OIIO_CHECK_EQUAL(I(x, y)[1], y);
+                OIIO_CHECK_EQUAL(I(x, y)[2], i);
+            }
+        }
+    }
+
+    // Test a full volumetric image
+    {
+        image_span<T> I((T*)IMG, C, X, Y, Z);
+        OIIO_CHECK_EQUAL(I.getptr(0, 0, 0), &IMG[0][0][0][0]);
+        OIIO_CHECK_EQUAL(I.getptr(1, 0, 0), &IMG[0][0][0][1]);
+        OIIO_CHECK_EQUAL(I.getptr(0, 1, 0), &IMG[0][0][1][0]);
+        OIIO_CHECK_EQUAL(I.getptr(0, 0, 1), &IMG[0][1][0][0]);
+        for (int z = 0; z < Z; ++z) {
+            for (int y = 0, i = 0; y < Y; ++y) {
+                for (int x = 0; x < X; ++x, ++i) {
+                    OIIO_CHECK_EQUAL(I.get(0, x, y, z), x);
+                    OIIO_CHECK_EQUAL(I.get(1, x, y, z), y);
+                    OIIO_CHECK_EQUAL(I.get(2, x, y, z), i);
+                    OIIO_CHECK_EQUAL(I(x, y, z)[0], x);
+                    OIIO_CHECK_EQUAL(I(x, y, z)[1], y);
+                    OIIO_CHECK_EQUAL(I(x, y, z)[2], i);
+                }
+            }
+        }
+    }
+
+    // Extra tests for mutable types
+    if constexpr (!std::is_const_v<T>) {
+        image_span<T> I((T*)IMG, C, X, Y, Z);
+        for (int y = 0, i = 0; y < Y; ++y) {
+            for (int x = 0; x < X; ++x, ++i) {
+                I(x, y)[0] = x;
+                I(x, y)[1] = y;
+                I(x, y)[2] = i;
+            }
+        }
+
+        for (int y = 0, i = 0; y < Y; ++y) {
+            for (int x = 0; x < X; ++x, ++i) {
+                OIIO_CHECK_EQUAL(I(x, y)[0], x);
+                OIIO_CHECK_EQUAL(I(x, y)[1], y);
+                OIIO_CHECK_EQUAL(I(x, y)[2], i);
+            }
+        }
+    }
+}
+
+
+
+template<typename T = float>
+void
+benchmark_image_span_copy_image()
+{
+    // Benchmark old (ptr) versus new (span) copy_image functions
+    Benchmarker bench;
+    bench.units(Benchmarker::Unit::us);
+    const int xres = 2048, yres = 1536, nchans = 4;
+    std::vector<T> sbuf(xres * yres * nchans);
+    std::vector<T> dbuf(xres * yres * nchans);
+    const size_t chansize = sizeof(T);
+
+    print("Benchmarking copy_image {} (total {} MB):\n",
+          TypeDescFromC<T>::value(),
+          xres * yres * nchans * chansize * 3 / 4 / 1024 / 1024);
+
+    // We test different amounts of contiguity. Each test copies 3/4 of the
+    // total image, to keep the total number of bytes copied identical.
+    const stride_t src_xstride(chansize * nchans);
+    const stride_t src_ystride(src_xstride * xres);
+    for (int i = 0; i < 3; ++i) {
+        size_t nc(nchans), pixsize(chansize * nchans), w(xres), h(yres);
+        std::string label;
+        if (i == 0) {
+            // Fully contiguous region -- copy 3/4 of the image.
+            label = "contig buffer";
+            h     = h * 3 / 4;
+        } else if (i == 1) {
+            // Contiguous scanlines -- copy 3/4 of the width of each scanline.
+            label = "contig scanlines";
+            w     = w * 3 / 4;
+        } else if (i == 2) {
+            // Contiguous pixels -- copy 3 of 4 channels of each pixel.
+            label = "contig pixels";
+            nc    = nc * 3 / 4;
+        }
+        bench(Strutil::format("  copy_image image_span {}", label), [&]() {
+            copy_image(image_span<T>(dbuf.data(), nc, w, h, 1, chansize,
+                                     src_xstride, src_ystride, AutoStride,
+                                     chansize),
+                       image_span<const T>(sbuf.data(), nc, w, h, 1));
+        });
+        bench(Strutil::format("  copy_image raw ptrs   {}", label), [&]() {
+            copy_image(nc, w, h, 1, sbuf.data(), pixsize, src_xstride,
+                       src_ystride, AutoStride, dbuf.data(), AutoStride,
+                       AutoStride, AutoStride);
+        });
+    }
+}
+
+
+
+template<typename T = float>
+void
+benchmark_image_span_contiguize()
+{
+    // Benchmark old (ptr) versus new (span) contiguize functions
+    using pvt::contiguize;
+
+    // Benchmark old (ptr) versus new (span) contiguize functions
+    Benchmarker bench;
+    bench.units(Benchmarker::Unit::us);
+    const int xres = 2048, yres = 1536, nchans = 4;
+    std::vector<T> sbuf(xres * yres * nchans);
+    std::vector<T> dbuf(xres * yres * nchans);
+    const size_t chansize = sizeof(T);
+
+    print("Benchmarking contiguize {} (total {} MB):\n",
+          TypeDescFromC<T>::value(),
+          xres * yres * nchans * chansize * 3 / 4 / 1024 / 1024);
+
+    // We test different amounts of contiguity. Each test copies 3/4 of the
+    // total image, to keep the total number of bytes copied identical.
+    const stride_t src_xstride(chansize * nchans);
+    const stride_t src_ystride(src_xstride * xres);
+    for (int i = 0; i < 3; ++i) {
+        size_t nc(nchans), /*pixsize(chansize * nchans),*/ w(xres), h(yres);
+        std::string label;
+        if (i == 0) {
+            // Fully contiguous region -- copy 3/4 of the image.
+            label = "contig buffer";
+            h     = h * 3 / 4;
+        } else if (i == 1) {
+            // Contiguous scanlines -- copy 3/4 of the width of each scanline.
+            label = "contig scanlines";
+            w     = w * 3 / 4;
+        } else if (i == 2) {
+            // Contiguous pixels -- copy 3 of 4 channels of each pixel.
+            label = "contig pixels";
+            nc    = nc * 3 / 4;
+        }
+        bench(Strutil::format("  contiguize image_span {}", label), [&]() {
+            auto r = contiguize(image_span(reinterpret_cast<const std::byte*>(
+                                               sbuf.data()),
+                                           nc, w, h, 1, chansize, src_xstride,
+                                           src_ystride, AutoStride, chansize),
+                                as_writable_bytes(make_span(dbuf)));
+            OIIO_ASSERT(r.size_bytes() == nc * w * h * sizeof(T));
+        });
+        bench(Strutil::format("  contiguize raw ptrs   {}", label), [&]() {
+            contiguize(sbuf.data(), nc, src_xstride, src_ystride,
+                       src_ystride * h, dbuf.data(), w, h, 1,
+                       TypeDescFromC<T>::value());
+        });
+    }
+}
+
+
+
+int
+main(int /*argc*/, char* /*argv*/[])
+{
+    test_image_span<float>();
+    test_image_span<const float>();
+    test_image_span<uint16_t>();
+    test_image_span<const uint16_t>();
+    test_image_span<uint8_t>();
+    test_image_span<const uint8_t>();
+
+    benchmark_image_span_copy_image<float>();
+    benchmark_image_span_copy_image<uint16_t>();
+    benchmark_image_span_copy_image<uint8_t>();
+
+    benchmark_image_span_contiguize<float>();
+    benchmark_image_span_contiguize<uint16_t>();
+    benchmark_image_span_contiguize<uint8_t>();
+
+    return unit_test_failures;
+}

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -750,6 +750,7 @@ pvt::contiguize(image_span<const std::byte> src, span<std::byte> dst)
         image_span dstspan(dst.data(), src.nchannels(), src.width(),
                            src.height(), src.depth(), AutoStride, AutoStride,
                            AutoStride, AutoStride, src.chansize());
+        OIIO_DASSERT(dstspan.size_bytes() == src.size_bytes());
         copy_image(dstspan, src);
         return make_cspan(dst.data(), src.size_bytes());
     }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -733,11 +733,36 @@ _contiguize(const T* src, int nchannels, stride_t xstride, stride_t ystride,
 
 }  // namespace
 
+
+
+span<const std::byte>
+pvt::contiguize(image_span<const std::byte> src, span<std::byte> dst)
+{
+    // Contiguized result must fit in dst
+    OIIO_DASSERT(src.size_bytes() <= dst.size_bytes());
+
+    if (src.is_contiguous()) {
+        // Already contiguous -- don't copy, just return a span representation
+        // of the place it already lives in src.
+        return make_cspan(src.data(), src.size_bytes());
+    } else {
+        // Non-contiguous -- rely on copy_image() to do the heavy lifting.
+        image_span dstspan(dst.data(), src.nchannels(), src.width(),
+                           src.height(), src.depth(), AutoStride, AutoStride,
+                           AutoStride, AutoStride, src.chansize());
+        copy_image(dstspan, src);
+        return make_cspan(dst.data(), src.size_bytes());
+    }
+}
+
+
+
 const void*
 pvt::contiguize(const void* src, int nchannels, stride_t xstride,
                 stride_t ystride, stride_t zstride, void* dst, int width,
                 int height, int depth, TypeDesc format)
 {
+    OIIO_DASSERT(nchannels >= 0 && width >= 0 && height >= 0 && depth >= 0);
     switch (format.basetype) {
     case TypeDesc::FLOAT:
         return _contiguize((const float*)src, nchannels, xstride, ystride,
@@ -1018,6 +1043,117 @@ copy_image(int nchannels, int width, int height, int depth, const void* src,
                     memcpy(t, f, pixelsize);
                     f += src_xstride;
                     t += dst_xstride;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+
+
+template<typename T>
+void
+aligned_copy_image(image_span<std::byte> dst, image_span<const std::byte> src)
+{
+    size_t systride  = src.ystride();
+    size_t dystride  = dst.ystride();
+    size_t chunksize = src.chansize() * src.nchannels();
+    size_t nT        = chunksize / sizeof(T);
+    size_t sstrideT  = src.xstride() / sizeof(T);
+    size_t dstrideT  = dst.xstride() / sizeof(T);
+    for (uint32_t z = 0; z < src.depth(); ++z) {
+        std::byte* dscanline       = dst.getptr(0, 0, 0, z);
+        const std::byte* sscanline = src.getptr(0, 0, 0, z);
+        for (uint32_t y = 0; y < src.height(); ++y) {
+            auto dscanlineT = reinterpret_cast<T*>(dscanline);
+            auto sscanlineT = reinterpret_cast<const T*>(sscanline);
+            for (uint32_t x = 0; x < src.width(); ++x) {
+                for (size_t c = 0; c < nT; ++c) {
+                    dscanlineT[x * dstrideT + c] = sscanlineT[x * sstrideT + c];
+                }
+            }
+            sscanline += systride;
+            dscanline += dystride;
+        }
+    }
+}
+
+
+
+bool
+copy_image(image_span<std::byte> dst, image_span<const std::byte> src)
+{
+    OIIO_DASSERT(src.width() == dst.width() && src.height() == dst.height()
+                 && src.depth() == dst.depth()
+                 && src.nchannels() == dst.nchannels()
+                 && src.chansize() == dst.chansize());
+    if (src.is_contiguous() && dst.is_contiguous()) {
+        // Whole image is contiguous -- just do it in one memcpy
+        memcpy(dst.data(), src.data(), src.size_bytes());
+        return true;
+    }
+    if (src.is_contiguous_scanline() && dst.is_contiguous_scanline()) {
+        // Scanlines are contiguous -- do one memcpy per scanline
+        size_t chunksize = src.chansize() * src.nchannels()
+                           * size_t(src.width());
+        for (uint32_t z = 0; z < src.depth(); ++z) {
+            for (uint32_t y = 0; y < src.height(); ++y) {
+                std::byte* d       = dst.getptr(0, 0, y, z);
+                const std::byte* s = src.getptr(0, 0, y, z);
+                memcpy(d, s, chunksize);
+            }
+        }
+        return true;
+    }
+    if (dst.is_contiguous_pixel()) {
+        size_t systride = src.ystride();
+        size_t dystride = dst.ystride();
+        // Pixels are contiguous -- do one memcpy per pixel
+        size_t chunksize = src.chansize() * src.nchannels();
+#if 1
+        // Speedup trick: if we 'or' all the pointers and strides and the
+        // result is a multiple of 4, we can copy 4 bytes at a time.
+        size_t mashed = (chunksize | uintptr_t(src.data())
+                         | uintptr_t(dst.data()) | src.xstride() | src.ystride()
+                         | src.zstride());
+        if ((mashed & 3) == 0) {
+            aligned_copy_image<uint32_t>(dst, src);
+            return true;
+        }
+        if ((mashed & 1) == 0) {
+            aligned_copy_image<uint16_t>(dst, src);
+            return true;
+        }
+#endif
+        for (uint32_t z = 0; z < src.depth(); ++z) {
+            std::byte* dscanline       = dst.getptr(0, 0, 0, z);
+            const std::byte* sscanline = src.getptr(0, 0, 0, z);
+            for (uint32_t y = 0; y < src.height(); ++y) {
+                for (uint32_t x = 0; x < src.width(); ++x) {
+                    memcpy(dscanline + x * dst.xstride(),
+                           sscanline + x * src.xstride(), chunksize);
+                }
+                sscanline += systride;
+                dscanline += dystride;
+            }
+        }
+        return true;
+    }
+    // General case -- have to do item by item copy.
+    // FIXME: is there advantage to doing copies individually rather
+    // then with memcpy?
+    size_t chunksize = src.chansize();
+    for (uint32_t z = 0; z < src.depth(); ++z) {
+        for (uint32_t y = 0; y < src.height(); ++y) {
+            std::byte* dscanline       = dst.getptr(0, 0, y, z);
+            const std::byte* sscanline = src.getptr(0, 0, y, z);
+            for (uint32_t x = 0; x < src.width(); ++x) {
+                std::byte* dpel       = dscanline + x * dst.xstride();
+                const std::byte* spel = sscanline + x * src.xstride();
+                for (uint32_t c = 0; x < src.nchannels(); ++c) {
+                    memcpy(dpel + c * dst.chanstride(),
+                           spel + c * src.chanstride(), chunksize);
                 }
             }
         }

--- a/src/libutil/span_test.cpp
+++ b/src/libutil/span_test.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <vector>
 
-#include <OpenImageIO/image_view.h>
+#include <OpenImageIO/image_span.h>
 #include <OpenImageIO/span.h>
 #include <OpenImageIO/strided_ptr.h>
 #include <OpenImageIO/unittest.h>
@@ -260,60 +260,6 @@ test_span_strided_mutable()
 
 
 void
-test_image_view()
-{
-    const int X = 4, Y = 3, C = 3, Z = 1;
-    static const float IMG[Z][Y][X][C] = {
-        // 4x3 2D image with 3 channels
-        { { { 0, 0, 0 }, { 1, 0, 1 }, { 2, 0, 2 }, { 3, 0, 3 } },
-          { { 0, 1, 4 }, { 1, 1, 5 }, { 2, 1, 6 }, { 3, 1, 7 } },
-          { { 0, 2, 8 }, { 1, 2, 9 }, { 2, 2, 10 }, { 3, 2, 11 } } }
-    };
-
-    image_view<const float> I((const float*)IMG, 3, 4, 3);
-    for (int y = 0, i = 0; y < Y; ++y) {
-        for (int x = 0; x < X; ++x, ++i) {
-            OIIO_CHECK_EQUAL(I(x, y)[0], x);
-            OIIO_CHECK_EQUAL(I(x, y)[1], y);
-            OIIO_CHECK_EQUAL(I(x, y)[2], i);
-        }
-    }
-}
-
-
-
-void
-test_image_view_mutable()
-{
-    const int X = 4, Y = 3, C = 3, Z = 1;
-    static float IMG[Z][Y][X][C] = {
-        // 4x3 2D image with 3 channels
-        { { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } },
-          { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } },
-          { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } } }
-    };
-
-    image_view<float> I((float*)IMG, 3, 4, 3);
-    for (int y = 0, i = 0; y < Y; ++y) {
-        for (int x = 0; x < X; ++x, ++i) {
-            I(x, y)[0] = x;
-            I(x, y)[1] = y;
-            I(x, y)[2] = i;
-        }
-    }
-
-    for (int y = 0, i = 0; y < Y; ++y) {
-        for (int x = 0; x < X; ++x, ++i) {
-            OIIO_CHECK_EQUAL(I(x, y)[0], x);
-            OIIO_CHECK_EQUAL(I(x, y)[1], y);
-            OIIO_CHECK_EQUAL(I(x, y)[2], i);
-        }
-    }
-}
-
-
-
-void
 test_make_span()
 {
     print("testing make_span\n");
@@ -523,8 +469,6 @@ main(int /*argc*/, char* /*argv*/[])
     test_strided_ptr();
     test_span_strided();
     test_span_strided_mutable();
-    test_image_view();
-    test_image_view_mutable();
     test_make_span();
     test_as_bytes();
     test_span_cast();


### PR DESCRIPTION
* `image_span<T,Rank>` is a 2D-to-4D bounded span with byte-measured strides (describing data layout with dimensions for channel, x, y, z) for us to have future APIs deal with bounded+strided regions rather than YOLOing raw pointers.  Among other advantages, image_span will have robust bounds checking in debug builds. It also simplifies interfaces to pass a single image_span that encapsulates everything about an up-to-4D data layout, rather than needing to pass a long list of individual pointers, sizes, and strides.

* I've templated image_span on Rank, but default to Rank=4 and am using that version only in practice. The templating by rank allows future expansion to describe one scanline (rank 2) or 2D image plane (Rank 3) if we want to do so for certain API calls, but I'm not sure yet whether to bother with that, so for now, the ability to template by Rank is just flexibility for the future.

* Add image_span based versions of copy_image(), contiguize(), convert_pixel_values(), convert_image(), and parallel_convert_image() utilities. I added tests and benchmarks to verify their correctness and that they have similar performance to the pointer based versions.

* Deprecate image_view, which we did not ever use internally to OIIO or in its APIs. But since we published the headers, there's a chance it's used downstream and would be unwise to change its behavior or data layout. The new image_span is what we will use moving forward so that we are free to modify it and start with a fresh slate. Keeping the definition/header for now, but marking it with a deprecation warning.
