### PR TITLE
feat(oiiotool): Added create-dir cmd arg to create dir if it doesn't exist

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -932,6 +932,11 @@ output each one to a different file, with names `sub0001.tif`,
     Sets "no clobber" mode, in which existing images on disk will never be
     overridden, even if the `-o` command specifies that file.
 
+.. option:: --create-dir
+
+    Create output directories if it doesn't exists already 
+    during the `-o` output action.
+
 .. option:: --threads <n>
 
     Use *n* execution threads if it helps to speed up image operations. The

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -165,6 +165,10 @@ inline bool create_directory (string_view path) {
     return create_directory (path, err);
 }
 
+/// Create directory for every element in `path` that does not already exist.
+/// Return true for success, false for failure and place an error message in err.
+OIIO_UTIL_API bool create_directories(string_view path, std::string& err) noexcept;
+
 /// Copy a file, directory, or link. It is an error if 'to' already exists.
 /// The file names are all UTF-8 encoded. Return true upon success, false upon
 /// failure and place an error message in err.

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -382,6 +382,17 @@ Filesystem::create_directory(string_view path, std::string& err)
     return ok;
 }
 
+bool
+Filesystem::create_directories(string_view path, std::string& err) noexcept
+{
+    error_code ec;
+    bool ok = filesystem::create_directories(u8path(path), ec);
+    if (ok)
+        err.clear();
+    else
+        err = ec.message();
+    return ok;
+}
 
 bool
 Filesystem::copy(string_view from, string_view to, std::string& err)

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5514,6 +5514,18 @@ output_file(Oiiotool& ot, cspan<const char*> argv)
         return;
     }
 
+    if (ot.createdirectories) {
+        const std::string outputdirpath = Filesystem::parent_path(filename);
+        if (!Filesystem::exists(outputdirpath)) {
+            const bool result = Filesystem::create_directory(outputdirpath);
+            if (!result) {
+                ot.errorfmt(command, "Failed to create output directory: {}",
+                            outputdirpath);
+                return;
+            }
+        }
+    }
+
     if (ot.noclobber && Filesystem::exists(filename)) {
         ot.warningfmt(command, "{} already exists, not overwriting.", filename);
         return;
@@ -6458,6 +6470,8 @@ Oiiotool::getargs(int argc, char* argv[])
       .help("Do not overwrite existing files");
     ap.arg("--noclobber", &ot.noclobber)
       .hidden(); // synonym
+    ap.arg("--create-dir", &ot.createdirectories)
+      .help("Create output directories if it doesn't exists");
     ap.arg("--threads %d:N")
       .help("Number of threads (default 0 == #cores)")
       .OTACTION(set_threads);

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -77,11 +77,12 @@ public:
     int cachesize;
     int autotile;
     int frame_padding;
-    bool eval_enable;              // Enable evaluation of expressions
-    bool parallel_frames = false;  // Parallelize over frame iteration
-    bool skip_bad_frames = false;  // Just skip a bad frame, don't exit
-    bool nostderr        = false;  // If true, use stdout for errors
-    bool noerrexit       = false;  // Don't exit on error
+    bool eval_enable;                // Enable evaluation of expressions
+    bool parallel_frames   = false;  // Parallelize over frame iteration
+    bool skip_bad_frames   = false;  // Just skip a bad frame, don't exit
+    bool nostderr          = false;  // If true, use stdout for errors
+    bool noerrexit         = false;  // Don't exit on error
+    bool createdirectories = false;
     std::string dumpdata_C_name;
     std::string full_command_line;
     std::string printinfo_metamatch;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -77,12 +77,12 @@ public:
     int cachesize;
     int autotile;
     int frame_padding;
-    bool eval_enable;                // Enable evaluation of expressions
-    bool parallel_frames   = false;  // Parallelize over frame iteration
-    bool skip_bad_frames   = false;  // Just skip a bad frame, don't exit
-    bool nostderr          = false;  // If true, use stdout for errors
-    bool noerrexit         = false;  // Don't exit on error
-    bool createdirectories = false;
+    bool eval_enable;              // Enable evaluation of expressions
+    bool parallel_frames = false;  // Parallelize over frame iteration
+    bool skip_bad_frames = false;  // Just skip a bad frame, don't exit
+    bool nostderr        = false;  // If true, use stdout for errors
+    bool noerrexit       = false;  // Don't exit on error
+    bool create_dir      = false;
     std::string dumpdata_C_name;
     std::string full_command_line;
     std::string printinfo_metamatch;

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -58,6 +58,11 @@ half data[2][2][3] =
   { /* (0, 1): */ { 0.000000000, 0.000000000, 0.000000000 },
     /* (1, 1): */ { 1.000000000, 1.000000000, 0.000000000 } },
 };
