### PR TITLE
fix: ImageInput/ImageOutput did not set per-file threads correctly

### DIFF
--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -34,7 +34,7 @@ static std::atomic_int64_t input_next_id(0);
 class ImageInput::Impl {
 public:
     Impl()
-        : m_id(++input_next_id)
+        : m_id(++input_next_id), m_threads(pvt::oiio_threads)
     {
     }
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -34,7 +34,8 @@ static std::atomic_int64_t input_next_id(0);
 class ImageInput::Impl {
 public:
     Impl()
-        : m_id(++input_next_id), m_threads(pvt::oiio_threads)
+        : m_id(++input_next_id)
+        , m_threads(pvt::oiio_threads)
     {
     }
 

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -37,7 +37,8 @@ static std::atomic_int64_t output_next_id(0);
 class ImageOutput::Impl {
 public:
     Impl()
-        : m_id(++output_next_id), m_threads(pvt::oiio_threads)
+        : m_id(++output_next_id)
+        , m_threads(pvt::oiio_threads)
     {
     }
 

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -37,7 +37,7 @@ static std::atomic_int64_t output_next_id(0);
 class ImageOutput::Impl {
 public:
     Impl()
-        : m_id(++output_next_id)
+        : m_id(++output_next_id), m_threads(pvt::oiio_threads)
     {
     }
 


### PR DESCRIPTION
II and IO were documented as initializing their internal "how many threads to use when reading/writing this particular file" to the global "threads" OIIO attribute. But they did not, they always initialized to 0 ("all the threads") even if the global attribute had been set differently prior to creation of the reader or writer.
