### PR TITLE
fix(python): IBA.demosaic had GIL release in wrong spot

### DIFF
--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -2397,9 +2397,9 @@ IBA_demosaic_ret(const ImageBuf& src, const std::string& pattern = "",
                  py::object white_balance = py::none(), ROI roi = ROI::All(),
                  int nthreads = 0)
 {
-    py::gil_scoped_release gil;
     std::vector<float> wb;
     py_to_stdvector(wb, white_balance);
+    py::gil_scoped_release gil;
     return ImageBufAlgo::demosaic(src,
                                   { { "pattern", pattern },
                                     { "algorithm", algorithm },
@@ -2416,9 +2416,9 @@ IBA_demosaic(ImageBuf& dst, const ImageBuf& src,
              py::object white_balance = py::none(), ROI roi = ROI::All(),
              int nthreads = 0)
 {
-    py::gil_scoped_release gil;
     std::vector<float> wb;
     py_to_stdvector(wb, white_balance);
+    py::gil_scoped_release gil;
     return ImageBufAlgo::demosaic(dst, src,
                                   { { "pattern", pattern },
                                     { "algorithm", algorithm },


### PR DESCRIPTION
Only symptomatic on debug builds, but I was seeing exceptions from pybind11 about bad GIL release. I traced it to the recent implementations of demosaic. Apparently it's not safe to release the GIL until AFTER the call to py_to_stdvector. Which makes sense when you think about it -- we need the lock whenever we are interacting directly with Python calls or data structures (such as what py_to_stdvector is doing), but we release it when we're done with the python and only calling OIIO internals (such as IBA::demosaic() itself).
