### PR TITLE
oiiotool: -i:native=1, fix --native behavior, fix convert datatype

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1180,8 +1180,13 @@ Reading images
 
     Optional appended modifiers include:
 
+      `:native=` *int*
+        If nonzero, read the image in as close as possible to its "native"
+        format, versus oiiotool's default of converting all images to float
+        internally. This also turns on "now". (Added in release 3.0.6.0.)
       `:now=` *int*
-        If 1, read the image now, before proceeding to the next command.
+        If nonzero, read the image now, before proceeding to the next command
+        (bypassing the ImageCache, even for big images).
       `:autocc=` *int*
         Enable or disable `--autocc` for this input image (the default is to use
         the global setting).

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -335,8 +335,16 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
                 if (m_input_dataformat != ib->nativespec().format)
                     m_subimages[s].m_was_direct_read = false;
                 forceread = true;
-            } else if (readpolicy & ReadNative)
-                convert = ib->nativespec().format;
+            } else if (readpolicy & ReadNative) {
+                if (channel_set.size()) {
+                    convert = TypeUnknown;
+                    for (int c = chbegin; c < chend; ++c)
+                        convert = TypeDesc::basetype_merge(
+                            convert, ib->nativespec().channelformat(c));
+                } else {
+                    convert = ib->nativespec().format;
+                }
+            }
             if (!forceread && convert != TypeDesc::UINT8
                 && convert != TypeDesc::UINT16 && convert != TypeDesc::HALF
                 && convert != TypeDesc::FLOAT) {


### PR DESCRIPTION
A constellation of closely related fixes and additions related to oiiotool `-i` behavior:

* When using `-i:now=1` to force for immediate read rather than using an ImageCache, it would "forget" any prior setting of `--native`. This is fixed now to correctly combine desire for bypassing the cache with hinting to maintain native data type.

* When restricting channel subset with `-i:ch=...`, use of the `--native` flag was incorrect in some cases -- it would use the overall best single data format of all channels, rather than restricting that to the selected channel range. So, for example, if you said `-i:ch=R,G,B,A` and those channels were all `half`, but channel 17 (not selected) was `float`, you would get a conversion to float rather than keeping the selected channels at their native half. The solution here is that the type chosen for `--native` behavior should only consider the selected channel subset, not all channels.

* Add a new `-i` modifier: `:native=1`, allowing you to select the "native" behavior on a per-input-file basis (the existing `--native` command sets the default).
