### PR TITLE
simd.h: address compiler warnings

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -602,7 +602,7 @@ inline bool cpu_has_avx512f() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<16)) !
 inline bool cpu_has_avx512dq() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<17)) != 0; }
 inline bool cpu_has_avx512ifma() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<21)) != 0; }
 inline bool cpu_has_avx512pf() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<26)) != 0; }
-inline bool cpu_has_avx512er() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<27)) != 0; }
+inline bool cpu_has_avx512er() { return false; /* knights landing only */ }
 inline bool cpu_has_avx512cd() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<28)) != 0; }
 inline bool cpu_has_avx512bw() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<30)) != 0; }
 inline bool cpu_has_avx512vl() {int i[4]; cpuid(i,7,0); return (i[1] & (0x80000000 /*1<<31*/)) != 0; }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -170,7 +170,6 @@ hw_simd_caps()
     if (cpu_has_avx512dq())    caps.emplace_back ("avx512dq");
     if (cpu_has_avx512ifma())  caps.emplace_back ("avx512ifma");
     if (cpu_has_avx512pf())    caps.emplace_back ("avx512pf");
-    if (cpu_has_avx512er())    caps.emplace_back ("avx512er");
     if (cpu_has_avx512cd())    caps.emplace_back ("avx512cd");
     if (cpu_has_avx512bw())    caps.emplace_back ("avx512bw");
     if (cpu_has_avx512vl())    caps.emplace_back ("avx512vl");
@@ -202,7 +201,6 @@ oiio_simd_caps()
     if (OIIO_AVX512DQ_ENABLED)   caps.emplace_back ("avx512dq");
     if (OIIO_AVX512IFMA_ENABLED) caps.emplace_back ("avx512ifma");
     if (OIIO_AVX512PF_ENABLED)   caps.emplace_back ("avx512pf");
-    if (OIIO_AVX512ER_ENABLED)   caps.emplace_back ("avx512er");
     if (OIIO_AVX512CD_ENABLED)   caps.emplace_back ("avx512cd");
     if (OIIO_AVX512BW_ENABLED)   caps.emplace_back ("avx512bw");
     if (OIIO_AVX512VL_ENABLED)   caps.emplace_back ("avx512vl");


### PR DESCRIPTION
* We passed a bad flag to _mm512_cvtps_ph intrinsics because of what I can only imagine was a bad cut-and-paste years ago. (Harmless because it set bits never used, but a warning on Windows.)

* Remove clauses for AVX512-EL, I'm not sure why they were there, because those instructions were only for "Knights Landing" which was never made available to the general public and has been discontinued. It must be that years ago, I got a little overzealous with the SIMD intrinsics.
