### PR TITLE
Fix #4718 do not resize on open and other zoom fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ gastest.o
 /*.exr
 /*.tif
 /*.jpg
+/*.png
 /*.jxl
 /*.tx
 /*.log

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1252,13 +1252,14 @@ ImageViewer::displayCurrentImage(bool update)
 
     if (update) {
         glwin->update();
+        glwin->clamp_view_to_window();
     }
     float z = zoom();
     if (fitImageToWindowAct->isChecked())
         z = zoom_needed_to_fit(glwin->width(), glwin->height());
     zoom(z);
     //    glwin->trigger_redraw ();
-
+    
     updateTitle();
     updateStatusBar();
     if (infoWindow)

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -2015,7 +2015,7 @@ ImageViewer::zoomIn(bool smooth)
     float current_zoom = zoom();
     if (current_zoom >= 64)
         return;
-    
+
     float newzoom = ceil2f(current_zoom);
 
     this->zoomToCursor(newzoom, smooth);
@@ -2028,11 +2028,11 @@ ImageViewer::zoomOut(bool smooth)
     IvImage* img = cur();
     if (!img)
         return;
-    
+
     float current_zoom = zoom();
     if (current_zoom <= 1.0f / 64)
         return;
-    
+
     float newzoom = floor2f(current_zoom);
 
     this->zoomToCursor(newzoom, smooth);
@@ -2051,10 +2051,11 @@ ImageViewer::zoomToCursor(float newzoom, bool smooth)
     float yoffset = yc - ym;
 
     float maxzoomratio = std::max(oldzoom / newzoom, newzoom / oldzoom);
-    int nsteps = smooth ? (int)OIIO::clamp(20 * (maxzoomratio - 1), 2.0f, 10.0f) : 1;
+    int nsteps = smooth ? (int)OIIO::clamp(20 * (maxzoomratio - 1), 2.0f, 10.0f)
+                        : 1;
     for (int i = 1; i <= nsteps; ++i) {
-        float a = (float)i / (float)nsteps;  // Interpolation amount
-        float z = OIIO::lerp(oldzoom, newzoom, a);
+        float a         = (float)i / (float)nsteps;  // Interpolation amount
+        float z         = OIIO::lerp(oldzoom, newzoom, a);
         float zoomratio = z / oldzoom;
         view(xm + xoffset / zoomratio, ym + yoffset / zoomratio, z, false);
         if (i != nsteps) {

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1252,14 +1252,13 @@ ImageViewer::displayCurrentImage(bool update)
 
     if (update) {
         glwin->update();
-        glwin->clamp_view_to_window();
     }
     float z = zoom();
     if (fitImageToWindowAct->isChecked())
         z = zoom_needed_to_fit(glwin->width(), glwin->height());
     zoom(z);
     //    glwin->trigger_redraw ();
-    
+
     updateTitle();
     updateStatusBar();
     if (infoWindow)

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -854,14 +854,11 @@ ImageViewer::open()
         if (filename.empty())
             continue;
         add_image(filename);
-        //        int n = m_images.size()-1;
-        //        IvImage *newimage = m_images[n];
-        //        newimage->read_iv (0, false, image_progress_callback, this);
     }
+
     if (old_lastimage >= 0) {
         // Otherwise, add_image already did this for us.
         current_image(old_lastimage + 1);
-        fitWindowToImage(true, true);
     }
 }
 
@@ -887,7 +884,6 @@ ImageViewer::openRecentFile()
         if (m_images.size() > 1) {
             // Otherwise, add_image already did this for us.
             current_image(m_images.size() - 1);
-            fitWindowToImage(true, true);
         }
     }
 }

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -265,8 +265,9 @@ private slots:
     void moveToNewWindow();     ///< Split current image off as a new window
     void print();               ///< Print current image
     void deleteCurrentImage();  ///< Deleting displayed image
-    void zoomIn();              ///< Zoom in to next power of 2
-    void zoomOut();             ///< Zoom out to next power of 2
+    void zoomIn(bool smooth = true);              ///< Zoom in to next power of 2
+    void zoomOut(bool smooth = true);             ///< Zoom out to next power of 2
+    void zoomToCursor(float newzoom, bool smooth = true); ///< Zoom to a specific level
     void normalSize();          ///< Adjust zoom to 1:1
     void fitImageToWindow();    ///< Adjust zoom to fit window exactly
     /// Resize window to fit image exactly.  If zoomok is false, do not

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -265,11 +265,12 @@ private slots:
     void moveToNewWindow();     ///< Split current image off as a new window
     void print();               ///< Print current image
     void deleteCurrentImage();  ///< Deleting displayed image
-    void zoomIn(bool smooth = true);              ///< Zoom in to next power of 2
-    void zoomOut(bool smooth = true);             ///< Zoom out to next power of 2
-    void zoomToCursor(float newzoom, bool smooth = true); ///< Zoom to a specific level
-    void normalSize();          ///< Adjust zoom to 1:1
-    void fitImageToWindow();    ///< Adjust zoom to fit window exactly
+    void zoomIn(bool smooth = true);   ///< Zoom in to next power of 2
+    void zoomOut(bool smooth = true);  ///< Zoom out to next power of 2
+    void zoomToCursor(float newzoom,
+                      bool smooth = true);  ///< Zoom to a specific level
+    void normalSize();                      ///< Adjust zoom to 1:1
+    void fitImageToWindow();  ///< Adjust zoom to fit window exactly
     /// Resize window to fit image exactly.  If zoomok is false, do not
     /// change the zoom, even to fit on screen. If minsize is true, do not
     /// resize smaller than default_width x default_height.

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1212,7 +1212,7 @@ IvGL::mousePressEvent(QMouseEvent* event)
 {
     remember_mouse(event->pos());
     int mousemode = m_viewer.mouseModeComboBox->currentIndex();
-    bool Alt = (event->modifiers() & Qt::AltModifier);
+    bool Alt      = (event->modifiers() & Qt::AltModifier);
     m_drag_button = event->button();
     if (!m_mouse_activation) {
         switch (event->button()) {

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1212,19 +1212,19 @@ IvGL::mousePressEvent(QMouseEvent* event)
 {
     remember_mouse(event->pos());
     int mousemode = m_viewer.mouseModeComboBox->currentIndex();
-    bool Alt      = (event->modifiers() & Qt::AltModifier);
+    bool Alt = (event->modifiers() & Qt::AltModifier);
     m_drag_button = event->button();
     if (!m_mouse_activation) {
         switch (event->button()) {
         case Qt::LeftButton:
             if (mousemode == ImageViewer::MouseModeZoom && !Alt)
-                m_viewer.zoomIn();
+                m_viewer.zoomIn(true);  // Animated zoom for mouse clicks
             else
                 m_dragging = true;
             return;
         case Qt::RightButton:
             if (mousemode == ImageViewer::MouseModeZoom && !Alt)
-                m_viewer.zoomOut();
+                m_viewer.zoomOut(true);  // Animated zoom for mouse clicks
             else
                 m_dragging = true;
             return;
@@ -1326,11 +1326,14 @@ IvGL::wheelEvent(QWheelEvent* event)
 {
     m_mouse_activation = false;
     QPoint angdelta    = event->angleDelta() / 8;  // div by 8 to get degrees
+    std::cerr << "angdelta.y() " << angdelta.y() << " angdelta.x() " << angdelta.x() << "\n";
     if (abs(angdelta.y()) > abs(angdelta.x())      // predominantly vertical
         && abs(angdelta.y()) > 2) {                // suppress tiny motions
-        float oldzoom = m_viewer.zoom();
-        float newzoom = (angdelta.y() > 0) ? ceil2f(oldzoom) : floor2f(oldzoom);
-        m_viewer.zoom(newzoom);
+        if (angdelta.y() > 0) {
+            m_viewer.zoomIn(false);
+        } else {
+            m_viewer.zoomOut(false);
+        }
         event->accept();
     }
     // TODO: Update this to keep the zoom centered on the event .x, .y

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1326,7 +1326,6 @@ IvGL::wheelEvent(QWheelEvent* event)
 {
     m_mouse_activation = false;
     QPoint angdelta    = event->angleDelta() / 8;  // div by 8 to get degrees
-    std::cerr << "angdelta.y() " << angdelta.y() << " angdelta.x() " << angdelta.x() << "\n";
     if (abs(angdelta.y()) > abs(angdelta.x())      // predominantly vertical
         && abs(angdelta.y()) > 2) {                // suppress tiny motions
         if (angdelta.y() > 0) {

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -96,8 +96,6 @@ public:
                             GLenum& gltype, GLenum& glformat,
                             GLenum& glinternal) const;
 
-    void clamp_view_to_window();
-
 protected:
     ImageViewer& m_viewer;          ///< Backpointer to viewer
     bool m_shaders_created;         ///< Have the shaders been created?
@@ -189,6 +187,8 @@ private:
     /// closeuptexsize is the size of the texture used to upload the pixelview
     /// to OpenGL.
     const static int closeuptexsize = 16;
+
+    void clamp_view_to_window();
 
     /// checks what OpenGL extensions we have
     ///

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -96,6 +96,8 @@ public:
                             GLenum& gltype, GLenum& glformat,
                             GLenum& glinternal) const;
 
+    void clamp_view_to_window();
+
 protected:
     ImageViewer& m_viewer;          ///< Backpointer to viewer
     bool m_shaders_created;         ///< Have the shaders been created?
@@ -187,8 +189,6 @@ private:
     /// closeuptexsize is the size of the texture used to upload the pixelview
     /// to OpenGL.
     const static int closeuptexsize = 16;
-
-    void clamp_view_to_window();
 
     /// checks what OpenGL extensions we have
     ///

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -266,7 +266,7 @@ public:
     /// precompute.
     struct LevelInfo {
         std::unique_ptr<ImageSpec> m_spec;  ///< ImageSpec for the mip level,
-            // only specified if different from nativespec
+        // only specified if different from nativespec
         ImageSpec nativespec;  ///< Native ImageSpec for the mip level
         mutable std::unique_ptr<float[]> polecolor;  ///< Pole colors
         atomic_ll* tiles_read;  ///< Bitfield for tiles read at least once
@@ -394,10 +394,10 @@ private:
     std::atomic<std::shared_ptr<ImageInput>> m_input;
 #else
     std::shared_ptr<ImageInput> m_input;  ///< Open ImageInput, NULL if closed
-        // Note that m_input, the shared pointer itself, is NOT safe to
-        // access directly. ALWAYS retrieve its value with get_imageinput
-        // (it's thread-safe to use that result) and set its value with
-        // set_imageinput -- those are guaranteed thread-safe.
+    // Note that m_input, the shared pointer itself, is NOT safe to
+    // access directly. ALWAYS retrieve its value with get_imageinput
+    // (it's thread-safe to use that result) and set its value with
+    // set_imageinput -- those are guaranteed thread-safe.
 #endif
     std::vector<SubimageInfo> m_subimages;  ///< Info on each subimage
     TexFormat m_texformat;                  ///< Which texture format


### PR DESCRIPTION
## Description

Fixes #4718

See the demo of problems that were fixed and of fixes in action over here: https://www.loom.com/share/3bdee20b32434e0bbba47d393928d4f7

There are fixed for three problems:
1) Window is not resizing when new image is loaded in (it still does when image being loaded is the only one)
2) When you using scroll mouse wheel it is taking into account where the cursor is (there is some corner case when it doesn't do it perfectly, that I can't catch when it doesn't follow it exactly, but a bit of panning fixes it)
~~3) Switching between images recenters (if image is smaller) or making some other panning nessery to have image in the viewport. I believe it is doing same stuff what happens when window is resized.~~ This has been reverted.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
