### PR TITLE
Add `htj2k` as a compression option for the OpenEXR plugin in OIIO

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1497,8 +1497,8 @@ The official OpenEXR site is http://www.openexr.com/.
    * - ``compression``
      - string
      - one of: ``"none"``, ``"rle"``, ``"zip"``, ``"zips"``, ``"piz"``,
-       ``"pxr24"``, ``"b44"``, ``"b44a"``, ``"dwaa"``, or ``"dwab"``.  If
-       the writer receives a request for a compression type it does not
+       ``"pxr24"``, ``"b44"``, ``"b44a"``, ``"dwaa"``, ``"dwab"`` or ``"htj2k"``.
+       If the writer receives a request for a compression type it does not
        recognize or is not supported by the version of OpenEXR on the
        system, it will use ``"zip"`` by default. For ``"dwaa"`` and
        ``"dwab"``, the dwaCompressionLevel may be optionally appended to the

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1498,6 +1498,7 @@ The official OpenEXR site is http://www.openexr.com/.
      - string
      - one of: ``"none"``, ``"rle"``, ``"zip"``, ``"zips"``, ``"piz"``,
        ``"pxr24"``, ``"b44"``, ``"b44a"``, ``"dwaa"``, ``"dwab"`` or ``"htj2k"``.
+       (``"htj2k"`` is only supported with OpenEXR 3.4 or later.)
        If the writer receives a request for a compression type it does not
        recognize or is not supported by the version of OpenEXR on the
        system, it will use ``"zip"`` by default. For ``"dwaa"`` and

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -437,6 +437,9 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         case Imf::B44A_COMPRESSION: comp = "b44a"; break;
         case Imf::DWAA_COMPRESSION: comp = "dwaa"; break;
         case Imf::DWAB_COMPRESSION: comp = "dwab"; break;
+#ifdef IMF_HTJ2K_COMPRESSION
+        case Imf::HTJ2K_COMPRESSION: comp = "htj2k"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -571,6 +571,9 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
         case EXR_COMPRESSION_B44A: comp = "b44a"; break;
         case EXR_COMPRESSION_DWAA: comp = "dwaa"; break;
         case EXR_COMPRESSION_DWAB: comp = "dwab"; break;
+#ifdef IMF_HTJ2K_COMPRESSION
+        case EXR_COMPRESSION_HTJ2K: comp = "htj2k"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -962,7 +962,7 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
                 header.compression() = Imf::DWAB_COMPRESSION;
 #ifdef IMF_HTJ2K_COMPRESSION
             else if (Strutil::iequals(str, "htj2k"))
-                header.compression() = Imf::HTJ2k_COMPRESSION;
+                header.compression() = Imf::HTJ2K_COMPRESSION;
 #endif
         }
         return true;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -960,6 +960,10 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
                 header.compression() = Imf::DWAA_COMPRESSION;
             else if (Strutil::iequals(str, "dwab"))
                 header.compression() = Imf::DWAB_COMPRESSION;
+#ifdef IMF_HTJ2K_COMPRESSION
+            else if (Strutil::iequals(str, "htj2k"))
+                header.compression() = Imf::HTJ2k_COMPRESSION;
+#endif
         }
         return true;
     }


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

After adding the new `htj2k` compression codec to OpenEXR,  here we enable it in the OIIO stack so it will be recognized by the library and binary tools, such as using `oiiotool` to directly change compression type into htj2k.

EXR side is planning to do a round of renaming of enum names (https://github.com/AcademySoftwareFoundation/openexr/pull/2048), and therefore this MR is marked as Draft for visibility for now. The enum names should be changed to `htj2k` name after 2048 on the EXR side goes into the mainline.

I'm also trying to study if more changes on the OIIO side is required to enabled the new `htj2k` codec throughout the OIIO tool chain... suggestions welcome.
 
## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

Draft MR, more test will be followed up.

Does this need a new test?

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
