### PR TITLE
api!: add image_span versions of ImageOutput methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.18.2...4.0)
 
-set (OpenImageIO_VERSION "3.1.1.0")
+set (OpenImageIO_VERSION "3.1.2.0")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OpenImageIO_VERSION_OVERRIDE)

--- a/src/include/OpenImageIO/image_span.h
+++ b/src/include/OpenImageIO/image_span.h
@@ -365,7 +365,7 @@ template<typename T> using image1d_span = image_span<T, 2>;
 /// covering the same range of memory.
 template<typename T, size_t Rank>
 image_span<const std::byte>
-as_image_span_bytes(image_span<T, Rank> src) noexcept
+as_image_span_bytes(const image_span<T, Rank>& src) noexcept
 {
     return image_span<const std::byte>(
         reinterpret_cast<const std::byte*>(src.data()), src.nchannels(),
@@ -378,7 +378,7 @@ as_image_span_bytes(image_span<T, Rank> src) noexcept
 /// the same range of memory.
 template<typename T, size_t Rank>
 image_span<std::byte>
-as_image_span_writable_bytes(image_span<T, Rank> src) noexcept
+as_image_span_writable_bytes(const image_span<T, Rank>& src) noexcept
 {
     return image_span<std::byte>(reinterpret_cast<std::byte*>(src.data()),
                                  src.nchannels(), src.width(), src.height(),

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2246,14 +2246,16 @@ public:
     ///
     /// * There is a base case that takes a `image_span<byte>` describing
     ///   untyped memory layout and a `TypeDesc` describing the data type
-    ///   that the values should be converted to (or TypeUnknown to keep
-    ///   the data in its "native" file types with no conversion).
+    ///   that the values should be converted from (or TypeUnknown to
+    ///   indicate that the data is already in its "native" file types with
+    ///   no conversion needed).
     ///
-    /// * The type-aware versions that accept an `image_span<T>` and
-    ///   understand to convert the data into the approprate `T` type.
+    /// * The type-aware versions that accept an `image_span<T>` (for
+    ///   optionally non-contiguous data) or `span<T>` (for contiguous data)
+    ///   and understand to convert the data from the given `T` type.
     ///
     /// * The image_span (in either case) includes the memory bounds and
-    ///   stride lengths (in bytes) between channels, scanlines, and
+    ///   stride lengths (in bytes) between channels, pixels, scanlines, and
     ///   volumetric slices.
     ///
     /// * Any *range* parameters (such as `ybegin` and `yend`) describe a
@@ -2288,8 +2290,8 @@ public:
     ///                     that `data`'s memory contains. Use `TypeUnknown`
     ///                     to indicate that the data is already in the native
     ///                     format and needs no type conversion.
-    /// @param  data        An `image_span<T>` describing the memory extent
-    ///                     of the data buffer and including the sizes and
+    /// @param  data        An `image_span<const byte>` describing the memory
+    ///                     extent of the data buffer and including the sizes
     ///                     and byte strides for each dimension (channel, x,
     ///                     y, and z).
     /// @returns            `true` upon success, or `false` upon failure.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2330,6 +2330,9 @@ public:
     /// The image_span must have a width equal to a full scanline width,
     /// and its height and depth must be 1.
     ///
+    /// Added in OIIO 3.1, this is the "safe" preferred alternative to
+    /// the version of write_scanline that takes raw pointers.
+    ///
     /// @param  y           The y coordinate of the scanline.
     /// @param  format      A TypeDesc describing the type of the pixel data
     ///                     that `data`'s memory contains. Use `TypeUnknown`
@@ -2375,6 +2378,9 @@ public:
     ///
     /// The image_span must have a width equal to a full scanline width,
     /// and its height must be yend - ybegin.
+    ///
+    /// Added in OIIO 3.1, this is the "safe" preferred alternative to
+    /// the version of write_scanlines that takes raw pointers.
     ///
     /// @param  ybegin/yend The y range of the scanlines being passed.
     /// @param  format      A TypeDesc describing the type of the pixel data
@@ -2424,7 +2430,7 @@ public:
     /// left corner) pixel of a tile.
     ///
     /// Added in OIIO 3.1, this is the "safe" preferred alternative to
-    /// the version of write_image that takes raw pointers.
+    /// the version of write_tile that takes raw pointers.
     ///
     /// @param  x/y/z       The x range of the pixels being passed.
     /// @param  ybegin/yend The y range of the pixels being passed.
@@ -2438,6 +2444,9 @@ public:
     ///                     including its sizes and byte strides for each
     ///                     dimension (channel, x, y, z).
     /// @returns            `true` upon success, or `false` upon failure.
+    ///
+    /// Added in OIIO 3.1, this is the "safe" preferred alternative to
+    /// the version of write_tile that takes raw pointers.
     ///
     virtual bool write_tile(int x, int y, int z, TypeDesc format,
                             const image_span<const std::byte>& data);
@@ -2476,7 +2485,7 @@ public:
     /// coordinates must be at tile or image boundaries.
     ///
     /// Added in OIIO 3.1, this is the "safe" preferred alternative to
-    /// the version of write_image that takes raw pointers.
+    /// the version of write_tiles that takes raw pointers.
     ///
     /// @param  xbegin/xend The x range of the pixels being passed.
     /// @param  ybegin/yend The y range of the pixels being passed.
@@ -2533,7 +2542,7 @@ public:
     /// `supports("rectangles")`.
     ///
     /// Added in OIIO 3.1, this is the "safe" preferred alternative to
-    /// the version of write_image that takes raw pointers.
+    /// the version of write_rectangle that takes raw pointers.
     ///
     /// @param  xbegin/xend The x range of the pixels being passed.
     /// @param  ybegin/yend The y range of the pixels being passed.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2321,8 +2321,8 @@ public:
         return write_image(ispan);
     }
 
-    /// Write one scanline that include pixels (*,y,z) from `data`, which is
-    /// an `image_span` of un-typed bytes incorporating its bounded dimensions
+    /// Write one scanline that include pixels (*,y) from `data`, which is an
+    /// `image_span` of un-typed bytes incorporating its bounded dimensions
     /// and strides. The data type is given explicity by the `format`
     /// argument, and will be automatically converted to the type being stored
     /// in the file.
@@ -2330,7 +2330,7 @@ public:
     /// The image_span must have a width equal to a full scanline width,
     /// and its height and depth must be 1.
     ///
-    /// @param  y/z         The y & z coordinates of the scanline.
+    /// @param  y           The y coordinate of the scanline.
     /// @param  format      A TypeDesc describing the type of the pixel data
     ///                     that `data`'s memory contains. Use `TypeUnknown`
     ///                     to indicate that the data is already in the native
@@ -2340,34 +2340,31 @@ public:
     ///                     dimension (channel, x, y, z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_scanline(int y, int z, TypeDesc format,
+    virtual bool write_scanline(int y, TypeDesc format,
                                 const image_span<const std::byte>& data);
 
     /// A version of `write_scanline()` taking an `image_span<T>`, where the
     /// type of the underlying data is `T`.  This is a convenience wrapper
     /// around the `write_scanline()` that takes an `image_span<const
     /// std::byte>`.
-    template<typename T>
-    bool write_scanline(int y, int z, const image_span<T>& data)
+    template<typename T> bool write_scanline(int y, const image_span<T>& data)
     {
         // reduce to type + image_span<byte>
-        return write_scanline(y, z, TypeDescFromC<T>::value(),
+        return write_scanline(y, TypeDescFromC<T>::value(),
                               as_image_span_bytes(data));
     }
 
     /// A version of `write_scanline()` taking a `cspan<T>`, which assumes
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_scanline()` that takes an `image_span<const T>`.
-    template<typename T> bool write_scanline(int y, int z, span<T> data)
+    template<typename T> bool write_scanline(int y, span<T> data)
     {
         // reduce to type + image_span<byte>
-        auto isize = m_spec.image_bytes(TypeDescFromC<T>::value());
-        return write_scanline(y, z,
-                              image_span<T>(data.data(), m_spec.nchannels,
-                                            m_spec.width, 1, 1));
+        return write_scanline(y, image_span<T>(data.data(), m_spec.nchannels,
+                                               m_spec.width, 1, 1));
     }
 
-    /// Write multiple scanlines that include pixels (*,y,z) for all `ybegin
+    /// Write multiple scanlines that include pixels (*,y) for all `ybegin
     /// <= y < yend`, from `data`, which is an `image_span` of un-typed bytes
     /// incorporating its bounded dimensions and strides. The data type is
     /// given explicity by the `format` argument, and will be automatically
@@ -2380,7 +2377,6 @@ public:
     /// and its height must be yend - ybegin.
     ///
     /// @param  ybegin/yend The y range of the scanlines being passed.
-    /// @param  z           The z coordinate of the scanline.
     /// @param  format      A TypeDesc describing the type of the pixel data
     ///                     that `data`'s memory contains. Use `TypeUnknown`
     ///                     to indicate that the data is already in the native
@@ -2390,7 +2386,7 @@ public:
     ///                     dimension (channel, x, y, z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_scanlines(int ybegin, int yend, int z, TypeDesc format,
+    virtual bool write_scanlines(int ybegin, int yend, TypeDesc format,
                                  const image_span<const std::byte>& data);
 
     /// A version of `write_scanlines()` taking an `image_span<T>`, where the
@@ -2398,10 +2394,10 @@ public:
     /// around the `write_scanlines()` that takes an `image_span<const
     /// std::byte>`.
     template<typename T>
-    bool write_scanlines(int ybegin, int yend, int z, const image_span<T>& data)
+    bool write_scanlines(int ybegin, int yend, const image_span<T>& data)
     {
         // image_span<T>: reduces to type + byte_buffer
-        return write_scanlines(ybegin, yend, z, TypeDescFromC<T>::value(),
+        return write_scanlines(ybegin, yend, TypeDescFromC<T>::value(),
                                data.as_image_span_bytes());
     }
 
@@ -2409,13 +2405,13 @@ public:
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_scanlines()` that takes an `image_span<const T>`.
     template<typename T>
-    bool write_scanlines(int ybegin, int yend, int z, span<T> data)
+    bool write_scanlines(int ybegin, int yend, span<T> data)
     {
         auto ispan = image_span<T>(data.data(), m_spec.nchannels, m_spec.width,
                                    yend - ybegin, 1);
         OIIO_DASSERT(data.size_bytes() == ispan.size_bytes()
                      && ispan.is_contiguous());
-        return write_scanlines(ybegin, yend, z, ispan);
+        return write_scanlines(ybegin, yend, ispan);
     }
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2346,8 +2346,7 @@ public:
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_scanlines()` that takes an `image_span<const T>`.
     template<typename T>
-    bool write_scanlines(int ybegin, int yend, int z, TypeDesc format,
-                         span<T> data)
+    bool write_scanlines(int ybegin, int yend, int z, span<T> data)
     {
         auto ispan = image_span<T>(data.data(), m_spec.nchannels, m_spec.width,
                                    yend - ybegin, 1);

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2296,12 +2296,13 @@ public:
     ///                     y, and z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_image(TypeDesc format, image_span<const std::byte> data);
+    virtual bool write_image(TypeDesc format,
+                             const image_span<const std::byte>& data);
 
     /// A version of `write_image()` taking an `image_span<T>`, where the type
     /// of the underlying data is `T`.  This is a convenience wrapper around
     /// the `write_image()` that takes an `image_span<const std::byte>`.
-    template<typename T> bool write_image(image_span<T> data)
+    template<typename T> bool write_image(const image_span<T>& data)
     {
         return write_image(TypeDescFromC<T>::value(),
                            as_image_span_bytes(data));
@@ -2340,13 +2341,14 @@ public:
     /// @returns            `true` upon success, or `false` upon failure.
     ///
     virtual bool write_scanline(int y, int z, TypeDesc format,
-                                image_span<const std::byte> data);
+                                const image_span<const std::byte>& data);
 
     /// A version of `write_scanline()` taking an `image_span<T>`, where the
     /// type of the underlying data is `T`.  This is a convenience wrapper
     /// around the `write_scanline()` that takes an `image_span<const
     /// std::byte>`.
-    template<typename T> bool write_scanline(int y, int z, image_span<T> data)
+    template<typename T>
+    bool write_scanline(int y, int z, const image_span<T>& data)
     {
         // reduce to type + image_span<byte>
         return write_scanline(y, z, TypeDescFromC<T>::value(),
@@ -2389,14 +2391,14 @@ public:
     /// @returns            `true` upon success, or `false` upon failure.
     ///
     virtual bool write_scanlines(int ybegin, int yend, int z, TypeDesc format,
-                                 image_span<const std::byte> data);
+                                 const image_span<const std::byte>& data);
 
     /// A version of `write_scanlines()` taking an `image_span<T>`, where the
     /// type of the underlying data is `T`.  This is a convenience wrapper
     /// around the `write_scanlines()` that takes an `image_span<const
     /// std::byte>`.
     template<typename T>
-    bool write_scanlines(int ybegin, int yend, int z, image_span<T> data)
+    bool write_scanlines(int ybegin, int yend, int z, const image_span<T>& data)
     {
         // image_span<T>: reduces to type + byte_buffer
         return write_scanlines(ybegin, yend, z, TypeDescFromC<T>::value(),
@@ -2442,13 +2444,13 @@ public:
     /// @returns            `true` upon success, or `false` upon failure.
     ///
     virtual bool write_tile(int x, int y, int z, TypeDesc format,
-                            image_span<const std::byte> data);
+                            const image_span<const std::byte>& data);
 
     /// A version of `write_tile()` taking an `image_span<T>`, where the type
     /// of the underlying data is `T`.  This is a convenience wrapper around
     /// the `write_tile()` that takes an `image_span<const std::byte>`.
     template<typename T>
-    bool write_tile(int x, int y, int z, image_span<T> data)
+    bool write_tile(int x, int y, int z, const image_span<T>& data)
     {
         return write_tile(x, y, z, TypeDescFromC<T>::value(),
                           as_image_span_bytes(data));
@@ -2495,14 +2497,14 @@ public:
     ///
     virtual bool write_tiles(int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, TypeDesc format,
-                             image_span<const std::byte> data);
+                             const image_span<const std::byte>& data);
 
     /// A version of `write_tiles()` taking an `image_span<T>`, where the type
     /// of the underlying data is `T`.  This is a convenience wrapper around
     /// the `write_tiles()` that takes an `image_span<const std::byte>`.
     template<typename T>
     bool write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
-                     int zend, image_span<T> data)
+                     int zend, const image_span<T>& data)
     {
         return write_tiles(xbegin, xend, ybegin, yend, zbegin, zend,
                            TypeDescFromC<T>::value(),
@@ -2550,7 +2552,7 @@ public:
     ///
     virtual bool write_rectangle(int xbegin, int xend, int ybegin, int yend,
                                  int zbegin, int zend, TypeDesc format,
-                                 image_span<const std::byte> data);
+                                 const image_span<const std::byte>& data);
 
     /// A version of `write_rectangle()` taking an `image_span<T>`, where the
     /// type of the underlying data is `T`.  This is a convenience wrapper
@@ -2558,7 +2560,7 @@ public:
     /// std::byte>`.
     template<typename T>
     bool write_rectangle(int xbegin, int xend, int ybegin, int yend, int zbegin,
-                         int zend, image_span<T> data)
+                         int zend, const image_span<T>& data)
     {
         return write_rectangle(xbegin, xend, ybegin, yend, zbegin, zend,
                                TypeDescFromC<T>::value(),
@@ -3141,7 +3143,7 @@ protected:
     /// the pixels to the right position in the dither pattern.
     template<typename T>
     cspan<std::byte> to_native(int xbegin, int xend, int ybegin, int yend,
-                               int zbegin, int zend, image_span<T> data,
+                               int zbegin, int zend, const image_span<T>& data,
                                std::vector<unsigned char>& scratch,
                                unsigned int dither = 0, int xorigin = 0,
                                int yorigin = 0, int zorigin = 0)
@@ -3158,7 +3160,7 @@ protected:
     /// `format` and an image_span of generic (std::byte) data.
     cspan<std::byte> to_native(int xbegin, int xend, int ybegin, int yend,
                                int zbegin, int zend, TypeDesc format,
-                               image_span<const std::byte> data,
+                               const image_span<const std::byte>& data,
                                std::vector<unsigned char>& scratch,
                                unsigned int dither = 0, int xorigin = 0,
                                int yorigin = 0, int zorigin = 0);
@@ -3856,7 +3858,7 @@ OIIO_API bool convert_image (int nchannels, int width, int height, int depth,
 /// Return true if ok, false if it didn't know how to do the conversion.
 template<typename SrcType, typename DstType>
 bool
-convert_image(image_span<SrcType> src, image_span<DstType> dst)
+convert_image(const image_span<SrcType>& src, const image_span<DstType>& dst)
 {
     // For now, just implement by wrapping the pointer-based version.
     OIIO_DASSERT(src.nchannels() == dst.nchannels()
@@ -3876,8 +3878,8 @@ convert_image(image_span<SrcType> src, image_span<DstType> dst)
 /// `TypeDesc`, and the spans are untyped bytes that provide the dimensions
 /// and memory layout.
 inline bool
-convert_image(image_span<const std::byte> src, TypeDesc src_type,
-              image_span<std::byte> dst, TypeDesc dst_type)
+convert_image(const image_span<const std::byte>& src, TypeDesc src_type,
+              const image_span<std::byte>& dst, TypeDesc dst_type)
 {
     // For now, just implement by wrapping the pointer-based version.
     OIIO_DASSERT(src.nchannels() == dst.nchannels()
@@ -3908,8 +3910,8 @@ OIIO_API bool parallel_convert_image (
 /// threads. The data types are taken from the spans.
 template<typename SrcType, typename DstType>
 bool
-parallel_convert_image(image_span<SrcType> src, image_span<DstType> dst,
-                       int nthreads = 0)
+parallel_convert_image(const image_span<SrcType>& src,
+                       const image_span<DstType>& dst, int nthreads = 0)
 {
     // For now, just implement by wrapping the pointer-based version.
     OIIO_DASSERT(src.nchannels() == dst.nchannels()
@@ -3927,9 +3929,9 @@ parallel_convert_image(image_span<SrcType> src, image_span<DstType> dst,
 /// threads. The data types are passed as `TypeDesc`, and the spans are
 /// untyped bytes that provide the dimensions and memory layout.
 inline bool
-parallel_convert_image(image_span<const std::byte> src, TypeDesc src_type,
-                       image_span<std::byte> dst, TypeDesc dst_type,
-                       int nthreads = 0)
+parallel_convert_image(const image_span<const std::byte>& src,
+                       TypeDesc src_type, const image_span<std::byte>& dst,
+                       TypeDesc dst_type, int nthreads = 0)
 {
     // For now, just implement by wrapping the pointer-based version.
     OIIO_DASSERT(src.nchannels() == dst.nchannels()
@@ -3995,7 +3997,8 @@ OIIO_API bool copy_image (int nchannels, int width, int height, int depth,
 /// strides. Return true if ok, false if it couldn't do it. (Reserved for
 /// future use; currently is always succeeds)
 template<typename D, size_t Drank, typename S, size_t Srank>
-bool copy_image(image_span<D, Drank> dst, image_span<S, Srank> src)
+bool copy_image(const image_span<D, Drank>& dst,
+                const image_span<S, Srank>& src)
 {
     // Arbitrary types are handled by just converting to generic byte
     // image_spans.
@@ -4005,7 +4008,8 @@ bool copy_image(image_span<D, Drank> dst, image_span<S, Srank> src)
 
 /// copy_image base case: generic span of bytes.
 OIIO_API bool
-copy_image(image_span<std::byte> dst, image_span<const std::byte> src);
+copy_image(const image_span<std::byte> &dst,
+           const image_span<const std::byte>& src);
 
 
 

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -41,7 +41,8 @@ OIIO_NAMESPACE_BEGIN
 using span_size_t = size_t;
 using oiio_span_size_type = OIIO::span_size_t;  // back-compat alias
 
-inline constexpr span_size_t dynamic_extent = -1;
+inline constexpr span_size_t dynamic_extent
+    = std::numeric_limits<span_size_t>::max();
 
 
 
@@ -582,6 +583,18 @@ span<const std::byte>
 as_bytes_ref(const T& ref) noexcept
 {
     return make_cspan(reinterpret_cast<const std::byte*>(&ref), sizeof(T));
+}
+
+
+
+/// Copy the memory contents of `src` to `dst`. They must have the same
+/// total size.
+template<typename T, typename S>
+inline void
+spancpy(span<T> dst, span<S> src)
+{
+    OIIO_DASSERT(dst.size_bytes() == src.size_bytes());
+    memcpy(dst.data(), src.data(), src.size_bytes());
 }
 
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -394,44 +394,60 @@ inline constexpr TypeDesc TypeUstringhash(TypeDesc::USTRINGHASH);
 ///
 template<typename T> struct BaseTypeFromC {};
 template<> struct BaseTypeFromC<unsigned char> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT8; };
+template<> struct BaseTypeFromC<const unsigned char> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT8; };
 template<> struct BaseTypeFromC<char> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT8; };
+template<> struct BaseTypeFromC<const char> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT8; };
 template<> struct BaseTypeFromC<uint16_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT16; };
+template<> struct BaseTypeFromC<const uint16_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT16; };
 template<> struct BaseTypeFromC<int16_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT16; };
+template<> struct BaseTypeFromC<const int16_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT16; };
 template<> struct BaseTypeFromC<uint32_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT; };
+template<> struct BaseTypeFromC<const uint32_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT; };
 template<> struct BaseTypeFromC<int32_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT; };
+template<> struct BaseTypeFromC<const int32_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT; };
 template<> struct BaseTypeFromC<uint64_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT64; };
+template<> struct BaseTypeFromC<const uint64_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT64; };
 template<> struct BaseTypeFromC<int64_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT64; };
+template<> struct BaseTypeFromC<const int64_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT64; };
 #if defined(__GNUC__) && __WORDSIZE == 64 && !(defined(__APPLE__) && defined(__MACH__))
 // Some platforms consider int64_t and long long to be different types, even
 // though they are actually the same size.
 static_assert(!std::is_same_v<unsigned long long, uint64_t>);
 static_assert(!std::is_same_v<long long, int64_t>);
 template<> struct BaseTypeFromC<unsigned long long> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT64; };
+template<> struct BaseTypeFromC<const unsigned long long> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT64; };
 template<> struct BaseTypeFromC<long long> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT64; };
+template<> struct BaseTypeFromC<const long long> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT64; };
 #endif
 #if defined(_HALF_H_) || defined(IMATH_HALF_H_)
 template<> struct BaseTypeFromC<half> { static constexpr TypeDesc::BASETYPE value = TypeDesc::HALF; };
+template<> struct BaseTypeFromC<const half> { static constexpr TypeDesc::BASETYPE value = TypeDesc::HALF; };
 #endif
 template<> struct BaseTypeFromC<float> { static constexpr TypeDesc::BASETYPE value = TypeDesc::FLOAT; };
+template<> struct BaseTypeFromC<const float> { static constexpr TypeDesc::BASETYPE value = TypeDesc::FLOAT; };
 template<> struct BaseTypeFromC<double> { static constexpr TypeDesc::BASETYPE value = TypeDesc::DOUBLE; };
-template<> struct BaseTypeFromC<const char*> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
+template<> struct BaseTypeFromC<const double> { static constexpr TypeDesc::BASETYPE value = TypeDesc::DOUBLE; };
 template<> struct BaseTypeFromC<char*> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
+template<> struct BaseTypeFromC<const char*> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
 template<> struct BaseTypeFromC<std::string> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
+template<> struct BaseTypeFromC<const std::string> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
 template<> struct BaseTypeFromC<string_view> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
+template<> struct BaseTypeFromC<const string_view> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
 class ustring;
 template<> struct BaseTypeFromC<ustring> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
+template<> struct BaseTypeFromC<const ustring> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
 template<size_t S> struct BaseTypeFromC<char[S]> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
 template<size_t S> struct BaseTypeFromC<const char[S]> { static constexpr TypeDesc::BASETYPE value = TypeDesc::STRING; };
 template<typename P> struct BaseTypeFromC<P*> { static constexpr TypeDesc::BASETYPE value = TypeDesc::PTR; };
 
 /// `BaseTypeFromC_v<T>` is shorthand for `BaseTypeFromC<T>::value()`.
 template<typename T>
-constexpr TypeDesc::BASETYPE BaseTypeFromC_v = BaseTypeFromC<std::remove_cv_t<T>>::value();
+constexpr TypeDesc::BASETYPE BaseTypeFromC_v = BaseTypeFromC<std::remove_cv_t<T>>::value;
 
 /// A template mechanism for getting the TypeDesc from a C type.
 /// The default for simple types is just the TypeDesc based on BaseTypeFromC.
 /// But we can specialize more complex types.
-template<typename T> struct TypeDescFromC { static const constexpr TypeDesc value() { return TypeDesc(BaseTypeFromC<T>::value); } };
+template<typename T> struct TypeDescFromC { static const constexpr TypeDesc value() { return TypeDesc(BaseTypeFromC_v<T>); } };
 template<> struct TypeDescFromC<int32_t> { static const constexpr TypeDesc value() { return TypeDesc::INT32; } };
 template<> struct TypeDescFromC<uint32_t> { static const constexpr TypeDesc value() { return TypeDesc::UINT32; } };
 template<> struct TypeDescFromC<int16_t> { static const constexpr TypeDesc value() { return TypeDesc::INT16; } };

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -89,7 +89,7 @@ get_default_quantize(TypeDesc format, long long& quant_min,
 /// which is either dst or src (if the strides indicated that data were
 /// already contiguous).
 OIIO_API span<const std::byte>
-contiguize(image_span<const std::byte> src, span<std::byte> dst);
+contiguize(const image_span<const std::byte>& src, span<std::byte> dst);
 
 /// Turn potentially non-contiguous-stride data (e.g. "RGBxRGBx") into
 /// contiguous-stride ("RGBRGB"), for any format or stride values

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -734,7 +734,7 @@ _contiguize(const T* src, int nchannels, stride_t xstride, stride_t ystride,
 
 
 span<const std::byte>
-pvt::contiguize(image_span<const std::byte> src, span<std::byte> dst)
+pvt::contiguize(const image_span<const std::byte>& src, span<std::byte> dst)
 {
     // Contiguized result must fit in dst
     OIIO_DASSERT(src.size_bytes() <= dst.size_bytes());
@@ -1053,7 +1053,8 @@ copy_image(int nchannels, int width, int height, int depth, const void* src,
 
 template<typename T>
 void
-aligned_copy_image(image_span<std::byte> dst, image_span<const std::byte> src)
+aligned_copy_image(const image_span<std::byte>& dst,
+                   const image_span<const std::byte>& src)
 {
     size_t systride  = src.ystride();
     size_t dystride  = dst.ystride();
@@ -1081,7 +1082,8 @@ aligned_copy_image(image_span<std::byte> dst, image_span<const std::byte> src)
 
 
 bool
-copy_image(image_span<std::byte> dst, image_span<const std::byte> src)
+copy_image(const image_span<std::byte>& dst,
+           const image_span<const std::byte>& src)
 {
     OIIO_DASSERT(src.width() == dst.width() && src.height() == dst.height()
                  && src.depth() == dst.depth()

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -684,11 +684,10 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
 bool
 ImageOutput::write_image(TypeDesc format, image_span<const std::byte> data)
 {
-    size_t sz = m_spec.image_bytes(/*native=*/ format == TypeUnknown);
+    size_t sz = m_spec.image_bytes(/*native=*/format == TypeUnknown);
     if (sz != data.size_bytes()) {
-        errorfmt(
-            "write_image: Buffer size is incorrect ({} bytes vs {} needed)",
-            sz, data.size_bytes());
+        errorfmt("write_image: Buffer size is incorrect ({} bytes vs {} needed)",
+                 sz, data.size_bytes());
         return false;
     }
 

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -112,7 +112,7 @@ ImageOutput::write_scanline(int /*y*/, int /*z*/, TypeDesc /*format*/,
 
 bool
 ImageOutput::write_scanline(int y, int z, TypeDesc format,
-                            image_span<const std::byte> data)
+                            const image_span<const std::byte>& data)
 {
     size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
                                        : format.size() * m_spec.nchannels)
@@ -154,7 +154,7 @@ ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
 bool
 ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
-                             image_span<const std::byte> data)
+                             const image_span<const std::byte>& data)
 {
     size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
                                        : format.size() * m_spec.nchannels)
@@ -186,7 +186,7 @@ ImageOutput::write_tile(int /*x*/, int /*y*/, int /*z*/, TypeDesc /*format*/,
 
 bool
 ImageOutput::write_tile(int x, int y, int z, TypeDesc format,
-                        image_span<const std::byte> data)
+                        const image_span<const std::byte>& data)
 {
     size_t sz = format == TypeUnknown
                     ? m_spec.pixel_bytes(true /*native*/)
@@ -267,7 +267,7 @@ ImageOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
 bool
 ImageOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
                          int zend, TypeDesc format,
-                         image_span<const std::byte> data)
+                         const image_span<const std::byte>& data)
 {
     // Default implementation (for now): call the old pointer+stride
     return write_tiles(xbegin, xend, ybegin, yend, zbegin, zend, format,
@@ -293,7 +293,7 @@ bool
 ImageOutput::write_rectangle(int /*xbegin*/, int /*xend*/, int /*ybegin*/,
                              int /*yend*/, int /*zbegin*/, int /*zend*/,
                              TypeDesc /*format*/,
-                             image_span<const std::byte> /*data*/)
+                             const image_span<const std::byte>& /*data*/)
 {
     return false;
 }
@@ -570,7 +570,7 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
 cspan<std::byte>
 ImageOutput::to_native(int xbegin, int xend, int ybegin, int yend, int zbegin,
                        int zend, TypeDesc format,
-                       image_span<const std::byte> data,
+                       const image_span<const std::byte>& data,
                        std::vector<unsigned char>& scratch, unsigned int dither,
                        int xorigin, int yorigin, int zorigin)
 {
@@ -682,7 +682,8 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
 
 
 bool
-ImageOutput::write_image(TypeDesc format, image_span<const std::byte> data)
+ImageOutput::write_image(TypeDesc format,
+                         const image_span<const std::byte>& data)
 {
     size_t sz = m_spec.image_bytes(/*native=*/format == TypeUnknown);
     if (sz != data.size_bytes()) {

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -111,6 +111,32 @@ ImageOutput::write_scanline(int /*y*/, int /*z*/, TypeDesc /*format*/,
 
 
 bool
+ImageOutput::write_scanline(int y, int z, TypeDesc format,
+                            image_span<const std::byte> data)
+{
+    if (pvt::oiio_print_debug
+#ifndef NDEBUG
+        || true
+#endif
+    ) {
+        size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
+                                           : format.size() * m_spec.nchannels)
+                    * size_t(m_spec.width);
+        if (sz != data.size_bytes()) {
+            errorfmt(
+                "write_scanline: Buffer size is incorrect ({} bytes vs {} needed)",
+                sz, data.size_bytes());
+            return false;
+        }
+    }
+
+    // Default implementation (for now): call the old pointer+stride
+    return write_scanline(y, z, format, data.data(), data.xstride());
+}
+
+
+
+bool
 ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
                              const void* data, stride_t xstride,
                              stride_t ystride)
@@ -133,12 +159,67 @@ ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
 
 bool
+ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
+                             image_span<const std::byte> data)
+{
+    if (pvt::oiio_print_debug
+#ifndef NDEBUG
+        || true
+#endif
+    ) {
+        size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
+                                           : format.size() * m_spec.nchannels)
+                    * size_t(yend - ybegin) * size_t(m_spec.width);
+        if (sz != data.size_bytes()) {
+            errorfmt(
+                "write_scanlines: Buffer size is incorrect ({} bytes vs {} needed)",
+                sz, data.size_bytes());
+            return false;
+        }
+    }
+
+    // Default implementation (for now): call the old pointer+stride
+    return write_scanlines(ybegin, yend, z, format, data.data(), data.xstride(),
+                           data.ystride());
+}
+
+
+
+bool
 ImageOutput::write_tile(int /*x*/, int /*y*/, int /*z*/, TypeDesc /*format*/,
                         const void* /*data*/, stride_t /*xstride*/,
                         stride_t /*ystride*/, stride_t /*zstride*/)
 {
     // Default implementation: don't know how to write tiles
     return false;
+}
+
+
+
+bool
+ImageOutput::write_tile(int x, int y, int z, TypeDesc format,
+                        image_span<const std::byte> data)
+{
+    if (pvt::oiio_print_debug
+#ifndef NDEBUG
+        || true
+#endif
+    ) {
+        size_t sz = format == TypeUnknown
+                        ? m_spec.pixel_bytes(true /*native*/)
+                        : m_spec.tile_pixels() * size_t(m_spec.nchannels)
+                              * format.size();
+        if (sz != data.size_bytes()) {
+            errorfmt(
+                "write_tile: Buffer size is incorrect ({} bytes vs {} needed)",
+                sz, data.size_bytes());
+            return false;
+        }
+    }
+
+    // Default implementation (for now): call the old pointer+stride
+    return write_tile(x, y, z, format, data.data(), data.xstride(),
+                      data.ystride(), data.zstride());
 }
 
 
@@ -203,11 +284,35 @@ ImageOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
 
 
 bool
+ImageOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                         int zend, TypeDesc format,
+                         image_span<const std::byte> data)
+{
+    // Default implementation (for now): call the old pointer+stride
+    return write_tiles(xbegin, xend, ybegin, yend, zbegin, zend, format,
+                       data.data(), data.xstride(), data.ystride(),
+                       data.zstride());
+}
+
+
+
+bool
 ImageOutput::write_rectangle(int /*xbegin*/, int /*xend*/, int /*ybegin*/,
                              int /*yend*/, int /*zbegin*/, int /*zend*/,
                              TypeDesc /*format*/, const void* /*data*/,
                              stride_t /*xstride*/, stride_t /*ystride*/,
                              stride_t /*zstride*/)
+{
+    return false;
+}
+
+
+
+bool
+ImageOutput::write_rectangle(int /*xbegin*/, int /*xend*/, int /*ybegin*/,
+                             int /*yend*/, int /*zbegin*/, int /*zend*/,
+                             TypeDesc /*format*/,
+                             image_span<const std::byte> /*data*/)
 {
     return false;
 }
@@ -481,6 +586,28 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
 
 
 
+cspan<std::byte>
+ImageOutput::to_native(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                       int zend, TypeDesc format,
+                       image_span<const std::byte> data,
+                       std::vector<unsigned char>& scratch, unsigned int dither,
+                       int xorigin, int yorigin, int zorigin)
+{
+    // Eventually, we will make a fully save, span-native implementation of
+    // this function. For now, we will just call the old version for the
+    // heavy lifting.
+    auto ptr = ImageOutput::to_native_rectangle(xbegin, xend, ybegin, yend,
+                                                zbegin, zend, format,
+                                                data.data(), data.xstride(),
+                                                data.ystride(), data.zstride(),
+                                                scratch, dither, xorigin,
+                                                yorigin, zorigin);
+    return cspan<std::byte>(reinterpret_cast<const std::byte*>(ptr),
+                            m_spec.pixel_bytes(true) * data.npixels());
+}
+
+
+
 bool
 ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
                          stride_t ystride, stride_t zstride,
@@ -569,6 +696,16 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
         progress_callback(progress_callback_data, 1.0f);
 
     return ok;
+}
+
+
+
+bool
+ImageOutput::write_image(TypeDesc format, image_span<const std::byte> data)
+{
+    // Default implementation (for now): call the old pointer+stride
+    return write_image(format, data.data(), data.xstride(), data.ystride(),
+                       data.zstride());
 }
 
 

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -684,6 +684,14 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
 bool
 ImageOutput::write_image(TypeDesc format, image_span<const std::byte> data)
 {
+    size_t sz = m_spec.image_bytes(/*native=*/ format == TypeUnknown);
+    if (sz != data.size_bytes()) {
+        errorfmt(
+            "write_image: Buffer size is incorrect ({} bytes vs {} needed)",
+            sz, data.size_bytes());
+        return false;
+    }
+
     // Default implementation (for now): call the old pointer+stride
     return write_image(format, data.data(), data.xstride(), data.ystride(),
                        data.zstride());

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -114,20 +114,14 @@ bool
 ImageOutput::write_scanline(int y, int z, TypeDesc format,
                             image_span<const std::byte> data)
 {
-    if (pvt::oiio_print_debug
-#ifndef NDEBUG
-        || true
-#endif
-    ) {
-        size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
-                                           : format.size() * m_spec.nchannels)
-                    * size_t(m_spec.width);
-        if (sz != data.size_bytes()) {
-            errorfmt(
-                "write_scanline: Buffer size is incorrect ({} bytes vs {} needed)",
-                sz, data.size_bytes());
-            return false;
-        }
+    size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
+                                       : format.size() * m_spec.nchannels)
+                * size_t(m_spec.width);
+    if (sz != data.size_bytes()) {
+        errorfmt(
+            "write_scanline: Buffer size is incorrect ({} bytes vs {} needed)",
+            sz, data.size_bytes());
+        return false;
     }
 
     // Default implementation (for now): call the old pointer+stride
@@ -162,20 +156,14 @@ bool
 ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
                              image_span<const std::byte> data)
 {
-    if (pvt::oiio_print_debug
-#ifndef NDEBUG
-        || true
-#endif
-    ) {
-        size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
-                                           : format.size() * m_spec.nchannels)
-                    * size_t(yend - ybegin) * size_t(m_spec.width);
-        if (sz != data.size_bytes()) {
-            errorfmt(
-                "write_scanlines: Buffer size is incorrect ({} bytes vs {} needed)",
-                sz, data.size_bytes());
-            return false;
-        }
+    size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
+                                       : format.size() * m_spec.nchannels)
+                * size_t(yend - ybegin) * size_t(m_spec.width);
+    if (sz != data.size_bytes()) {
+        errorfmt(
+            "write_scanlines: Buffer size is incorrect ({} bytes vs {} needed)",
+            sz, data.size_bytes());
+        return false;
     }
 
     // Default implementation (for now): call the old pointer+stride
@@ -200,21 +188,14 @@ bool
 ImageOutput::write_tile(int x, int y, int z, TypeDesc format,
                         image_span<const std::byte> data)
 {
-    if (pvt::oiio_print_debug
-#ifndef NDEBUG
-        || true
-#endif
-    ) {
-        size_t sz = format == TypeUnknown
-                        ? m_spec.pixel_bytes(true /*native*/)
-                        : m_spec.tile_pixels() * size_t(m_spec.nchannels)
-                              * format.size();
-        if (sz != data.size_bytes()) {
-            errorfmt(
-                "write_tile: Buffer size is incorrect ({} bytes vs {} needed)",
-                sz, data.size_bytes());
-            return false;
-        }
+    size_t sz = format == TypeUnknown
+                    ? m_spec.pixel_bytes(true /*native*/)
+                    : m_spec.tile_pixels() * size_t(m_spec.nchannels)
+                          * format.size();
+    if (sz != data.size_bytes()) {
+        errorfmt("write_tile: Buffer size is incorrect ({} bytes vs {} needed)",
+                 sz, data.size_bytes());
+        return false;
     }
 
     // Default implementation (for now): call the old pointer+stride
@@ -593,7 +574,7 @@ ImageOutput::to_native(int xbegin, int xend, int ybegin, int yend, int zbegin,
                        std::vector<unsigned char>& scratch, unsigned int dither,
                        int xorigin, int yorigin, int zorigin)
 {
-    // Eventually, we will make a fully save, span-native implementation of
+    // Eventually, we will make a fully safe, span-native implementation of
     // this function. For now, we will just call the old version for the
     // heavy lifting.
     auto ptr = ImageOutput::to_native_rectangle(xbegin, xend, ybegin, yend,

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -111,7 +111,7 @@ ImageOutput::write_scanline(int /*y*/, int /*z*/, TypeDesc /*format*/,
 
 
 bool
-ImageOutput::write_scanline(int y, int z, TypeDesc format,
+ImageOutput::write_scanline(int y, TypeDesc format,
                             const image_span<const std::byte>& data)
 {
     size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
@@ -125,7 +125,7 @@ ImageOutput::write_scanline(int y, int z, TypeDesc format,
     }
 
     // Default implementation (for now): call the old pointer+stride
-    return write_scanline(y, z, format, data.data(), data.xstride());
+    return write_scanline(y, 0, format, data.data(), data.xstride());
 }
 
 
@@ -153,7 +153,7 @@ ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
 
 bool
-ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
+ImageOutput::write_scanlines(int ybegin, int yend, TypeDesc format,
                              const image_span<const std::byte>& data)
 {
     size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
@@ -167,7 +167,7 @@ ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
     }
 
     // Default implementation (for now): call the old pointer+stride
-    return write_scanlines(ybegin, yend, z, format, data.data(), data.xstride(),
+    return write_scanlines(ybegin, yend, 0, format, data.data(), data.xstride(),
                            data.ystride());
 }
 

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -87,20 +87,52 @@ test_templates()
 {
     print("Testing templates\n");
     OIIO_CHECK_EQUAL(BaseTypeFromC<float>::value, TypeDesc::FLOAT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const float>::value, TypeDesc::FLOAT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<half>::value, TypeDesc::HALF);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const half>::value, TypeDesc::HALF);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<double>::value, TypeDesc::DOUBLE);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const double>::value, TypeDesc::DOUBLE);
+
     OIIO_CHECK_EQUAL(BaseTypeFromC<int>::value, TypeDesc::INT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const int>::value, TypeDesc::INT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<int32_t>::value, TypeDesc::INT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const int32_t>::value, TypeDesc::INT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<unsigned int>::value, TypeDesc::UINT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const unsigned int>::value, TypeDesc::UINT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<uint32_t>::value, TypeDesc::UINT);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const uint32_t>::value, TypeDesc::UINT);
+
+    OIIO_CHECK_EQUAL(BaseTypeFromC<short>::value, TypeDesc::INT16);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const short>::value, TypeDesc::INT16);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<int16_t>::value, TypeDesc::INT16);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const int16_t>::value, TypeDesc::INT16);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<unsigned short>::value, TypeDesc::UINT16);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const unsigned short>::value,
+                     TypeDesc::UINT16);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<uint16_t>::value, TypeDesc::UINT16);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const uint16_t>::value, TypeDesc::UINT16);
+
     OIIO_CHECK_EQUAL(BaseTypeFromC<char*>::value, TypeDesc::STRING);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const char*>::value, TypeDesc::STRING);
     OIIO_CHECK_EQUAL(BaseTypeFromC<ustring>::value, TypeDesc::STRING);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const ustring>::value, TypeDesc::STRING);
     OIIO_CHECK_EQUAL(BaseTypeFromC<void*>::value, TypeDesc::PTR);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const void*>::value, TypeDesc::PTR);
     OIIO_CHECK_EQUAL(BaseTypeFromC<int*>::value, TypeDesc::PTR);
