### PR TITLE
Use screen pixel ratio to render sharp text in pixel view tool

### DIFF
--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -690,7 +690,9 @@ IvGL::shadowed_text(float x, float y, float /*z*/, const std::string& s,
      * Paint on intermediate QImage, AA text on QOpenGLWidget based
      * QPaintDevice requires MSAA
      */
-    QImage t(size(), QImage::Format_ARGB32_Premultiplied);
+    qreal dpr = devicePixelRatio();
+    QImage t(size() * dpr, QImage::Format_ARGB32_Premultiplied);
+    t.setDevicePixelRatio(dpr);
     t.fill(qRgba(0, 0, 0, 0));
     {
         QPainter painter(&t);


### PR DESCRIPTION
## Description

Improve sharpness of text in pixel view tool for HiDPI screen

Before:
![Screenshot 2025-05-17 at 4 45 50 pm](https://github.com/user-attachments/assets/f2b14aa6-dcbe-46a7-a2d5-a83097baa94d)

After:
![Screenshot 2025-05-17 at 4 47 11 pm](https://github.com/user-attachments/assets/be42f794-d6e0-4b9f-8847-da733b3a3872)

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
