### PR TITLE
Upload python stubs as an artifact in CI

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -163,7 +163,11 @@ jobs:
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: cibw-wheels-${{ matrix.python }}-${{ matrix.manylinux }}
-          path: ./wheelhouse/*.whl
+          path: |
+            ./wheelhouse/*.whl
+            ./wheelhouse/OpenImageIO/__init__.pyi
+        # if stub validation fails we want to upload the stubs for users to review
+        if: success() || failure()
 
   # ---------------------------------------------------------------------------
   # Linux ARM Wheels
@@ -225,7 +229,11 @@ jobs:
         - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
           with:
             name: cibw-wheels-${{ matrix.python }}-${{ matrix.manylinux }}
-            path: ./wheelhouse/*.whl
+            path: |
+              ./wheelhouse/*.whl
+              ./wheelhouse/OpenImageIO/__init__.pyi
+          # if stub validation fails we want to upload the stubs for users to review
+          if: success() || failure()
 
   # ---------------------------------------------------------------------------
   # macOS Wheels

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -398,7 +398,7 @@ for more information on customizing and overriding build-tool options and CMake 
 This repo contains python type stubs which are generated from `pybind11` signatures.
 The workflow for releasing new stubs is as follows:
 
-- Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/)
+- Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) and `docker`
 - Run `make pystubs` locally to generate updated stubs in `src/python/stubs/__init__.pyi`
 - Run `make test-pystubs` locally to use mypy to test the stubs against the code in 
   the python testsuite.
@@ -410,6 +410,10 @@ The workflow for releasing new stubs is as follows:
   in a change to the stubs, developers are notified of the need to regenerate 
   the stubs, so that changes can be reviewed and the rules in `generate_stubs.py` 
   can be updated, if necessary.
+
+Note that if you can't (or don't want to) build the stubs locally, you can 
+download an artifact containing the wheel and `__init__.pyi` file from any job 
+that fails the stub validation.
 
 Test Images
 -----------

--- a/src/python/stubs/generate_stubs.py
+++ b/src/python/stubs/generate_stubs.py
@@ -208,6 +208,7 @@ def main() -> None:
             print("Changes to the source code have resulted in a change to the stubs.")
             print(get_colored_diff(old_text, new_text))
             print("Run `make pystubs` locally and commit the results for review.")
+            print("The resulting __init__.pyi file will be uploaded as an artifact on this job.")
             sys.exit(2)
 
 


### PR DESCRIPTION
Provides a path for users who can't build the stubs locally

<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

if the stub check fails, it should generate new stubs and save it as an artifact, so that from the GH page showing the test failure, the user who submitted the PR can download the file, inspect it, and add it to their PR even if they didn't have the capacity to generate it on their end. (This is basically mimicking our "clang-format" test, which when it fails, allows people to download the diffs to apply on their end even if it's not possible for them to actually run "clang-format" with the right version on their own machine.)

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
