### PR TITLE
fix(iv): Bug fix for iv window loosing focus on mac on startup

### DIFF
--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -138,6 +138,8 @@ main(int argc, char* argv[])
     if (ap["rawcolor"].get<int>())
         mainWin->rawcolor(true);
 
+    QApplication::processEvents();  // Process any pending events
+
     // Make sure we are the top window with the focus.
     mainWin->raise();
     mainWin->activateWindow();


### PR DESCRIPTION
## Description

Master version of the iv today when opening on mac sometimes opens without a focus, which causes top menu bar not to be populated (just `iv` on the left). Workaround is to switch back and forth once to and from another app for menu bar too get populated.

It is unclear to me how reliably replicate the bug so that I have a solid prove, that this fix works. But since building with this line it never happend to me yet.

Maybe more knowledgable in Qt can verify if it makes sense.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