+    OIIO_CHECK_EQUAL(BaseTypeFromC<const int*>::value, TypeDesc::PTR);
 
     OIIO_CHECK_EQUAL(TypeDescFromC<float>::value(), TypeFloat);
+    OIIO_CHECK_EQUAL(TypeDescFromC<const float>::value(), TypeFloat);
     OIIO_CHECK_EQUAL(TypeDescFromC<int>::value(), TypeInt);
+    OIIO_CHECK_EQUAL(TypeDescFromC<const int>::value(), TypeInt);
     OIIO_CHECK_EQUAL(TypeDescFromC<ustring>::value(), TypeString);
+    OIIO_CHECK_EQUAL(TypeDescFromC<const ustring>::value(), TypeString);
     OIIO_CHECK_EQUAL(TypeDescFromC<char*>::value(), TypeString);
     OIIO_CHECK_EQUAL(TypeDescFromC<const char*>::value(), TypeString);
     OIIO_CHECK_EQUAL(TypeDescFromC<void*>::value(), TypePointer);
     OIIO_CHECK_EQUAL(TypeDescFromC<const void*>::value(), TypePointer);
     OIIO_CHECK_EQUAL(TypeDescFromC<int*>::value(), TypePointer);
+    OIIO_CHECK_EQUAL(TypeDescFromC<const int*>::value(), TypePointer);
 }
 
 

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
@@ -42,14 +42,14 @@ simple_write()
 {
     const char* filename = "simple.tif";
     const int xres = 320, yres = 240, channels = 3;
-    unsigned char pixels[xres * yres * channels] = { 0 };
+    std::vector<unsigned char> pixels(xres * yres * channels);
 
     std::unique_ptr<ImageOutput> out = ImageOutput::create(filename);
     if (!out)
         return;  // error
     ImageSpec spec(xres, yres, channels, TypeDesc::UINT8);
     out->open(filename, spec);
-    out->write_image(TypeDesc::UINT8, pixels);
+    out->write_image(make_cspan(pixels));
     out->close();
 }
 // END-imageoutput-simple
