### PR TITLE
feat:area probe

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -2380,9 +2380,9 @@ void
 ImageViewer::toggleAreaSample()
 {
     m_areaSampleMode = !m_areaSampleMode;
-    // if (m_areaSampleMode == false){
-    //     updateStatusBar();
-    // }
+    if (m_areaSampleMode == false){
+        updateStatusBar();
+    }
     ((QOpenGLWidget*)(glwin))->update();
 }
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -460,6 +460,11 @@ ImageViewer::createActions()
     slideShowDuration->setAccelerated(true);
     connect(slideShowDuration, SIGNAL(valueChanged(int)), this,
             SLOT(setSlideShowDuration(int)));
+
+    toggleAreaSampleAct = new QAction(tr("Toggle Area Sample"), this);
+    toggleAreaSampleAct->setCheckable(true);
+    toggleAreaSampleAct->setShortcut(tr("E"));
+    connect(toggleAreaSampleAct, SIGNAL(triggered()), this, SLOT(toggleAreaSample()));
 }
 
 
@@ -706,6 +711,7 @@ ImageViewer::createMenus()
     // Mode: select, zoom, pan, wipe
     toolsMenu->addAction(showInfoWindowAct);
     toolsMenu->addAction(showPixelviewWindowAct);
+    toolsMenu->addAction(toggleAreaSampleAct);
     toolsMenu->addMenu(slideMenu);
     toolsMenu->addMenu(sortMenu);
 
@@ -2367,4 +2373,19 @@ ImageViewer::editPreferences()
         preferenceWindow->setPalette(m_palette);
     }
     preferenceWindow->show();
+}
+
+
+void
+ImageViewer::toggleAreaSample()
+{
+    m_areaSampleMode = !m_areaSampleMode;
+    // if (m_areaSampleMode == false){
+    //     updateStatusBar();
+    // }
+    ((QOpenGLWidget*)(glwin))->update();
+}
+
+bool ImageViewer::areaSampleMode() const {
+    return m_areaSampleMode;
 }

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -248,6 +248,7 @@ public:
 
     void rawcolor(bool val) { m_rawcolor = val; }
     bool rawcolor() const { return m_rawcolor; }
+    bool areaSampleMode() const;
 
     bool useOCIO() { return m_useOCIO; }
     const std::string& ocioColorSpace() { return m_ocioColourSpace; }
@@ -313,6 +314,7 @@ private slots:
     void showInfoWindow();       ///< View extended info on image
     void showPixelviewWindow();  ///< View closeup pixel view
     void editPreferences();      ///< Edit viewer preferences
+    void toggleAreaSample();     ///< Use area probe
 
     void useOCIOAction(bool checked);
     void ocioColorSpaceAction();
@@ -380,6 +382,7 @@ private:
     QAction* showInfoWindowAct;
     QAction* editPreferencesAct;
     QAction* showPixelviewWindowAct;
+    QAction* toggleAreaSampleAct;
     QAction* toggleWindowGuidesAct;
     QMenu *fileMenu, *editMenu, /**imageMenu,*/ *viewMenu, *toolsMenu,
         *helpMenu;
@@ -416,6 +419,7 @@ private:
     QPalette m_palette;                       // Custom palette
     bool m_darkPalette;                       // Use dark palette?
     bool m_rawcolor = false;                  // Use raw color mode
