### PR TITLE
fix(exr): not honoring 'missingcolor' for scanline files

### DIFF
--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -220,6 +220,10 @@ private:
         m_missingcolor.clear();
     }
 
+    bool read_native_scanlines_individually(int subimage, int miplevel,
+                                            int ybegin, int yend, int z,
+                                            int chbegin, int chend, void* data,
+                                            stride_t ystride);
     bool read_native_tiles_individually(int subimage, int miplevel, int xbegin,
                                         int xend, int ybegin, int yend,
                                         int zbegin, int zend, int chbegin,

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1178,7 +1178,7 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
 
 bool
 OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
-                                    int yend, int /*z*/, int chbegin, int chend,
+                                    int yend, int z, int chbegin, int chend,
                                     void* data)
 {
     lock_guard lock(*this);
@@ -1263,8 +1263,31 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             return false;
         }
     } catch (const std::exception& e) {
-        errorfmt("Failed OpenEXR read: {}", e.what());
-        return false;
+        std::string err = e.what();
+        if (m_missingcolor.size()) {
+            // User said not to fail for bad or missing scanlines. If we
+            // failed reading a single scanline, use the fill pattern. If we
+            // failed reading many scanlines, we don't know which ones, so go
+            // back and read them individually for a second chance.
+            DBGEXR("Handling missingcolor case for {}-{}: {}\n", ybegin, yend,
+                   err);
+            if (yend - ybegin == 1) {
+                // Read of one tile -- use the fill pattern
+                fill_missing(m_spec.x, m_spec.x + m_spec.width, ybegin, yend, 0,
+                             1, chbegin, chend, data, pixelbytes,
+                             scanlinebytes);
+            } else {
+                // Read of many tiles -- don't know which failed, so try
+                // again to read them all individually.
+                return read_native_scanlines_individually(subimage, miplevel,
+                                                          ybegin, yend, z,
+                                                          chbegin, chend, data,
+                                                          scanlinebytes);
+            }
+        } else {
+            errorfmt("Failed OpenEXR read: {}", err);
+            return false;
+        }
     } catch (...) {  // catch-all for edge cases or compiler bugs
         errorfmt("Failed OpenEXR read: unknown exception");
         return false;
@@ -1415,6 +1438,25 @@ OpenEXRInput::read_native_tiles(int subimage, int miplevel, int xbegin,
     }
 
     return true;
+}
+
+
+
+bool
+OpenEXRInput::read_native_scanlines_individually(int subimage, int miplevel,
+                                                 int ybegin, int yend, int z,
+                                                 int chbegin, int chend,
+                                                 void* data, stride_t ystride)
+{
+    // Note: this is only called by read_native_scanlines, which still holds
+    // the mutex, so it's safe to directly access m_spec.
+    bool ok = true;
+    for (int y = ybegin; y < yend; ++y) {
+        char* d = (char*)data + (y - ybegin) * ystride;
+        ok &= read_native_scanlines(subimage, miplevel, y, y + 1, z, chbegin,
+                                    chend, d);
+    }
+    return ok;
 }
 
 

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -1209,7 +1209,8 @@ OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     parallel_for_chunked(
         ychunkstart, yend, scansperchunk,
         [&](int64_t yb, int64_t ye) {
-            int y             = std::max(int(yb), ybegin);
+            int y = std::max(int(yb), ybegin);
+            DBGEXR("reading y={}\n", y);
             uint8_t* linedata = static_cast<uint8_t*>(data)
                                 + scanlinebytes * (y - ybegin);
             default_init_vector<uint8_t> fullchunk;
@@ -1268,8 +1269,19 @@ OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             if (rv == EXR_ERR_SUCCESS)
                 rv = exr_decoding_run(m_exr_context, subimage, &decoder);
             if (rv != EXR_ERR_SUCCESS) {
-                ok = false;
-            } else if (cdata != linedata) {
+                if (check_fill_missing(spec.x, spec.x + spec.width, y,
+                                       y + nlines, 0, 1, chbegin, chend,
+                                       cdata + invalid * scanlinebytes,
+                                       pixelbytes, scanlinebytes)) {
+                    // clear the error
+                    DBGEXR("cfm true y={} {}-{}\n", y, yb, ye);
+                    rv = EXR_ERR_SUCCESS;
+                } else {
+                    DBGEXR("cfm false {}-{}\n", yb, ye);
+                    ok = false;
+                }
+            }
+            if (rv == EXR_ERR_SUCCESS && cdata != linedata) {
                 y += invalid;
                 nlines = std::min(nlines, yend - y);
                 memcpy(linedata, cdata + invalid * scanlinebytes,


### PR DESCRIPTION
As a reminder, the global OIIO attribute "missingcolor", or the file-specific ImageInput open hint "oiio:missingcolor" is designed to treat missing scanlines or tiles as not a true error, but instead just pass over them and substitute the missingcolor value for those missing areas on the file.

The nature of this PR is that while we had implemented this behavior fully for tile-based exr files, we never did so for scanline-based files. So here we do.

Now then, unfortunately, it does not work. I think it's a bug in the OpenEXR library itself, but we're still trying to figure that out. But nonetheless, I believe this change is correct.
