### PR TITLE
feat(webp): Allow finer grained control over WEBP compression settings

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -3099,6 +3099,19 @@ control aspects of the writing itself:
        unassociated form (non-premultiplied colors) and should stay that way
        for output rather than being assumed to be associated and get automatic
        un-association to store in the file.
+   * - ``Compression``
+     - string
+     - If supplied, can be either ``"webp:quality"`` or ``"lossless:quality"``
+       where quality can be an integer between 0 and 100, and where using "webp"
+       indicates a request for lossy compression. For lossy, 0 gives the smallest
+       size and 100 the largest. For lossless, this parameter is the amount of effort
+       put into the compression: 0 is the fastest but gives larger files compared to
+       the slowest, but best, 100. The default, if quality is not specified, is
+       100 for lossy and 70 for lossless.
+   * - ``webp:method``
+     - int
+     - A general quality/speed trade-off (0=fast, 6=slower-better) for both
+       lossy and lossless image encoding. The default is 6.
 
 **Custom I/O Overrides**
 


### PR DESCRIPTION
## Description

WEBP uses the `WebPConfig::factor` setting to also control how hard it tries to compress when lossless compression is used. It also uses another `WebPConfig::method` setting to further tune both lossless and lossy schemes. [1]

Expose both of these settings so client applications using OIIO can adjust these values as they see fit.

This PR makes 4 changes:
- Adds support for using a `lossless:factor` value for the `compression` attribute. The 'factor' value controls the effort that WEBP uses during the compression process.
- Adds support for using a `webp:method` int attribute. The value of this attribute controls the `WebPConfig::method` setting. Note: this is different than the compression settings but will also affect speed and quality in various ways.
- Sets `WebPPicture::use_argb` to `true` when using lossless compression (per the WEBP documentation[2])
- Changes default lossless "quality" from 100 to 70. This results in much faster image output at a very minor increase in file size (e.g. a 2048x2048 test image goes from 1300ms/364kb to 800ms/371kb after this change)

Before - just 2 basic forms were possible:
```
Client uses "compression=lossless"
- OIIO uses lossless=true, method=6, quality=100, use_argb=false
Client uses "compression=webp:90"
- OIIO uses lossless=false, method=6, quality=90, use_argb=false
```

After - several additional variations are possible:
```
Client uses "compression=lossless"
- OIIO uses lossless=true, method=6, quality=70, use_argb=true
Client uses "compression=lossless:100" and "webp:method=4"
- OIIO uses lossless=true, method=4, quality=100, use_argb=true
Client uses "compression=webp:90"
- OIIO uses lossless=false, method=6, quality=90, use_argb=false
Client uses "compression=webp:90" and "webp:method=4"
- OIIO uses lossless=false, method=4, quality=90, use_argb=false
```

[1] https://developers.google.com/speed/webp/docs/api#advanced_encoding_api
[2] See notes around `use_argb` from the above link and see also the internal Encode helper function which keeps lossless and use_argb in sync: https://github.com/webmproject/libwebp/blob/main/src/enc/picture_enc.c#L241

## Tests

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
