### PR TITLE
fix: build break from untested combo of two PRs

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3915,7 +3915,7 @@ ImageCacheImpl::add_tile(ustring filename, int subimage, int miplevel, int x,
     }
     if (chend < chbegin) {  // chend < chbegin means "all channels."
         chbegin = 0;
-        chend   = file->spec(subimage, miplevel).nchannels;
+        chend   = file->spec(subimage).nchannels;
     }
     TileID tileid(*file, subimage, miplevel, x, y, z, chbegin, chend);
     ImageCacheTileRef tile


### PR DESCRIPTION
Oops, my bad. Looks like #4664 (merged about a week ago) and #4783 (merged today, but authored before #4664 was merged) interacted in a way that produced a build break. This tiny fix is essential to unbreak it.