@@ -68,12 +68,12 @@ scanlines_write()
     ImageSpec spec(xres, yres, channels, TypeDesc::UINT8);
 
     // BEGIN-imageoutput-scanlines
-    unsigned char scanline[xres * channels] = { 0 };
+    std::vector<unsigned char> scanline(xres * channels);
     out->open(filename, spec);
     int z = 0;  // Always zero for 2D images
     for (int y = 0; y < yres; ++y) {
         // ... generate data in scanline[0..xres*channels-1] ...
-        out->write_scanline(y, z, TypeDesc::UINT8, scanline);
+        out->write_scanline(y, z, make_span(scanline));
     }
     out->close();
     // END-imageoutput-scanlines

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
@@ -70,10 +70,9 @@ scanlines_write()
     // BEGIN-imageoutput-scanlines
     std::vector<unsigned char> scanline(xres * channels);
     out->open(filename, spec);
-    int z = 0;  // Always zero for 2D images
     for (int y = 0; y < yres; ++y) {
         // ... generate data in scanline[0..xres*channels-1] ...
-        out->write_scanline(y, z, make_span(scanline));
+        out->write_scanline(y, make_span(scanline));
     }
     out->close();
     // END-imageoutput-scanlines


### PR DESCRIPTION
* ImageOutput methods that write scanlines, tiles, and images, which are the main customization points for format output implementations, are given additional methods that take `image_span` in place of raw pointers and strides.

* Generally, for each, there is a templated version that takes `image_span<T>` that communicates both the memory area and the data type conversion requested, a "base case" that takes an explicit TypeDesc for the conversion type and a `image_view<std::byte>` giving the raw memory layout, and a `span<T>` convenience version for when there are contiguous strides. Note that when reading mixed channel data types in "native" mode (no type conversion, just leave the data in its original types), you have to use the std::byte image_span version, since the idea is not to do any format conversion, and there may not be a single type involved.

* For now, the default implementations of these new ImageOutput methods are just wrappers that call the old pointer-based ones. One by one, over time, we can swap them, changing the format implementations to have a full implementation of the new bounded versions, and make their raw pointer versions call the wrappers. The raw pointer ones will be understood to be "unsafe", merely assuming that the pointers always refer to appropriately-sized memory areas. Meanwhile, the ones using spans and image_spans will, due to assertions in their implementations, make it easier to verify (at least in debug mode), that we never touch memory outside these bounds.