+oiiotool ERROR: -o : Non-existent output directory: folder1/folder2
+	--create-dir to create missing output directories
+Full command line was:
+> oiiotool --create 2x2 1 -o folder1/folder2/out.tif
+folder1/folder2/out.tif :    2 x    2, 1 channel, float tiff
 Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -239,6 +239,14 @@ command += oiiotool ("--pattern fill:left=0,0,0:right=1,1,0 2x2 3 -d half -o dum
 command += oiiotool ("-echo dumpdata: --dumpdata dump.exr")
 command += oiiotool ("-echo dumpdata:C --dumpdata:C=data dump.exr")
 
+# TODO: Remove folder1/folder2/out.tif so that consecutive test run passes.
+# Test --create-dir
+# Validate -o failed due to missing directory `folder1/folder2/`
+command += oiiotool ("--create 2x2 1 -o folder1/folder2/out.tif")
+# Validate -o sucessed with flag `--create-dir` and `out.tif` is valid and inside directory `folder1/folder2/`
+command += oiiotool ("--create-dir --create 2x2 1 -o folder1/folder2/out.tif")
+command += oiiotool ("--info folder1/folder2/out.tif")
+
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,
 # below.

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import os
+import shutil
 
 # Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
@@ -239,13 +241,17 @@ command += oiiotool ("--pattern fill:left=0,0,0:right=1,1,0 2x2 3 -d half -o dum
 command += oiiotool ("-echo dumpdata: --dumpdata dump.exr")
 command += oiiotool ("-echo dumpdata:C --dumpdata:C=data dump.exr")
 
-# TODO: Remove folder1/folder2/out.tif so that consecutive test run passes.
 # Test --create-dir
+# Remove `folder1/` if it already exists in order to subsequent test run to pass
+root_folder = "folder1"
+if os.path.exists(root_folder) and os.path.isdir(root_folder):
+    shutil.rmtree(root_folder)
+
 # Validate -o failed due to missing directory `folder1/folder2/`
-command += oiiotool ("--create 2x2 1 -o folder1/folder2/out.tif")
+command += oiiotool (f"--create 2x2 1 -o {root_folder}/folder2/out.tif")
 # Validate -o sucessed with flag `--create-dir` and `out.tif` is valid and inside directory `folder1/folder2/`
-command += oiiotool ("--create-dir --create 2x2 1 -o folder1/folder2/out.tif")
-command += oiiotool ("--info folder1/folder2/out.tif")
+command += oiiotool (f"--create-dir --create 2x2 1 -o {root_folder}/folder2/out.tif")
+command += oiiotool (f"--info {root_folder}/folder2/out.tif")
 
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,


### PR DESCRIPTION
Fixes #4598.

## Description

It was noted in the issue that running `oiiotool` with output filename inside a folder that doesn't exist will cause OIIO to consume time and resources, but fail eventually due to the folder not existing.

Take for example the command:
```
oiiotool --create-dir -i input.png -o ./output_folder/output.png -o ./output_folder_2/output.png
```

During the output action, it creates the directories if needed (`output_folder` and `output_folder_2`), and outputs the images into the folder.

## Tests
Added unit tests. Tested it locally, and it creates both the above folders and outputs the image.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
