### PR TITLE
build: Detect libultrahdr version and enforce minimum of 1.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,6 +74,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Ptex >= 2.3.1 (probably works for older; tested through 2.4.3)
  * If you want to be able to do font rendering into images:
      * Freetype >= 2.10.0 (tested through 2.13)
+ * If you want to be able to read "ultra-HDR" embedded in JPEG files:
+     * libultrahdr >= 1.3 (tested through 1.4)
  * We use PugiXML for XML parsing. There is a version embedded in the OIIO
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distributions with policies against

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -39,7 +39,7 @@ brew link --overwrite --force python@${PYTHON_VERSION} || true
 #brew install --display-times -q libtiff
 brew install --display-times -q imath openexr opencolorio
 #brew install --display-times -q libpng giflib webp
-brew install --display-times -q jpeg-turbo openjpeg
+brew install --display-times -q jpeg-turbo openjpeg libultrahdr
 brew install --display-times -q freetype libraw dcmtk pybind11 numpy || true
 brew install --display-times -q ffmpeg libheif ptex || true
 brew install --display-times -q tbb || true

--- a/src/cmake/build_libuhdr.cmake
+++ b/src/cmake/build_libuhdr.cmake
@@ -6,7 +6,7 @@
 # libuhdr by hand!
 ######################################################################
 
-set_cache (libuhdr_BUILD_VERSION 1.2.0 "libuhdr version for local builds")
+set_cache (libuhdr_BUILD_VERSION 1.4.0 "libultrahdr version for local builds")
 set (libuhdr_GIT_REPOSITORY "https://github.com/google/libultrahdr")
 set (libuhdr_GIT_TAG "v${libuhdr_BUILD_VERSION}")
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -87,8 +87,8 @@ endif ()
 
 
 # Ultra HDR
-checked_find_package (libuhdr)
-
+checked_find_package (libuhdr
+                      VERSION_MIN 1.3)
 
 checked_find_package (TIFF REQUIRED
                       VERSION_MIN 4.0)

--- a/src/cmake/modules/Findlibuhdr.cmake
+++ b/src/cmake/modules/Findlibuhdr.cmake
@@ -9,6 +9,7 @@
 # libuhdr_FOUND            True if libuhdr was found.
 # LIBUHDR_INCLUDE_DIR      Where to find libuhdr headers
 # LIBUHDR_LIBRARY          Library for uhdr
+# LIBUHDR_VERSION          Version of the library
 
 include (FindPackageHandleStandardArgs)
 
@@ -24,7 +25,34 @@ find_library(LIBUHDR_LIBRARY uhdr
     lib
 )
 
+if (LIBUHDR_INCLUDE_DIR)
+    file (STRINGS "${LIBUHDR_INCLUDE_DIR}/ultrahdr_api.h" TMP REGEX "^#define UHDR_LIB_VER_MAJOR .*$")
+    string (REGEX MATCHALL "[0-9]+" LIBUHDR_VERSION_MAJOR ${TMP})
+    file (STRINGS "${LIBUHDR_INCLUDE_DIR}/ultrahdr_api.h" TMP REGEX "^#define UHDR_LIB_VER_MINOR .*$")
+    string (REGEX MATCHALL "[0-9]+" LIBUHDR_VERSION_MINOR ${TMP})
+    file (STRINGS "${LIBUHDR_INCLUDE_DIR}/ultrahdr_api.h" TMP REGEX "^#define UHDR_LIB_VER_PATCH .*$")
+    string (REGEX MATCHALL "[0-9]+" LIBUHDR_VERSION_PATCH ${TMP})
+    set (LIBUHDR_VERSION "${LIBUHDR_VERSION_MAJOR}.${LIBUHDR_VERSION_MINOR}.${LIBUHDR_VERSION_PATCH}")
+endif ()
+
 find_package_handle_standard_args (libuhdr
     REQUIRED_VARS   LIBUHDR_INCLUDE_DIR
                     LIBUHDR_LIBRARY
+    VERSION_VAR     LIBUHDR_VERSION
     )
