### PR TITLE
feat(oiio): Added preflight action process for output action

### DIFF
--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -277,6 +277,8 @@ public:
     /// @defgroup Parsing arguments
     /// @{
 
+    void parse_args_preflight(int argc, const char** argv);
+
     /// With the options already set up, parse the command line. Return 0 if
     /// ok, -1 if it's a malformed command line.
     int parse_args(int argc, const char** argv);
@@ -523,6 +525,15 @@ public:
             m_argparse.params()[dest()] = 1;
             action(ArgParse::store_false());
             return *this;
+        }
+
+        /// Add an arbitrary action:   `func(Arg&, cspan<const char*>)`
+        Arg& pre_action(ArgAction&& func);
+
+        /// Add an arbitrary pre-action:   `func(cspan<const char*>)`
+        Arg& pre_action(Action&& func)
+        {
+            return pre_action([=](Arg&, cspan<const char*> a) { func(a); });
         }
 
         /// Add an arbitrary action:   `func(Arg&, cspan<const char*>)`

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -108,13 +108,13 @@ private:
     std::vector<TypeDesc> m_paramtypes;  // Expected param types
     std::vector<std::string> m_prettyargs;
     ArgParse::ArgAction m_pre_action = nullptr;
-    ArgParse::ArgAction m_action = nullptr;
-    callback_t m_callback        = nullptr;
-    int m_repetitions            = 0;      // number of times on cmd line
-    bool m_has_callback          = false;  // needs a callback?
-    bool m_hidden                = false;  // hidden?
-    bool m_always_run            = false;  // always run?
-    bool m_error                 = false;  // invalid option, had an error
+    ArgParse::ArgAction m_action     = nullptr;
+    callback_t m_callback            = nullptr;
+    int m_repetitions                = 0;      // number of times on cmd line
+    bool m_has_callback              = false;  // needs a callback?
+    bool m_hidden                    = false;  // hidden?
+    bool m_always_run                = false;  // always run?
+    bool m_error                     = false;  // invalid option, had an error
     friend class ArgParse;
     friend class ArgParse::Arg;
     friend class ArgParse::Impl;
@@ -445,7 +445,7 @@ ArgParse::parse_args(int xargc, const char** xargv)
     return r;
 }
 
-void 
+void
 ArgParse::Impl::parse_args_preflight(int argc, const char** argv)
 {
     for (int i = 1; i < argc; ++i) {
@@ -465,7 +465,7 @@ ArgParse::Impl::parse_args_preflight(int argc, const char** argv)
                 } else {
                     int n = option->nargs();
                     option->m_pre_action(*option,
-                        { argv + i, span_size_t(n + 1) });
+                                         { argv + i, span_size_t(n + 1) });
                 }
             }
         }

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5456,7 +5456,7 @@ static void
 pre_output_file(Oiiotool& ot, cspan<const char*> argv)
 {
     OIIO_DASSERT(argv.size() == 2);
-    const std::string filename = ot.express(argv[1]);
+    const std::string filename      = ot.express(argv[1]);
     const std::string outputdirpath = Filesystem::parent_path(filename);
     if (!Filesystem::exists(outputdirpath)) {
         Filesystem::create_directory(outputdirpath);
@@ -6395,7 +6395,7 @@ Oiiotool::getargs(int argc, char* argv[])
 
     bool help = false;
 
-    bool sansattrib = false;
+    bool sansattrib       = false;
     bool preflightenabled = false;
     for (int i = 0; i < argc; ++i) {
         if (!strcmp(argv[i], "--sansattrib") || !strcmp(argv[i], "-sansattrib"))


### PR DESCRIPTION
## Description
This PR is for a feature request: https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4598.
It was noted in the issue that running `oiiotool` with output filename inside a folder that doesn't exist will cause OIIO to consume time and resources, but fail eventually due to the folder not existing.

This PR address this problem by having a new flag `--pre-flight`, that run's thru all the command line arugments, calling a `pre_action` step to the original `action` step.

Take for example the command:
```
oiiotool --pre-flight -i input.png -o ./output_folder/output.png -o ./output_folder_2/output.png
```

In the `-o` action step, the pre output action (`pre_output_file`) will create both the `./output_folder` and `./output_folder_2` folders, and the whole operations completes without failure.

In the future, this can be further extended to other actions that can do validation before the main action (`-i` etc).

## Tests
I can look into adding unit test, but tested it locally, and it creates both the above folders and outputs the image.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
