### PR TITLE
fix(exr): did not properly allocate 'missingcolor' vector

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -250,7 +250,7 @@ OpenEXRInput::open(const std::string& name, ImageSpec& newspec,
             // missingcolor as numeric array
             int n = m->type().basevalues();
             m_missingcolor.clear();
-            m_missingcolor.reserve(n);
+            m_missingcolor.resize(n);
             for (int i = 0; i < n; ++i)
                 m_missingcolor[i] = m->get_float(i);
         }

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -368,7 +368,7 @@ OpenEXRCoreInput::open(const std::string& name, ImageSpec& newspec,
             // missingcolor as numeric array
             int n = m->type().basevalues();
             m_missingcolor.clear();
-            m_missingcolor.reserve(n);
+            m_missingcolor.resize(n);
             for (int i = 0; i < n; ++i)
                 m_missingcolor[i] = m->get_float(i);
         }


### PR DESCRIPTION
Oops, this internal vector called `reserve()` and then filled in results. Should have been `resize()`.