+    bool m_areaSampleMode = false;            // Use area sample mode
 
     // The default width and height of the window:
     static const int m_default_width  = 640;

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1321,7 +1321,7 @@ IvGL::mousePressEvent(QMouseEvent* event)
 {
     remember_mouse(event->pos());
     int mousemode = m_viewer.mouseModeComboBox->currentIndex();
-    mousemode = 3;
+    // mousemode = 3;
     bool Alt      = (event->modifiers() & Qt::AltModifier);
     m_drag_button = event->button();
     if (!m_mouse_activation) {
@@ -1389,8 +1389,8 @@ IvGL::mouseMoveEvent(QMouseEvent* event)
     int mousemode = m_viewer.mouseModeComboBox->currentIndex();
     bool do_pan = false, do_zoom = false, do_wipe = false;
     bool do_select = false, do_annotate = false;
-    std::cerr << mousemode;
-    switch (3) {
+    // std::cerr << mousemode;
+    switch (mousemode) {
     case ImageViewer::MouseModeZoom:
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
         if ((m_drag_button == Qt::MiddleButton)

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -699,9 +699,23 @@ IvGL::paintGL()
         
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        glColor4f(0.2f, 0.5f, 1.0f, 1.3f);  // Light blue fill with transparency
+        glColor4f(0.2f, 0.5f, 1.0f, 0.3f);  // Light blue fill with transparency
+
+        int w = width();
+        int h = height();
+
+        float x1 = m_select_start.x() - w / 2.0f;
+        float y1 = -(m_select_start.y() - h / 2.0f);
+
+        float x2 = m_select_end.x() - w / 2.0f;
+        float y2 = -(m_select_end.y() - h / 2.0f);
         
-        gl_rect( 0,0,200,200, -0.1f);     
+        int left   = std::min(x1, x2);
+        int right  = std::max(x1, x2);
+        int bottom = std::min(y1, y2);
+        int top    = std::max(y1, y2);   
+        
+        gl_rect( left, bottom, right, top, -0.1f);     
         
         glPopAttrib();     
     

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -665,31 +665,12 @@ IvGL::paintGL()
         paint_windowguides();
     }
 
-    // glPushMatrix();
-    //     glLoadIdentity();
-    //     glTranslatef(0, 0, 0);
-
-    //     glPushAttrib(GL_ENABLE_BIT | GL_CURRENT_BIT);
-    //     glDisable(GL_TEXTURE_2D);
-    //     if (m_use_shaders) {
-    //         glUseProgram(0);
-    //     }
-        
-    //     glEnable(GL_BLEND);
-    //     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    //     glColor4f(0.2f, 0.5f, 1.0f, .3f);  // Light blue fill with transparency
-        
-    //     gl_rect( 0,0,200,200, -0.1f);     
-        
-    //     glPopAttrib();
-
-    // glPopMatrix();
-
     if (m_selecting){
-        std::cerr << "Drawing selection rectangle...\n";
         glPushMatrix();
         glLoadIdentity();
-        glTranslatef(0, 0, 0);
+        // Transform is now same as the main GL viewport -- window pixels as
+        // units, with (0,0) at the center of the visible window.
+
 
         glPushAttrib(GL_ENABLE_BIT | GL_CURRENT_BIT);
         glDisable(GL_TEXTURE_2D);
@@ -1264,40 +1245,70 @@ IvGL::clamp_view_to_window()
 void
 IvGL::analyze_selected_area()
 {
-    QRect rect = QRect(m_select_start, m_select_end).normalized();
+    IvImage* img = m_current_image;
+    const ImageSpec& spec(img->spec());
 
-    float zoom = m_zoom;
-    int img_x0 = (rect.left() - m_centerx) / zoom;
-    int img_y0 = (rect.top() - m_centery) / zoom;
-    int img_x1 = (rect.right() - m_centerx) / zoom;
-    int img_y1 = (rect.bottom() - m_centery) / zoom;
+    int x1, y1;
+    get_given_image_pixel(x1, y1, m_select_start.x(), m_select_start.y());
 
-    float minVal = FLT_MAX, maxVal = -FLT_MAX, sum = 0;
+    int x2, y2;
+    get_given_image_pixel(x2, y2, m_select_end.x(), m_select_end.y());
+    
+    float scale_x  = 1.0f;
+    float scale_y  = 1.0f;
+    float rotate_z = 0.0f;
+    float x1_img = x1;
+    float y1_img = y1;
+    float x2_img = x2;
+    float y2_img = y2;
+
+    handle_orientation(img->orientation(), spec.width, spec.height,
+                    scale_x, scale_y, rotate_z, x1_img, y1_img, true);
+    handle_orientation(img->orientation(), spec.width, spec.height,
+                    scale_x, scale_y, rotate_z, x2_img, y2_img, true);
+
+    x1_img = clamp<int>(x1_img, 0, spec.width - 1);
+    x2_img = clamp<int>(x2_img, 0, spec.width - 1);
+    y1_img = clamp<int>(y1_img, 0, spec.height - 1);
+    y2_img = clamp<int>(y2_img, 0, spec.height - 1);
+
+    int xmin = std::min(x1_img, x2_img);
+    int xmax = std::max(x1_img, x2_img);
+    int ymin = std::min(y1_img, y2_img);
+    int ymax = std::max(y1_img, y2_img);
+
+    // Min and max
+    std::vector<float> min_vals(spec.nchannels, std::numeric_limits<float>::max());
+    std::vector<float> max_vals(spec.nchannels, std::numeric_limits<float>::lowest());
+    std::vector<double> sums(spec.nchannels, 0.0);
     int count = 0;
 
-    const ImageBuf* img = m_current_image;
-    if (!img) return;
-
-    ImageBuf::ConstIterator<float> it(*img);
-    for (int y = img_y0; y <= img_y1; ++y) {
-        for (int x = img_x0; x <= img_x1; ++x) {
-            it.pos(x, y);
-            if (!it.valid()) continue;
-
-            int nchannels = img->nchannels();
-            for (int c = 0; c < nchannels; ++c) {
-                float val = it[c];
-                minVal = std::min(minVal, val);
-                maxVal = std::max(maxVal, val);
-                sum += val;
-                ++count;
+    // loop through each pixel
+    float* fpixel = OIIO_ALLOCA(float, spec.nchannels);
+    for (int y = ymin; y <= ymax; ++y) {
+        for (int x = xmin; x <= xmax; ++x) {
+            img->getpixel(x + spec.x, y + spec.y, fpixel);
+            for (int c = 0; c < spec.nchannels; ++c) {
+                min_vals[c] = std::min(min_vals[c], fpixel[c]);
+                max_vals[c] = std::max(max_vals[c], fpixel[c]);
+                sums[c] += fpixel[c];
             }
+            ++count;
         }
     }
-    float avg = (count > 0) ? sum / count : 0;
-    QString result = QString("Area Probe: min=%1 max=%2 avg=%3")
-                         .arg(minVal).arg(maxVal).arg(avg);
-    m_viewer.statusViewInfo->setText(result);
+
+QString result = "Area Probe:\n";
+for (int c = 0; c < spec.nchannels; ++c) {
+    float avg = (count > 0) ? static_cast<float>(sums[c] / count) : 0.0f;
+    result += QString(" [ch%1: min=%2 max=%3 avg=%4]\n")
+                  .arg(c)
+                  .arg(min_vals[c])
+                  .arg(max_vals[c])
+                  .arg(avg);
+                
+}
+
+m_viewer.statusViewInfo->setText(result);
 
 
 
@@ -1470,7 +1481,29 @@ IvGL::get_focus_window_pixel(int& x, int& y)
     y = m_mousey;
 }
 
-
+void
+IvGL::get_given_image_pixel(int& x, int& y, int mouseX, int mouseY){
+    int w = width(), h = height();
+    float z = m_zoom;
+    // left,top,right,bottom are the borders of the visible window, in
+    // pixel coordinates
+    float left   = m_centerx - 0.5 * w / z;
+    float top    = m_centery - 0.5 * h / z;
+    float right  = m_centerx + 0.5 * w / z;
+    float bottom = m_centery + 0.5 * h / z;
+    // normx,normy are the position of the mouse, in normalized (i.e. [0..1])
+    // visible window coordinates.
+    float normx = (float)(mouseX + 0.5f) / w;
+    float normy = (float)(mouseY + 0.5f) / h;
+    // imgx,imgy are the position of the mouse, in pixel coordinates
+    float imgx = OIIO::lerp(left, right, normx);
+    float imgy = OIIO::lerp(top, bottom, normy);
+    // So finally x,y are the coordinates of the image pixel (on [0,res-1])
+    // underneath the mouse cursor.
+    //FIXME: Shouldn't this take image rotation into account?
+    x = (int)floorf(imgx);
+    y = (int)floorf(imgy);
+}
 
 void
 IvGL::get_focus_image_pixel(int& x, int& y)

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -213,6 +213,7 @@ private:
 
     /// Destroys shaders and selects fixed-function pipeline
     void create_shaders_abort(void);
+    
 };
 
 #endif  // OPENIMAGEIO_IVGL_H

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -76,6 +76,10 @@ public:
     /// widget boundaries)
     void get_focus_window_pixel(int& x, int& y);
 
+    /// Which image pixel is in the given mouse position?
+    ///
+    void get_given_image_pixel(int& x, int& y, int mouseX, int mouseY);
+
     void analyze_selected_area();
 
     /// Returns true if OpenGL is capable of loading textures in the sRGB color

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -76,6 +76,8 @@ public:
     /// widget boundaries)
     void get_focus_window_pixel(int& x, int& y);
 
+    void analyze_selected_area();
+
     /// Returns true if OpenGL is capable of loading textures in the sRGB color
     /// space.
     bool is_srgb_capable(void) const { return m_use_srgb; }
@@ -107,6 +109,9 @@ protected:
     bool m_dragging;                ///< Are we dragging?
     int m_mousex, m_mousey;         ///< Last mouse position
     Qt::MouseButton m_drag_button;  ///< Button on when dragging
+    QPoint m_select_start;
+    QPoint m_select_end;
+    bool m_selecting;
     bool m_use_shaders;             ///< Are shaders supported?
     bool m_use_halffloat;           ///< Are half-float textures supported?
     bool m_use_float;               ///< Are float textures supported?

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -80,6 +80,7 @@ public:
     ///
     void get_given_image_pixel(int& x, int& y, int mouseX, int mouseY);
 
+    /// What are the min/max/avg values of each channel in the selected area?
     void analyze_selected_area();
 
     /// Returns true if OpenGL is capable of loading textures in the sRGB color
@@ -113,9 +114,9 @@ protected:
     bool m_dragging;                ///< Are we dragging?
     int m_mousex, m_mousey;         ///< Last mouse position
     Qt::MouseButton m_drag_button;  ///< Button on when dragging
-    QPoint m_select_start;
-    QPoint m_select_end;
-    bool m_selecting;
+    QPoint m_select_start;          ///< Mouse start position for the area probe
+    QPoint m_select_end;            ///< Mouse end position for the area probe
+    bool m_selecting;               ///< Are we selecting?
     bool m_use_shaders;             ///< Are shaders supported?
     bool m_use_halffloat;           ///< Are half-float textures supported?
     bool m_use_float;               ///< Are float textures supported?


### PR DESCRIPTION

## Description

This PR is for a feature request: https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4714.

This PR adds support for selecting a rectangular region within an image to compute and display per-channel minimum, maximum, and average values.

The feature can be activated through the Tools menu or by using a keyboard shortcut (E) . Once active, the user can click and drag with the left mouse button to define a rectangular area, which is visually indicated by a blue outline. Upon releasing the mouse button, the tool calculates statistics for all pixels within the selected area and displays the results in the status bar.

## Checklist:

- [x ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