+
+if (LIBUHDR_FOUND)
+    set(LIBUHDR_LIBRARIES ${LIBUHDR_LIBRARY})
+    set(LIBUHDR_INCLUDES ${LIBUHDR_INCLUDE_DIR})
+    if (NOT TARGET libuhdr::libuhdr)
+        add_library(libuhdr::libuhdr UNKNOWN IMPORTED)
+        set_target_properties(libuhdr::libuhdr PROPERTIES
+                              INTERFACE_INCLUDE_DIRECTORIES "${LIBUHDR_INCLUDES}")
+        set_property(TARGET libuhdr::libuhdr APPEND PROPERTY
+                     IMPORTED_LOCATION "${LIBUHDR_LIBRARIES}")
+    endif ()
+else ()
+    unset (LIBUHDR_INCLUDE_DIR)
+    unset (LIBUHDR_LIBRARY)
+    unset (LIBUHDR_VERSION)
+endif()

--- a/src/doc/oiiointro.rst
+++ b/src/doc/oiiointro.rst
@@ -267,4 +267,4 @@ against dynamic libraries:
 * OpenVDB © 2012-2018 DreamWorks Animation LLC, Mozilla Public License 2.0. https://www.openvdb.org/
 * Thread Building Blocks © Intel. Apache 2.0 license. https://www.threadingbuildingblocks.org/
 * libheif © 2017-2018 Struktur AG (LGPL). https://github.com/strukturag/libheif
-
+* libultrahdr © 2022 The Android Open Source Project. Apache 2.0 license. https://github.com/google/libultrahdr

--- a/src/jpeg.imageio/CMakeLists.txt
+++ b/src/jpeg.imageio/CMakeLists.txt
@@ -11,10 +11,9 @@ else ()
 endif ()
 
 add_oiio_plugin (jpeginput.cpp jpegoutput.cpp
-                 INCLUDE_DIRS ${LIBUHDR_INCLUDE_DIR}
                  LINK_LIBRARIES
                      $<TARGET_NAME_IF_EXISTS:libjpeg-turbo::jpeg>
                      $<TARGET_NAME_IF_EXISTS:JPEG::JPEG>
-                     ${LIBUHDR_LIBRARY}
+                     $<TARGET_NAME_IF_EXISTS:libuhdr::libuhdr>
                  DEFINITIONS "${UHDR_DEFS}"
                  )

--- a/testsuite/jpeg-ultrahdr/ref/out-macarm.txt
+++ b/testsuite/jpeg-ultrahdr/ref/out-macarm.txt
@@ -1,7 +1,7 @@
 4080 x 3072, 4 channel, float jpeg
     Stats Min: 0.000000 0.000000 0.000000 1.000000 (float)
     Stats Max: 4.613281 4.613281 4.613281 1.000000 (float)
-    Stats Avg: 0.314776 0.358598 0.465455 1.000000 (float)
+    Stats Avg: 0.314777 0.358598 0.465455 1.000000 (float)
     Stats StdDev: 0.463126 0.471940 0.496298 0.000000 (float)
     Stats NanCount: 0 0 0 0 
     Stats InfCount: 0 0 0 0 


### PR DESCRIPTION
I discovered, by testing against the latest libultrahdr, that only starting in 1.3 does it support the "64 bit 'half' RGBA" variety of UHDR that is the flavor used by the testsuite example. But our "auto-build" is pegged to 1.2, which means that all along, we were not decoding that test file properly as UHDR and our test reference output was therefore wrong. We also didn't detect libuhdr's version at all, let alone exclude versions that were too old.

Remediations:

* Amend Findlibuhdr.cmake to detect the version from symbols in its header files.

* Have our search for libuhdr enforce a minimum version of 1.3. (I feel bad about "changing minimum dependencies" in a release branch, which we usually disallow, but I think this time is an exception since we know versions < 1.3 are broken.)

* Change the auto-build selected version to 1.4, the latest.

* Mention libuhdr in the INSTALL description of dependencies and acknowledgement in the docs, where it had previously been omitted in those places.

* Update the testsuite/jpeg-ultrahdr test reference output. (You can tell it was wrong before because the "max" channel value was 1.0, and now it's 4.6.
