### PR TITLE
build: Restore OIIO_AVX512ER_ENABLED preprocessor symbol

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -213,6 +213,7 @@
 #  define OIIO_AVX512CD_ENABLED 0
 #  define OIIO_AVX512BW_ENABLED 0
 #endif
+#define OIIO_AVX512ER_ENABLED 0 /* DEPRECATED(3.1) */
 
 #if defined(__FMA__)
 #  define OIIO_FMA_ENABLED 1


### PR DESCRIPTION
This useless symbol was removed in PR #4724, but maybe downstream things used it and will break simply because it was removed, even though it never would have been nonzero. It should not have been completely removed except at a compatibility-breaking version boundary.

