### PR TITLE
ci: Update linux arm clang reference output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
               sudo rm -rf /usr/local/include/OpenEXR
               sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
           - desc: Linux ARM latest releases gcc14 C++20 py3.12 exr3.3 ocio2.4
-            nametag: linux-latest-releases
+            nametag: linux-arm-latest-releases
             runner: ubuntu-24.04-arm
             cc_compiler: gcc-14
             cxx_compiler: g++-14
@@ -533,7 +533,7 @@ jobs:
                             FREETYPE_VERSION=VER-2-13-3
                             USE_OPENVDB=0
           - desc: Linux ARM latest releases clang18 C++20 py3.12 exr3.3 ocio2.4
-            nametag: linux-latest-releases
+            nametag: linux-arm-latest-releases-clang
             runner: ubuntu-24.04-arm
             cc_compiler: clang-18
             cxx_compiler: clang++-18

--- a/testsuite/docs-examples-cpp/ref/out-linuxarm.txt
+++ b/testsuite/docs-examples-cpp/ref/out-linuxarm.txt
@@ -144,3 +144,5 @@ Comparing "simple.tif" and "ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "ref/scanlines.tif"
 PASS
+Comparing "tiles.tif" and "ref/tiles.tif"
+PASS

--- a/testsuite/docs-examples-python/ref/out-linuxarm.txt
+++ b/testsuite/docs-examples-python/ref/out-linuxarm.txt
@@ -144,3 +144,5 @@ Comparing "simple.tif" and "../docs-examples-cpp/ref/simple.tif"
 PASS
 Comparing "scanlines.tif" and "../docs-examples-cpp/ref/scanlines.tif"
 PASS
+Comparing "tiles.tif" and "ref/tiles.tif"
+PASS


### PR DESCRIPTION
Two PRs crossed paths in flight last week -- one adding the ARM tests, the other doing something that changed the reference output of this test slightly. Both passed on their own, but the combo left one platform's output needing the update.
