### PR TITLE
int: Address safety warnings in pvt::append_tiff_dir_entry

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -1092,6 +1092,7 @@ pvt::append_tiff_dir_entry(std::vector<TIFFDirEntry>& dirs,
     dir.tdir_tag        = tag;
     dir.tdir_type       = type;
     dir.tdir_count      = count;
+    dir.tdir_offset     = 0;
     size_t len          = tiff_data_size(dir);
     char* ptr           = nullptr;
     bool data_in_offset = false;
@@ -1099,8 +1100,9 @@ pvt::append_tiff_dir_entry(std::vector<TIFFDirEntry>& dirs,
         dir.tdir_offset = 0;
         data_in_offset  = true;
         if (mydata.size()) {
+            OIIO_DASSERT(len == mydata.size());
             ptr = (char*)&dir.tdir_offset;
-            memcpy(ptr, mydata.data(), mydata.size());
+            memcpy(ptr, mydata.data(), len);
         }
     } else {
         if (mydata.size()) {


### PR DESCRIPTION
I think what we were doing here was fine all along, but the idiom was confusing to static analyzers who identified a danger that we were memcpy'ing into a field that was potentially not big enough. A minor restructuring of the code and a new assertion should verify that it's safe and also make it clear to the static analyzer that we aren't falling into the case it warned about.
