### PR TITLE
feat(raw): add raw:ForceLoad hint

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2228,7 +2228,12 @@ options are supported:
      - Maximum memory allocation for processing of raw images. Stop processing if
        raw buffer size grows larger than that value (in megabytes).
        (Default: 2048)
-
+   * - ``raw:ForceLoad``
+     - int
+     - If 1, forces libraw to decompress and process the image during
+       initialization. This populates the image attributes which depend on the
+       pixel values.
+       (Default: 0)
 
 |
 


### PR DESCRIPTION

## Description

The raw input plugin populates the attributes in the ImageSpec from the libraw structures in the RawInput::open_raw() method. That is done before the actual image data being decompressed on demand in RawInput::read_native_scanline(). Libraw re-calculates some values after the pixels get available, it is impossible to access those, as the ImageBuf's spec does not get updated, and the updated ImageSpec is not available from outside of RawInput when/after the pixels are being processed.

An example: the initial values for the white balancing weights get populated from the image file metadata, those get copied into the ImageSpec. If the libraw was configured to white balance by averaging the pixels of the whole image or a region, the white balancing weights would get re-calculated by libraw after processing the pixels, but the updated numbers are impossible to access from outside of the RawInput plugin.

This change adds a hint "raw:ForceLoad", which, if set to 1, forces libraw to decompress and process the image in RawInput::open_raw(), so the image attributes returned from that method would contain the final values.

I am not certain if this is the best way to achieve what I needed. I have also looked into making the ImageBuf retain the ImageInput object instead of spawning multiple transient objects, but that seemed too complicated.

## Tests

I have not added any unit tests, not sure how to approach that. I have tested that the image does not get decompressed multiple times in a bunch of scenarios. 


## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
