### PR TITLE
fix(iv) fix crash on .DS_Store; fix uppercase extensions

### DIFF
--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -167,8 +167,10 @@ main(int argc, char* argv[])
 
             std::vector<std::string> validImages;  // Vector to hold valid images
             for (auto& file : files) {
-                std::string extension = Filesystem::extension(file).substr(
-                    1);  // Remove the leading dot
+                std::string extension
+                    = Filesystem::extension(file,
+                                            false);  // Remove the leading dot
+                Strutil::to_lower(extension);
                 if (std::find(extensionsVector.begin(), extensionsVector.end(),
                               extension)
                     != extensionsVector.end()) {


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

I've found a couple issues with iv when launched with a directory name as input, while iterating through the files in the directory:
1. Crash on .DS_Store file
2. The files with extension in capital letters are not recognised as valid images, due to case-sensitive compare. Capitalised extensions are common in raw camera images.

## Tests

No tests, the changes are trivial, and in UI-specific code, not easy to test.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
