### PR TITLE
docs: Fix furo requirement after recently breaking docs

### DIFF
--- a/src/doc/requirements.txt
+++ b/src/doc/requirements.txt
@@ -1,4 +1,4 @@
 sphinx >= 8.0
 breathe == 4.36.0
 sphinx-tabs
-furo==2022.6.21
+furo==2024.8.6


### PR DESCRIPTION
PR #4736 bumped the version of sphinx we use on readthedocs, and that was incompatible with the old version of furo we specified.

I'm not sure how the problem was not caught by our "docs" workflow.
