### PR TITLE
build: Fix broken OIIO_SITE customization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,11 @@ message(STATUS "Joint namespace PROJ_NAMESPACE_V:       ${PROJ_NAMESPACE_V}")
 # defined for downstream projects using OIIO.
 add_compile_definitions (OIIO_INTERNAL=1)
 
+# If CMake variable OIIO_SITE is set, set compile symbol OIIO_SITE_sitename
+if (OIIO_SITE)
+    add_compile_definitions (OIIO_SITE_${OIIO_SITE})
+endif ()
+
 include (GNUInstallDirs)
 
 # Utilities for build instructions of the format-reading plugins
@@ -253,13 +258,6 @@ set (format_plugin_libs "")
 set (format_plugin_include_dirs "")
 set (format_plugin_definitions "")
 file (GLOB all_format_plugin_dirs src/*.imageio)
-if ("${OIIO_SITE}" STREQUAL "SPI")
-    # SPI only -- because of a workaround for a very weird linkage issue
-    # specific to our system, we need to be sure libtiff is referenced first.
-    file (GLOB tiff_format_plugin_dir src/tiff.imageio)
-    list (REMOVE_ITEM all_format_plugin_dirs ${tiff_format_plugin_dir})
-    list (INSERT all_format_plugin_dirs 0 ${tiff_format_plugin_dir})
-endif ()
 if (EMBEDPLUGINS AND NOT BUILD_OIIOUTIL_ONLY)
     foreach (plugin_dir ${all_format_plugin_dirs})
         add_subdirectory (${plugin_dir})


### PR DESCRIPTION
Somewhere along the road to 3.0, the build files changed in such a way that OIIO_SITE was not correctly passed down to C++ symbols, and some SPI-specific (sorry) color space handling was inadvertently disabled as a result. This restores things to the way it was in 2.5, and should not affect anybody else.

Also eliminate some old SPI-specific code that's no longer needed (and clearly hasn't been needed for a long time, because we had been naming the site "spi" but testing "SPI", and no problems were evident with skipping that ancient code).
