### PR TITLE
ci: Add Linux ARM test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,26 @@ jobs:
             depcmds: |
               sudo rm -rf /usr/local/include/OpenEXR
               sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
+          - desc: Linux ARM latest releases gcc14 C++20 py3.12 avx2 exr3.3 ocio2.4
+            nametag: linux-latest-releases
+            runner: ubuntu-24.04-arm
+            cc_compiler: gcc-14
+            cxx_compiler: g++-14
+            cxx_std: 20
+            fmt_ver: 11.1.4
+            opencolorio_ver: v2.4.2
+            openexr_ver: v3.3.3
+            pybind11_ver: v2.13.6
+            python_ver: "3.12"
+            setenvs: export LIBJPEGTURBO_VERSION=3.1.0
+                            LIBRAW_VERSION=0.21.3
+                            LIBTIFF_VERSION=v4.7.0
+                            OPENJPEG_VERSION=v2.5.3
+                            PTEX_VERSION=v2.4.3
+                            PUGIXML_VERSION=v1.15
+                            WEBP_VERSION=v1.5.0
+                            FREETYPE_VERSION=VER-2-13-3
+                            USE_OPENVDB=0
 
 
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,11 +512,31 @@ jobs:
             depcmds: |
               sudo rm -rf /usr/local/include/OpenEXR
               sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
-          - desc: Linux ARM latest releases gcc14 C++20 py3.12 avx2 exr3.3 ocio2.4
+          - desc: Linux ARM latest releases gcc14 C++20 py3.12 exr3.3 ocio2.4
             nametag: linux-latest-releases
             runner: ubuntu-24.04-arm
             cc_compiler: gcc-14
             cxx_compiler: g++-14
+            cxx_std: 20
+            fmt_ver: 11.1.4
+            opencolorio_ver: v2.4.2
+            openexr_ver: v3.3.3
+            pybind11_ver: v2.13.6
+            python_ver: "3.12"
+            setenvs: export LIBJPEGTURBO_VERSION=3.1.0
+                            LIBRAW_VERSION=0.21.3
+                            LIBTIFF_VERSION=v4.7.0
+                            OPENJPEG_VERSION=v2.5.3
+                            PTEX_VERSION=v2.4.3
+                            PUGIXML_VERSION=v1.15
+                            WEBP_VERSION=v1.5.0
+                            FREETYPE_VERSION=VER-2-13-3
+                            USE_OPENVDB=0
+          - desc: Linux ARM latest releases clang18 C++20 py3.12 exr3.3 ocio2.4
+            nametag: linux-latest-releases
+            runner: ubuntu-24.04-arm
+            cc_compiler: clang-18
+            cxx_compiler: clang++-18
             cxx_std: 20
             fmt_ver: 11.1.4
             opencolorio_ver: v2.4.2

--- a/testsuite/docs-examples-cpp/ref/out-linuxarm.txt
+++ b/testsuite/docs-examples-cpp/ref/out-linuxarm.txt
@@ -1,0 +1,146 @@
+pixels holds unassociated alpha
+example_output_error1
+error: Uninitialized input image
+example_output_error2
+error: Uninitialized input image
+example_zero
+example_fill
+example_checker
+example_noise1
+example_noise2
+example_point
+example_lines
+example_box
+example_text1
+example_text2
+example_channels
+example_channel_append
+example_copy
+example_crop
+example_cut
+example_paste
+example_rotate_n
+example_flip_flop_transpose
+example_reorient
+example_circular_shift
+example_rotate
+example_resize
+example_resample
+example_fit
+example_warp
+example_demosaic
+example_add
+example_sub
+example_absdiff
+example_abs
+example_scale
+example_mul
+example_div
+example_fixNonFinite
+Repaired 48 non-finite pixels
+example_fillholes_pushpull
+example_median_filter
+example_unsharp_mask
+example_make_texture
+zero1.exr            :  512 x  512, 3 channel, half openexr
+    SHA-1: 95823C334FCE55968E8D2827CCD1CF77CEE19ABD
+zero2.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+zero3.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 1254F2956229777B721576B94A6A944ECB806A37
+zero4.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 36EB49C5102703693C078717CE82AE05D4904680
+fill.exr             :  640 x  480, 3 channel, half openexr
+    SHA-1: 1BBCA1D5966D02554C13C1FAEF01F6E6E6169356
+checker.exr          :  640 x  480, 3 channel, half openexr
+    SHA-1: 64508259AE242B593B906C848A2D69C443A3FBFD
+noise1.exr           :  256 x  256, 3 channel, half openexr
+    SHA-1: 66FF64DDAFDDE290031C20FAA208A193908EE9D4
+noise2.exr           :  256 x  256, 3 channel, half openexr
+    SHA-1: 06011F9D59106096F4742A3DAB458D506A08E34C
+noise3.exr           :  512 x  384, 3 channel, half openexr
+    SHA-1: 95EDBCA9953281CE63A3E18C7C04BCCB07CB4C8A
+noise4.exr           :  512 x  384, 3 channel, half openexr
+    SHA-1: 43BC1FDFA1F18635B635A57D71DB08BB347CBD46
+blue-noise.exr       :  256 x  256, 4 channel, half openexr
+    SHA-1: 5A0A51D1AD3F34633B781AFF9B90E59996C31AD0
+point.exr            :  640 x  480, 4 channel, half openexr
+    SHA-1: 56E2BDBE03826F203132BD9E80AF44450307BDCE
+lines.exr            :  640 x  480, 4 channel, half openexr
+    SHA-1: 177C4C5C61ACDD54F198A45E52836DE897C4CE96
+box.exr              :  640 x  480, 4 channel, half openexr
+    SHA-1: 984273B0A06E54873E24A732651490117E40410C
+text1.exr            :  640 x  480, 3 channel, half openexr
+    SHA-1: 1CF68F9B099A30EFF06850CEFBEDD3C2F861A654
+text2.exr            :  640 x  480, 3 channel, half openexr
+    SHA-1: 00C96AE28FD12752AD1968D3D07EE30F1F218D76
+channels-rgba.exr    :  256 x  256, 4 channel, half openexr
+    SHA-1: C823E3701152B4B3C20DD79EA8A20CF4293F4B71
+channels-rgb.exr     :  256 x  256, 3 channel, half openexr
+    SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+channels-brga.exr    :  256 x  256, 4 channel, half openexr
+    SHA-1: 04E09E64C61CEA1634D26FB2E6C733875D163671
+channels-alpha.exr   :  256 x  256, 1 channel, half openexr
+    SHA-1: 99C332E70F321F0EA47C0F70AF8B0E3E6524F91F
+channel-append.exr   :  640 x  480, 5 channel, half openexr
+    SHA-1: E6A50C80C051F0F587FCB68B515B50E4DC3E9359
+copy.exr             :  256 x  256, 4 channel, float openexr
+    SHA-1: 7044589C8B904DAF6A2BA3246224E97DD460AC93
+crop.exr             :  200 x  100, 4 channel, half openexr
+    SHA-1: 4DA3918566D087A9D2D9E93B2A7BABE971FE6BBD
+cut.exr              :  200 x  100, 4 channel, half openexr
+    SHA-1: 4DA3918566D087A9D2D9E93B2A7BABE971FE6BBD
+paste.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 67A4C36DEAED98A5A8ABA5F0E0EDE697345DC22A
+rotate-90.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: AFFAEA876E8E7760226B017B0A89A3549B7A5895
+rotate-180.exr       :  256 x  256, 4 channel, half openexr
+    SHA-1: A5E42C5F18177DA146EC7E4567E4AE3AE2816C3C
+rotate-270.exr       :  256 x  256, 4 channel, half openexr
+    SHA-1: 46C803894186457376A0C590768C9DB4877737BB
+flip.exr             :  256 x  256, 4 channel, half openexr
+    SHA-1: A9EB9A8762BCD8DD161C00B01E2DF39E5C91B0D4
+flop.exr             :  256 x  256, 4 channel, half openexr
+    SHA-1: 7C10717DB4F2E21F0B4F6D5404C660CA8B504F5E
+rotate-45.tif        :  256 x  256, 4 channel, uint8 tiff
+    SHA-1: 7AB8CEEF016D73F34F6B7A1B40C44BC8A83F91FB
+resize.tif           :  320 x  240, 4 channel, uint8 tiff
+    SHA-1: 6FD1A7A97729CD6D51A22ADE0709CC4DFDC3C826
+resample.exr         :  320 x  240, 4 channel, half openexr
+    SHA-1: 16FC7DCFE01DC312593B00B9F90D71BAF3D52450
+fit.tif              :  240 x  240, 4 channel, uint8 tiff
+    SHA-1: 5474A93DED5F9F44E561B70A53F509677961AB34
+warp.exr             :  256 x  256, 4 channel, half openexr
+    SHA-1: F48EB9C437381524089E2824FAE9B3844D8F574A
+transpose.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: FAD57FB60460383D3D2D24B346F35A44846CCC39
+reorient.exr         :  256 x  256, 4 channel, half openexr
+    SHA-1: 46C803894186457376A0C590768C9DB4877737BB
+cshift.exr           :  256 x  256, 4 channel, half openexr
+    SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
+texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
+    SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+add.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: EA465A4FEA171DDF7D382931AE1FF1E37C4977F8
+add-cspan.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: 3E8E6F104951D3D156891708478193AAE6C5859F
+sub.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+absdiff.exr          :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+abs.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: A670546F9AB515ABEC009BFE4C4FF6AF4D628FBA
+mul.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: ECCDBBBF088912F0B77B887D6B8B480C3F93615E
+div.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A85C923DB82C893C0D88028386F1C58604A4757
+checker_with_alpha_filled.exr :  256 x  256, 4 channel, half openexr
+    SHA-1: B245E027638D5C1BA2608FEDDB3BB9B5E9FA3A44
+tahoe_median_filter.tif :  512 x  384, 3 channel, uint8 tiff
+    SHA-1: A0B2E3A10A16EA8CC905F144C5F91B6A0964A177
+tahoe_unsharp_mask.tif :  512 x  384, 3 channel, uint8 tiff
+    SHA-1: 5842D16483BC74700DE9FD27967B2FFBD54DFCD2
+Comparing "simple.tif" and "ref/simple.tif"
+PASS
+Comparing "scanlines.tif" and "ref/scanlines.tif"
+PASS

--- a/testsuite/docs-examples-python/ref/out-linuxarm.txt
+++ b/testsuite/docs-examples-python/ref/out-linuxarm.txt
@@ -1,0 +1,146 @@
+pixels holds unassociated alpha
+example1
+example_output_error1
+error: Uninitialized input image
+example_output_error2
+error: Uninitialized input image
+example_zero
+example_fill
+example_checker
+example_noise1
+example_noise2
+example_point
+example_lines
+example_box
+example_text1
+example_text2
+example_channels
+example_channel_append
+example_copy
+example_crop
+example_cut
+example_paste
+example_rotate_n
+example_flip_flop_transpose
+example_reorient
+example_circular_shift
+example_rotate
+example_resize
+example_resample
+example_fit
+example_warp
+example_demosaic
+example_add
+example_sub
+example_absdiff
+example_abs
+example_scale
+example_mul
+example_div
+example_fixNonFinite
+example_fillholes_pushpull
+example_median_filter
+example_unsharp_mask
+example_make_texture
+zero1.exr            :  512 x  512, 3 channel, half openexr
+    SHA-1: 95823C334FCE55968E8D2827CCD1CF77CEE19ABD
+zero2.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+zero3.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 1254F2956229777B721576B94A6A944ECB806A37
+zero4.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 36EB49C5102703693C078717CE82AE05D4904680
+fill.exr             :  640 x  480, 3 channel, half openexr
+    SHA-1: 1BBCA1D5966D02554C13C1FAEF01F6E6E6169356
+checker.exr          :  640 x  480, 3 channel, half openexr
+    SHA-1: 64508259AE242B593B906C848A2D69C443A3FBFD
+noise1.exr           :  256 x  256, 3 channel, half openexr
+    SHA-1: 66FF64DDAFDDE290031C20FAA208A193908EE9D4
+noise2.exr           :  256 x  256, 3 channel, half openexr
+    SHA-1: 06011F9D59106096F4742A3DAB458D506A08E34C
+noise3.exr           :  512 x  384, 3 channel, half openexr
+    SHA-1: 95EDBCA9953281CE63A3E18C7C04BCCB07CB4C8A
+noise4.exr           :  512 x  384, 3 channel, half openexr
+    SHA-1: 43BC1FDFA1F18635B635A57D71DB08BB347CBD46
+blue-noise.exr       :  256 x  256, 4 channel, half openexr
+    SHA-1: 5A0A51D1AD3F34633B781AFF9B90E59996C31AD0
+point.exr            :  640 x  480, 4 channel, half openexr
+    SHA-1: 56E2BDBE03826F203132BD9E80AF44450307BDCE
+lines.exr            :  640 x  480, 4 channel, half openexr
+    SHA-1: 177C4C5C61ACDD54F198A45E52836DE897C4CE96
+box.exr              :  640 x  480, 4 channel, half openexr
+    SHA-1: 984273B0A06E54873E24A732651490117E40410C
+text1.exr            :  640 x  480, 3 channel, half openexr
+    SHA-1: 1CF68F9B099A30EFF06850CEFBEDD3C2F861A654
+text2.exr            :  640 x  480, 3 channel, half openexr
+    SHA-1: 00C96AE28FD12752AD1968D3D07EE30F1F218D76
+channels-rgba.exr    :  256 x  256, 4 channel, half openexr
+    SHA-1: C823E3701152B4B3C20DD79EA8A20CF4293F4B71
+channels-rgb.exr     :  256 x  256, 3 channel, half openexr
+    SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+channels-brga.exr    :  256 x  256, 4 channel, half openexr
+    SHA-1: 04E09E64C61CEA1634D26FB2E6C733875D163671
+channels-alpha.exr   :  256 x  256, 1 channel, half openexr
+    SHA-1: 99C332E70F321F0EA47C0F70AF8B0E3E6524F91F
+channel-append.exr   :  640 x  480, 5 channel, half openexr
+    SHA-1: E6A50C80C051F0F587FCB68B515B50E4DC3E9359
+copy.exr             :  256 x  256, 4 channel, half openexr
+    SHA-1: C823E3701152B4B3C20DD79EA8A20CF4293F4B71
+crop.exr             :  200 x  100, 4 channel, half openexr
+    SHA-1: 4DA3918566D087A9D2D9E93B2A7BABE971FE6BBD
+cut.exr              :  200 x  100, 4 channel, half openexr
+    SHA-1: 4DA3918566D087A9D2D9E93B2A7BABE971FE6BBD
+paste.exr            :  256 x  256, 4 channel, half openexr
+    SHA-1: 67A4C36DEAED98A5A8ABA5F0E0EDE697345DC22A
+rotate-90.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: AFFAEA876E8E7760226B017B0A89A3549B7A5895
+rotate-180.exr       :  256 x  256, 4 channel, half openexr
+    SHA-1: A5E42C5F18177DA146EC7E4567E4AE3AE2816C3C
+rotate-270.exr       :  256 x  256, 4 channel, half openexr
+    SHA-1: 46C803894186457376A0C590768C9DB4877737BB
+flip.exr             :  256 x  256, 4 channel, half openexr
+    SHA-1: A9EB9A8762BCD8DD161C00B01E2DF39E5C91B0D4
+flop.exr             :  256 x  256, 4 channel, half openexr
+    SHA-1: 7C10717DB4F2E21F0B4F6D5404C660CA8B504F5E
+rotate-45.tif        :  256 x  256, 4 channel, uint8 tiff
+    SHA-1: 7AB8CEEF016D73F34F6B7A1B40C44BC8A83F91FB
+resize.tif           :  320 x  240, 4 channel, uint8 tiff
+    SHA-1: 6FD1A7A97729CD6D51A22ADE0709CC4DFDC3C826
+resample.exr         :  320 x  240, 4 channel, half openexr
+    SHA-1: 16FC7DCFE01DC312593B00B9F90D71BAF3D52450
+fit.tif              :  240 x  240, 4 channel, uint8 tiff
+    SHA-1: 5474A93DED5F9F44E561B70A53F509677961AB34
+warp.exr             :  256 x  256, 4 channel, half openexr
+    SHA-1: F48EB9C437381524089E2824FAE9B3844D8F574A
+transpose.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: FAD57FB60460383D3D2D24B346F35A44846CCC39
+reorient.exr         :  256 x  256, 4 channel, half openexr
+    SHA-1: 46C803894186457376A0C590768C9DB4877737BB
+cshift.exr           :  256 x  256, 4 channel, half openexr
+    SHA-1: 000F95FDC44D4DBDA8B4041C2506149C7AE28ACA
+texture.exr          :  256 x  256, 3 channel, half openexr (+mipmap)
+    SHA-1: 4074B050432CE7C664CEC4546A46E74F9A310CDC
+add.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: EA465A4FEA171DDF7D382931AE1FF1E37C4977F8
+add_cspan.exr        :  256 x  256, 4 channel, half openexr
+    SHA-1: 3E8E6F104951D3D156891708478193AAE6C5859F
+sub.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+absdiff.exr          :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A521E1D2A632C26E53B83D2CC4B0EDECFC1E68C
+abs.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: A670546F9AB515ABEC009BFE4C4FF6AF4D628FBA
+mul.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: ECCDBBBF088912F0B77B887D6B8B480C3F93615E
+div.exr              :  256 x  256, 4 channel, half openexr
+    SHA-1: 6A85C923DB82C893C0D88028386F1C58604A4757
+checker_with_alpha_filled.exr :  256 x  256, 4 channel, half openexr
+    SHA-1: B245E027638D5C1BA2608FEDDB3BB9B5E9FA3A44
+tahoe_median_filter.tif :  512 x  384, 3 channel, uint8 tiff
+    SHA-1: A0B2E3A10A16EA8CC905F144C5F91B6A0964A177
+tahoe_unsharp_mask.tif :  512 x  384, 3 channel, uint8 tiff
+    SHA-1: 5842D16483BC74700DE9FD27967B2FFBD54DFCD2
+Comparing "simple.tif" and "../docs-examples-cpp/ref/simple.tif"
+PASS
+Comparing "scanlines.tif" and "../docs-examples-cpp/ref/scanlines.tif"
+PASS

--- a/testsuite/psd/ref/out-linuxarm.txt
+++ b/testsuite/psd/ref/out-linuxarm.txt
@@ -1,0 +1,2100 @@
+Reading ../oiio-images/psd/psd_123.psd
+../oiio-images/psd/psd_123.psd :  257 x  126, 4 channel, uint8 psd
+    4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
+ subimage  0:  257 x  126, 4 channel, uint8 psd
+    SHA-1: D48458E9AEDB9C8618DE4B7DAA25BD4D7421778A
+    channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  1:   33 x   98, 4 channel, uint8 psd
+    SHA-1: CDA136B1B34A86AEBDCB88283F0D2323F921C00C
+    channel list: R, G, B, A
+    pixel data origin: x=15, y=15
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "1"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  2:   63 x  100, 4 channel, uint8 psd
+    SHA-1: E0B9D4A8BE16B52126EC5BC1E829D099EF4C5DC4
+    channel list: R, G, B, A
+    pixel data origin: x=84, y=13
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "2"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  3:   61 x  102, 4 channel, uint8 psd
+    SHA-1: 11FDE5499A2150FD5C779C9012649E839750C1D8
+    channel list: R, G, B, A
+    pixel data origin: x=175, y=14
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "3"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
+../oiio-images/psd/psd_123_nomaxcompat.psd :  257 x  126, 3 channel, uint8 psd
+    4 subimages: 257x126 [u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
+ subimage  0:  257 x  126, 3 channel, uint8 psd
+    SHA-1: 5A7BDC7A11A9E4BDCBEC968375EE466DE74D0481
+    channel list: R, G, B
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
+    IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:F4BDDC0457D2E011BF419187EAB8EBB9; xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00; 2011-08-29T12:10:28-04:00"
+ subimage  1:   33 x   98, 4 channel, uint8 psd
+    SHA-1: CDA136B1B34A86AEBDCB88283F0D2323F921C00C
+    channel list: R, G, B, A
+    pixel data origin: x=15, y=15
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
+    IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "1"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:F4BDDC0457D2E011BF419187EAB8EBB9; xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00; 2011-08-29T12:10:28-04:00"
+ subimage  2:   63 x  100, 4 channel, uint8 psd
+    SHA-1: E0B9D4A8BE16B52126EC5BC1E829D099EF4C5DC4
+    channel list: R, G, B, A
+    pixel data origin: x=84, y=13
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
+    IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "2"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:F4BDDC0457D2E011BF419187EAB8EBB9; xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00; 2011-08-29T12:10:28-04:00"
+ subimage  3:   61 x  102, 4 channel, uint8 psd
+    SHA-1: 11FDE5499A2150FD5C779C9012649E839750C1D8
+    channel list: R, G, B, A
+    pixel data origin: x=175, y=14
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
+    IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "3"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:F4BDDC0457D2E011BF419187EAB8EBB9; xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00; 2011-08-29T12:10:28-04:00"
+Reading ../oiio-images/psd/psd_bitmap.psd
+../oiio-images/psd/psd_bitmap.psd :  320 x  240, 3 channel, uint8 psd
+    SHA-1: F23185BC048E31BAC6BB4B319E5E5AC570CC7B89
+    channel list: R, G, B
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
+    Make: "Canon"
+    Model: "Canon PowerShot A640"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
+    Exif:ApertureValue: 3.625 (f/3.5)
+    Exif:ColorSpace: 65535
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash suppression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
+    Exif:FocalPlaneXResolution: 12710.8
+    Exif:FocalPlaneYResolution: 12725.6
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
+    Exif:SceneCaptureType: 1 (landscape)
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
+    IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    IPTC:InstanceID: "xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:40:47-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:40:47-04:00"
+    IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ColorMode: 0
+    rdf:parseType: "Resource"
+    stEvt:action: "saved; converted; derived"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:52DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:53DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:54DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:55DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:56DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:2A93235262CFE011B8B8C52D9599FB9E; xmp.iid:F310E7E462CFE011B8B8C52D9599FB9E; xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
+    stEvt:parameters: "from image/jpeg to application/vnd.adobe.photoshop; converted from image/jpeg to application/vnd.adobe.photoshop"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T21:56:08-04:00; 2011-08-22T21:56:36-04:00; 2011-08-22T21:56:49-04:00; 2011-08-25T17:40-04:00; 2011-08-25T17:40:47-04:00"
+    stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+Reading ../oiio-images/psd/psd_indexed_trans.psd
+../oiio-images/psd/psd_indexed_trans.psd :  320 x  240, 4 channel, uint8 psd
+    SHA-1: 3DEA3F342B61B6B2064310C06B2AE23692079EE7
+    channel list: R, G, B, A
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Make: "Canon"
+    Model: "Canon PowerShot A640"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
+    Exif:ApertureValue: 3.625 (f/3.5)
+    Exif:ColorSpace: 1
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash suppression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
+    Exif:FocalPlaneXResolution: 12710.8
+    Exif:FocalPlaneYResolution: 12725.6
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
+    Exif:SceneCaptureType: 1 (landscape)
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    IPTC:InstanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
+    IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
+    IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
+    IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 2
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "saved; converted; derived"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:52DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:53DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:54DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:55DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:56DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:2A93235262CFE011B8B8C52D9599FB9E; xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:parameters: "from image/jpeg to application/vnd.adobe.photoshop; converted from image/jpeg to application/vnd.adobe.photoshop"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T21:56:08-04:00; 2011-08-22T21:56:36-04:00; 2011-08-22T21:56:49-04:00; 2011-08-25T17:40-04:00; 2011-08-29T11:54:09-04:00"
+    stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+Reading ../oiio-images/psd/psd_rgb_8.psd
+../oiio-images/psd/psd_rgb_8.psd :  320 x  240, 3 channel, uint8 psd
+    SHA-1: 44362B2D9E51C40DF8ABF87CC749B77F2D0D9F4F
+    channel list: R, G, B
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Make: "Canon"
+    Model: "Canon PowerShot A640"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
+    Exif:ApertureValue: 3.625 (f/3.5)
+    Exif:ColorSpace: 1
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash suppression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
+    Exif:FocalPlaneXResolution: 12710.8
+    Exif:FocalPlaneYResolution: 12725.6
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
+    Exif:SceneCaptureType: 1 (landscape)
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    IPTC:InstanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:40-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:40-04:00"
+    IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "saved; converted; derived"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:52DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:53DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:54DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:55DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:56DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
+    stEvt:parameters: "from image/jpeg to application/vnd.adobe.photoshop; converted from image/jpeg to application/vnd.adobe.photoshop"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T21:56:08-04:00; 2011-08-22T21:56:36-04:00; 2011-08-22T21:56:49-04:00; 2011-08-25T17:40-04:00"
+    stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+Reading ../oiio-images/psd/psd_rgb_16.psd
+../oiio-images/psd/psd_rgb_16.psd :  320 x  240, 3 channel, uint16 psd
+    SHA-1: E42334B0F0684E3C3BF9125F2920B07C44C17B11
+    channel list: R, G, B
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Make: "Canon"
+    Model: "Canon PowerShot A640"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
+    Exif:ApertureValue: 3.625 (f/3.5)
+    Exif:ColorSpace: 1
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash suppression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
+    Exif:FocalPlaneXResolution: 12710.8
+    Exif:FocalPlaneYResolution: 12725.6
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
+    Exif:SceneCaptureType: 1 (landscape)
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    IPTC:InstanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
+    IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "saved; converted; derived"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:52DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:53DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:54DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
+    stEvt:parameters: "from image/jpeg to application/vnd.adobe.photoshop; converted from image/jpeg to application/vnd.adobe.photoshop"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T21:56:08-04:00; 2011-08-22T21:56:36-04:00; 2011-08-25T17:39:49-04:00"
+    stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+Reading ../oiio-images/psd/psd_rgb_32.psd
+../oiio-images/psd/psd_rgb_32.psd :  320 x  240, 3 channel, float psd
+    SHA-1: 63CF8F7B010D24EFD3C41F51C16D8D285FE07313
+    channel list: R, G, B
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
+    ICCProfile: 0, 0, 2, 8, 65, 68, 66, 69, 2, 16, 0, 0, 109, 110, 116, 114, ... [520 x uint8]
+    Make: "Canon"
+    Model: "Canon PowerShot A640"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
+    Exif:ApertureValue: 3.625 (f/3.5)
+    Exif:ColorSpace: 65535
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash suppression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
+    Exif:FocalPlaneXResolution: 12710.8
+    Exif:FocalPlaneYResolution: 12725.6
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
+    Exif:SceneCaptureType: 1 (landscape)
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1094992453
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 2011 Adobe Systems Incorporated"
+    ICCProfile:creation_date: "2011:08:23 01:56:54"
+    ICCProfile:creator_signature: "41444245"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "6e6f6e65"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1 (Linear RGB Profile)"
+    ICCProfile:profile_size: 520
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    IPTC:InstanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:38-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:38-04:00"
+    IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1 (Linear RGB Profile)"
+    rdf:parseType: "Resource"
+    stEvt:action: "saved; converted; derived"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:52DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:53DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:54DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:55DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:56DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:57DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:58DA7E112BCDE011A998CBE7B5CCEB92; xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
+    stEvt:parameters: "from image/jpeg to application/vnd.adobe.photoshop; converted from image/jpeg to application/vnd.adobe.photoshop"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T21:56:08-04:00; 2011-08-22T21:56:36-04:00; 2011-08-22T21:56:49-04:00; 2011-08-22T21:57:01-04:00; 2011-08-25T17:39:38-04:00"
+    stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+Reading ../oiio-images/psd/psd_rgba_8.psd
+../oiio-images/psd/psd_rgba_8.psd :  320 x  240, 4 channel, uint8 psd
+    2 subimages: 320x240 [u8,u8,u8,u8], 320x240 [u8,u8,u8,u8]
+ subimage  0:  320 x  240, 4 channel, uint8 psd
+    SHA-1: 81C22E59537BCDB081C12BF93E14DB2B5DDEEC13
+    channel list: R, G, B, A
+    DateTime: "2011-08-22T22:07:44-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:037A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:07:44-04:00; 2011-08-25T17:39:28-04:00"
+ subimage  1:  320 x  240, 4 channel, uint8 psd
+    SHA-1: 0C24F6EE3C3F1A14769F3A7272C35E684AB75AB3
+    channel list: R, G, B, A
+    DateTime: "2011-08-22T22:07:44-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Layer 1"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:037A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:07:44-04:00; 2011-08-25T17:39:28-04:00"
+Reading ../oiio-images/psd/psd_rgb_16_rle.psd
+../oiio-images/psd/psd_rgb_16_rle.psd : 3840 x 2160, 3 channel, uint16 psd
+    SHA-1: CF2071CFD7AF69ECEFC9EA00DC0EA7F8ED6A2E2B
+    channel list: R, G, B
+    DateTime: "2025-01-10T23:27:45+02:00"
+    ICCProfile: 0, 0, 2, 48, 65, 68, 66, 69, 2, 16, 0, 0, 109, 110, 116, 114, ... [560 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 26.0 (Windows)"
+    thumbnail_height: 90
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 3840
+    Exif:PixelYDimension: 2160
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1094992453
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 1999 Adobe Systems Incorporated"
+    ICCProfile:creation_date: "1999:06:03 00:00:00"
+    ICCProfile:creator_signature: "41444245"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "6e6f6e65"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Adobe RGB (1998)"
+    ICCProfile:profile_size: 560
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    IPTC:DocumentID: "xmp.did:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    IPTC:InstanceID: "xmp.iid:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    IPTC:MetadataDate: "2025-01-10T23:28:11+02:00"
+    IPTC:ModifyDate: "2025-01-10T23:28:11+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "Adobe RGB (1998)"
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:9de7a004-9188-384a-a78b-5202a1f8a5ae"
+    stEvt:softwareAgent: "Adobe Photoshop 26.0 (Windows)"
+    stEvt:when: "2025-01-10T23:27:45+02:00"
+Reading ../oiio-images/psd/psd_123.psd
+../oiio-images/psd/psd_123.psd :  257 x  126, 4 channel, uint8 psd
+    4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
+ subimage  0:  257 x  126, 4 channel, uint8 psd
+    SHA-1: B229DA843AD0DA7C6FF92ABC78C737E81FEB6CF2
+    channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  1:   33 x   98, 4 channel, uint8 psd
+    SHA-1: E99937CC4768F96DC58D9B4F11ED3083818E4D51
+    channel list: R, G, B, A
+    pixel data origin: x=15, y=15
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "1"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  2:   63 x  100, 4 channel, uint8 psd
+    SHA-1: EB2ED42882FCD4BC1F0E11795B6B3E483158C1B4
+    channel list: R, G, B, A
+    pixel data origin: x=84, y=13
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "2"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  3:   61 x  102, 4 channel, uint8 psd
+    SHA-1: 81D2828D49B81D99397544651501C3AB9696EF52
+    channel list: R, G, B, A
+    pixel data origin: x=175, y=14
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "3"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+Reading src/different-mask-size.psd
+src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
+    4 subimages: 30x90 [u8,u8,u8], 30x90 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8]
+ subimage  0:   30 x   90, 3 channel, uint8 psd
+    SHA-1: 42E73C11525323760BF0BEB74370AECC18FC2D92
+    channel list: R, G, B
+    DateTime: "2014-02-16T17:20:13+09:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 30
+    Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
+    IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
+    IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:e5390921-47bd-41b6-9237-d4903a41e966; xmp.iid:1710094a-3678-4874-8382-1f328830d993; xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC (Macintosh); Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2014-02-16T17:20:13+09:00; 2014-02-20T20:49:31+09:00; 2017-01-10T17:55:32+09:00"
+ subimage  1:   30 x   90, 4 channel, uint8 psd
+    SHA-1: B2E0D74684B53DF0382EAB0BB1A277438715BB2F
+    channel list: R, G, B, A
+    DateTime: "2014-02-16T17:20:13+09:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 30
+    Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
+    IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
+    IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Layer 0"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:e5390921-47bd-41b6-9237-d4903a41e966; xmp.iid:1710094a-3678-4874-8382-1f328830d993; xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC (Macintosh); Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2014-02-16T17:20:13+09:00; 2014-02-20T20:49:31+09:00; 2017-01-10T17:55:32+09:00"
+ subimage  2:    4 x   93, 4 channel, uint8 psd
+    SHA-1: 8CE9A2A394ED148194055A22E59E55CE7BDFB3B7
+    channel list: R, G, B, A
+    pixel data origin: x=18, y=-2
+    DateTime: "2014-02-16T17:20:13+09:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 30
+    Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
+    IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
+    IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "line1"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:e5390921-47bd-41b6-9237-d4903a41e966; xmp.iid:1710094a-3678-4874-8382-1f328830d993; xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC (Macintosh); Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2014-02-16T17:20:13+09:00; 2014-02-20T20:49:31+09:00; 2017-01-10T17:55:32+09:00"
+ subimage  3:    4 x   93, 4 channel, uint8 psd
+    SHA-1: 8CE9A2A394ED148194055A22E59E55CE7BDFB3B7
+    channel list: R, G, B, A
+    pixel data origin: x=8, y=-2
+    DateTime: "2014-02-16T17:20:13+09:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 30
+    Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
+    IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
+    IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "line2"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:e5390921-47bd-41b6-9237-d4903a41e966; xmp.iid:1710094a-3678-4874-8382-1f328830d993; xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC (Macintosh); Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2014-02-16T17:20:13+09:00; 2014-02-20T20:49:31+09:00; 2017-01-10T17:55:32+09:00"
+Reading src/layer-mask.psd
+src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
+    3 subimages: 10x10 [u8,u8,u8,u8], 8x8 [u8,u8,u8,u8], 9x9 [u8,u8,u8,u8]
+ subimage  0:   10 x   10, 4 channel, uint8 psd
+    SHA-1: D74BDBDC714B652B6C62DE190A928EF79A0095ED
+    channel list: R, G, B, A
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CC 2017 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 10
+    Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
+    IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
+    IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    photoshop:ColorMode: 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:a64763c8-be7b-ff48-b857-0f1ee8e5da2b; xmp.iid:9847e4c5-ca7e-fa42-9c7f-5fe6373d31de; xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T10:26:10+09:00; 2017-07-13T10:32:41+09:00; 2017-07-13T11:42:54+09:00"
+ subimage  1:    8 x    8, 4 channel, uint8 psd
+    SHA-1: D1803D25687AA8C80C50AC74CCD47B1C59865B2F
+    channel list: R, G, B, A
+    pixel data origin: x=0, y=1
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CC 2017 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 10
+    Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
+    IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
+    IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    oiio:subimagename: "Vector mask feather"
+    photoshop:ColorMode: 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:a64763c8-be7b-ff48-b857-0f1ee8e5da2b; xmp.iid:9847e4c5-ca7e-fa42-9c7f-5fe6373d31de; xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T10:26:10+09:00; 2017-07-13T10:32:41+09:00; 2017-07-13T11:42:54+09:00"
+ subimage  2:    9 x    9, 4 channel, uint8 psd
+    SHA-1: 6BEB9ABA4756704D8A330EA3B8F79640F3D88088
+    channel list: R, G, B, A
+    pixel data origin: x=-2, y=-1
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CC 2017 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 10
+    Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
+    IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
+    IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    oiio:subimagename: "Layer mask"
+    photoshop:ColorMode: 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created; saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:a64763c8-be7b-ff48-b857-0f1ee8e5da2b; xmp.iid:9847e4c5-ca7e-fa42-9c7f-5fe6373d31de; xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T10:26:10+09:00; 2017-07-13T10:32:41+09:00; 2017-07-13T11:42:54+09:00"
+oiiotool ERROR: read : Failed to decode Exif data
+failed to open "src/crash-psd-exif-1632.psd": failed load_resources
+Full command line was:
+> oiiotool --info -v -a --hash src/crash-psd-exif-1632.psd
+oiiotool ERROR: read : Corrupt thumbnail: 262304w * 24bpp does not match 480 width bytes
+failed to open "src/crash-thumb-1626.psd": failed load_resources
+Full command line was:
+> oiiotool --info -v -a --hash src/crash-thumb-1626.psd
+Reading src/Layers_8bit_RGB.psd
+src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
+    4 subimages: 48x27 [u8,u8,u8], 48x27 [u8,u8,u8,u8], 48x27 [u8,u8,u8,u8], 48x27 [u8,u8,u8,u8]
+ subimage  0:   48 x   27, 3 channel, uint8 psd
+    SHA-1: AF5EF97B5D5B5AFB6578005E416C5F7E636FE9E4
+    channel list: R, G, B
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    thumbnail_height: 27
+    thumbnail_nchannels: 3
+    thumbnail_width: 48
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:a9aabed2-61e6-1c48-b9c0-22e2e6b3631a"
+    IPTC:InstanceID: "xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:40+02:00"
+ subimage  1:   48 x   27, 4 channel, uint8 psd
+    SHA-1: 5AF647DD416B325A60135DC52F75AEE5CA748C5A
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:a9aabed2-61e6-1c48-b9c0-22e2e6b3631a"
+    IPTC:InstanceID: "xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Blue_Lagoon"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:40+02:00"
+ subimage  2:   48 x   27, 4 channel, uint8 psd
+    SHA-1: C303E1C0CD86E2F3411D8337B29F52D8214DA091
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:a9aabed2-61e6-1c48-b9c0-22e2e6b3631a"
+    IPTC:InstanceID: "xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Layer"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:40+02:00"
+ subimage  3:   48 x   27, 4 channel, uint8 psd
+    SHA-1: 79CF5E0C494DA95DF6EAADDC2CA0DD4D0CF4286C
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:a9aabed2-61e6-1c48-b9c0-22e2e6b3631a"
+    IPTC:InstanceID: "xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Layer2"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:91e10371-aef4-e042-b01b-18a054353721"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:40+02:00"
+Reading src/Layers_16bit_RGB.psd
+src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
+    4 subimages: 48x27 [u16,u16,u16], 48x27 [u16,u16,u16,u16], 48x27 [u16,u16,u16,u16], 48x27 [u16,u16,u16,u16]
+ subimage  0:   48 x   27, 3 channel, uint16 psd
+    SHA-1: 0228B2F3AA493695E9653E1C32D303022DDEFAE4
+    channel list: R, G, B
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    thumbnail_height: 27
+    thumbnail_nchannels: 3
+    thumbnail_width: 48
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:d0b5fcf6-f464-234f-b5df-47c18ab8b898"
+    IPTC:InstanceID: "xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:30+02:00"
+ subimage  1:   48 x   27, 4 channel, uint16 psd
+    SHA-1: 0D572837DF5C07DB70A5C63B355CE285439813A3
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:d0b5fcf6-f464-234f-b5df-47c18ab8b898"
+    IPTC:InstanceID: "xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Blue_Lagoon"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:30+02:00"
+ subimage  2:   48 x   27, 4 channel, uint16 psd
+    SHA-1: 31AB60835F2FB36DEBEE8FF56FB8D08F4A8F126D
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:d0b5fcf6-f464-234f-b5df-47c18ab8b898"
+    IPTC:InstanceID: "xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Layer"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:30+02:00"
+ subimage  3:   48 x   27, 4 channel, uint16 psd
+    SHA-1: 99B76EB713BA5C84D924E0ADDE14650ADAE2D590
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "adobe:docid:photoshop:d0b5fcf6-f464-234f-b5df-47c18ab8b898"
+    IPTC:InstanceID: "xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "Layer2"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:709ebe80-9e41-244a-81bc-8a5e754fe63e"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00; 2024-04-01T19:35:30+02:00"
+Reading src/Layers_32bit_RGB.psd
+src/Layers_32bit_RGB.psd :   48 x   27, 3 channel, float psd
+    4 subimages: 48x27 [f,f,f], 48x27 [f,f,f,f], 48x27 [f,f,f,f], 48x27 [f,f,f,f]
+ subimage  0:   48 x   27, 3 channel, float psd
+    SHA-1: C9C84C45C64884BD4D6F1B1E91CCA6744EA3C06C
+    channel list: R, G, B
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 2, 56, 108, 99, 109, 115, 4, 48, 0, 0, 109, 110, 116, 114, ... [568 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    thumbnail_height: 27
+    thumbnail_nchannels: 3
+    thumbnail_width: 48
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1818455411
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "No copyright, use freely"
+    ICCProfile:creation_date: "2024:04:01 17:31:55"
+    ICCProfile:creator_signature: "6c636d73"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "RGB built-in"
+    ICCProfile:profile_size: 568
+    ICCProfile:profile_version: "4.3.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    IPTC:DocumentID: "adobe:docid:photoshop:c17239f3-0dba-274a-8b00-2c4bfa538ebe"
+    IPTC:InstanceID: "xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    IPTC:MetadataDate: "2024-04-01T19:35:16+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:16+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "RGB built-in"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00"
+ subimage  1:   48 x   27, 4 channel, float psd
+    SHA-1: 00FF9A578E0AF4490EE2ACB6FDCC8EBC5FD119E4
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 2, 56, 108, 99, 109, 115, 4, 48, 0, 0, 109, 110, 116, 114, ... [568 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1818455411
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "No copyright, use freely"
+    ICCProfile:creation_date: "2024:04:01 17:31:55"
+    ICCProfile:creator_signature: "6c636d73"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "RGB built-in"
+    ICCProfile:profile_size: 568
+    ICCProfile:profile_version: "4.3.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    IPTC:DocumentID: "adobe:docid:photoshop:c17239f3-0dba-274a-8b00-2c4bfa538ebe"
+    IPTC:InstanceID: "xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    IPTC:MetadataDate: "2024-04-01T19:35:16+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:16+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:subimagename: "Blue_Lagoon"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "RGB built-in"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00"
+ subimage  2:   48 x   27, 4 channel, float psd
+    SHA-1: FD0AEA8F5823B878CFAB53B6E0D85F43A382D5CF
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 2, 56, 108, 99, 109, 115, 4, 48, 0, 0, 109, 110, 116, 114, ... [568 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1818455411
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "No copyright, use freely"
+    ICCProfile:creation_date: "2024:04:01 17:31:55"
+    ICCProfile:creator_signature: "6c636d73"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "RGB built-in"
+    ICCProfile:profile_size: 568
+    ICCProfile:profile_version: "4.3.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    IPTC:DocumentID: "adobe:docid:photoshop:c17239f3-0dba-274a-8b00-2c4bfa538ebe"
+    IPTC:InstanceID: "xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    IPTC:MetadataDate: "2024-04-01T19:35:16+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:16+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:subimagename: "Layer"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "RGB built-in"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00"
+ subimage  3:   48 x   27, 4 channel, float psd
+    SHA-1: EA826AA276DDD6E8A4A333EB2FF6F4FAAF1E695F
+    channel list: R, G, B, A
+    DateTime: "2024-03-06T15:22:40+01:00"
+    ICCProfile: 0, 0, 2, 56, 108, 99, 109, 115, 4, 48, 0, 0, 109, 110, 116, 114, ... [568 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop 23.3 (Windows)"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 65535
+    Exif:PixelXDimension: 48
+    Exif:PixelYDimension: 27
+    exrio:name: "applied_color_corrections; cameraAperture; cameraFNumber; cameraFarClip; cameraFarRange; cameraFocalLength; cameraFov; cameraNearClip; cameraNearRange; cameraProjection; cameraTargetDistance; cameraTransform; channels; compression; cryptomatte/881c23b/conversion; cryptomatte/881c23b/hash; cryptomatte/881c23b/manifest; cryptomatte/881c23b/name; dataWindow; displayWindow; lineOrder; name; pixelAspectRatio; screenWindowCenter; screenWindowWidth; type; vfb2_layers_json; vrayChannelInfo; vrayInfo/camera; vrayInfo/cameraPerPix; vrayInfo/cameraRayCountID; vrayInfo/cleanupTimeID; vrayInfo/computername; vrayInfo/cpu; vrayInfo/date; vrayInfo/elapsedtime; vrayInfo/engine; vrayInfo/filename; vrayInfo/frame; vrayInfo/frameTimeID; vrayInfo/freeMemCPU; vrayInfo/giPerPix; vrayInfo/giRayCountID; vrayInfo/h; vrayInfo/infinitePrimsID; vrayInfo/kpaths; vrayInfo/lightcacheTimeID; vrayInfo/mbTrisID"
+    exrio:type: "int; float; m44f; chlist; compression; string; box2i; lineOrder; v2f"
+    exrio:value: 0, 0
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1818455411
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "No copyright, use freely"
+    ICCProfile:creation_date: "2024:04:01 17:31:55"
+    ICCProfile:creator_signature: "6c636d73"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "RGB built-in"
+    ICCProfile:profile_size: 568
+    ICCProfile:profile_version: "4.3.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    IPTC:DocumentID: "adobe:docid:photoshop:c17239f3-0dba-274a-8b00-2c4bfa538ebe"
+    IPTC:InstanceID: "xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    IPTC:MetadataDate: "2024-04-01T19:35:16+02:00"
+    IPTC:ModifyDate: "2024-04-01T19:35:16+02:00"
+    IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
+    oiio:subimagename: "Layer2"
+    photoshop:ColorMode: 3
+    photoshop:ICCProfile: "RGB built-in"
+    rdf:parseType: "Resource"
+    rdf:resource: "http://doc.exr-io.com/metadata/1.0/attribute"
+    stEvt:action: "saved"
+    stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:68fcb000-4377-c148-974d-bdd193ca024d; xmp.iid:cbd904c5-53b4-0d4e-9ff8-37ac35429f46"
+    stEvt:softwareAgent: "Adobe Photoshop 23.3 (Windows)"
+    stEvt:when: "2024-04-01T19:35:16+02:00"

--- a/testsuite/psd/run.py
+++ b/testsuite/psd/run.py
@@ -11,6 +11,7 @@ files = [ "psd_123.psd", "psd_123_nomaxcompat.psd", "psd_bitmap.psd",
           "psd_rgb_32.psd", "psd_rgba_8.psd", "psd_rgb_16_rle.psd" ]
 for f in files:
     command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)
+    # command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + f"/{f} -o ./{f}.tif")
 
 # Test unassociated alpha metadata
 command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/psd_123.psd", extraargs="--no-autopremult")

--- a/testsuite/texture-interp-closest/run.py
+++ b/testsuite/texture-interp-closest/run.py
@@ -8,7 +8,8 @@
 # Adjust error thresholds a tad to account for platform-to-platform variation
 # in some math precision.
 hardfail = 0.032
-failpercent = 0.002
+failpercent = 0.02
+allowfailures = 1
 
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-interpmode 0  -d uint8 -o out.tif")

--- a/testsuite/tiff-depths/ref/out-linuxarm.txt
+++ b/testsuite/tiff-depths/ref/out-linuxarm.txt
@@ -1,0 +1,876 @@
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-02.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 431
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-02.tif" and "flower-minisblack-02.tif"
+PASS
+flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
+../oiio-images/libtiffpic/depth/flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-04.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 221
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-04.tif" and "flower-minisblack-04.tif"
+PASS
+flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
+../oiio-images/libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-06.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-06.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 6
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 148
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-06.tif" and "flower-minisblack-06.tif"
+PASS
+flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+../oiio-images/libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-08.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-08.tif" and "flower-minisblack-08.tif"
+PASS
+flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
+../oiio-images/libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-10.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-10.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 89
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-10.tif" and "flower-minisblack-10.tif"
+PASS
+flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+../oiio-images/libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-12.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-12.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 74
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-12.tif" and "flower-minisblack-12.tif"
+PASS
+flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+../oiio-images/libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-14.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-14.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 64
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-14.tif" and "flower-minisblack-14.tif"
+PASS
+flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+../oiio-images/libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-16.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-16.tif" and "flower-minisblack-16.tif"
+PASS
+flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+../oiio-images/libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-24.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 37
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-24.tif" and "flower-minisblack-24.tif"
+PASS
+flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+../oiio-images/libtiffpic/depth/flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-32.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-32.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 28
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-32.tif" and "flower-minisblack-32.tif"
+PASS
+flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+../oiio-images/libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+Reading ../oiio-images/libtiffpic/depth/flower-palette-02.tif
+../oiio-images/libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:BitsPerSample: 2
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 431
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-02.tif" and "flower-palette-02.tif"
+PASS
+flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
+../oiio-images/libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
+Reading ../oiio-images/libtiffpic/depth/flower-palette-04.tif
+../oiio-images/libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:BitsPerSample: 4
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 221
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-04.tif" and "flower-palette-04.tif"
+PASS
+flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
+../oiio-images/libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
+Reading ../oiio-images/libtiffpic/depth/flower-palette-08.tif
+../oiio-images/libtiffpic/depth/flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-08.tif" and "flower-palette-08.tif"
+PASS
+flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
+../oiio-images/libtiffpic/depth/flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
+Reading ../oiio-images/libtiffpic/depth/flower-palette-16.tif
+../oiio-images/libtiffpic/depth/flower-palette-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 543285C6812105A1DA3B8ADA691D5DA3AE89B10D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-16.tif" and "flower-palette-16.tif"
+PASS
+flower-palette-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 543285C6812105A1DA3B8ADA691D5DA3AE89B10D
+../oiio-images/libtiffpic/depth/flower-palette-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 543285C6812105A1DA3B8ADA691D5DA3AE89B10D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 148
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif" and "flower-rgb-contig-02.tif"
+PASS
+flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 74
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif" and "flower-rgb-contig-04.tif"
+PASS
+flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 37
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif" and "flower-rgb-contig-08.tif"
+PASS
+flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-10.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 29
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif" and "flower-rgb-contig-10.tif"
+PASS
+flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-12.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 24
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif" and "flower-rgb-contig-12.tif"
+PASS
+flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-14.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 21
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif" and "flower-rgb-contig-14.tif"
+PASS
+flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 18
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif" and "flower-rgb-contig-16.tif"
+PASS
+flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 12
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif" and "flower-rgb-contig-24.tif"
+PASS
+flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-32.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 9
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif" and "flower-rgb-contig-32.tif"
+PASS
+flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 431
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif" and "flower-rgb-planar-02.tif"
+PASS
+flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 221
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif" and "flower-rgb-planar-04.tif"
+PASS
+flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif" and "flower-rgb-planar-08.tif"
+PASS
+flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-10.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 89
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif" and "flower-rgb-planar-10.tif"
+PASS
+flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-12.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 74
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif" and "flower-rgb-planar-12.tif"
+PASS
+flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-14.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 64
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif" and "flower-rgb-planar-14.tif"
+PASS
+flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif" and "flower-rgb-planar-16.tif"
+PASS
+flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 37
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif" and "flower-rgb-planar-24.tif"
+PASS
+flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-32.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 28
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif" and "flower-rgb-planar-32.tif"
+PASS
+flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif
+../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-contig-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 28
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif" and "flower-separated-contig-08.tif"
+PASS
+flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif
+../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 5960EB6AB475E0FDB517736F65DF47F6D89F04CB
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-contig-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 14
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif" and "flower-separated-contig-16.tif"
+PASS
+flower-separated-contig-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: E55335D12E9A20EFB0A5EAE80F1801DF5A9BEE12
+../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 5960EB6AB475E0FDB517736F65DF47F6D89F04CB
+Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif
+../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-planar-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif" and "flower-separated-planar-08.tif"
+PASS
+flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif
+../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 5960EB6AB475E0FDB517736F65DF47F6D89F04CB
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-planar-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif" and "flower-separated-planar-16.tif"
+PASS
+flower-separated-planar-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: E55335D12E9A20EFB0A5EAE80F1801DF5A9BEE12
+../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 5960EB6AB475E0FDB517736F65DF47F6D89F04CB
+Comparing "cmyk_as_cmyk.tif" and "ref/cmyk_as_cmyk.tif"
+PASS


### PR DESCRIPTION
GHA offers free runners for Linux on ARM based machines. Let's throw them into the testing mix!

A very small number of tests needed additional reference outputs saved, due to a few LSB type errors in the math.
