### PR TITLE
api: Add new ImageInput::supports() query: "mipmap"

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -35,7 +35,7 @@ public:
     const char* format_name(void) const override { return "dds"; }
     int supports(string_view feature) const override
     {
-        return feature == "ioproxy";
+        return feature == "ioproxy" || feature == "mipmap";
     }
     bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1032,6 +1032,12 @@ public:
     ///       (Note: this doesn't necessarily mean that the particular
     ///       file this ImageInput is reading has multiple subimages.)
     ///
+    ///  - `"mipmap"` :
+    ///       Does this format support multiple resolutions for an
+    ///       image/subimage? (Note: this doesn't necessarily mean that the
+    ///       particular file this ImageInput is reading is MIP-mapped.)
+    ///       This query was added in OpenImageIO 3.1.
+    ///
     ///  - `"noimage"` :
     ///        Does this format allow 0x0 sized images, i.e. an image file
     ///        with metadata only and no pixels?

--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -102,7 +102,7 @@ public:
                 || feature == "exif"  // Because of arbitrary_metadata
                 || feature == "ioproxy"
                 || feature == "iptc"  // Because of arbitrary_metadata
-                || feature == "multiimage");
+                || feature == "multiimage" || feature == "mipmap");
     }
     bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec,

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -106,7 +106,7 @@ public:
                 || feature == "exif"  // Because of arbitrary_metadata
                 || feature == "ioproxy"
                 || feature == "iptc"  // Because of arbitrary_metadata
-                || feature == "multiimage");
+                || feature == "multiimage" || feature == "mipmap");
     }
     bool valid_file(const std::string& filename) const override;
     bool open(const std::string& name, ImageSpec& newspec,

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -23,8 +23,9 @@ public:
     int supports(string_view feature) const override
     {
         return (feature == "arbitrary_metadata"
-                || feature == "exif"    // Because of arbitrary_metadata
-                || feature == "iptc");  // Because of arbitrary_metadata
+                || feature == "exif"  // Because of arbitrary_metadata
+                || feature == "iptc"  // Because of arbitrary_metadata
+                || feature == "multiimage" || feature == "mipmap");
     }
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool close() override;

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -102,7 +102,7 @@ public:
     int supports(string_view feature) const override
     {
         return (feature == "exif" || feature == "iptc" || feature == "ioproxy"
-                || feature == "multiimage");
+                || feature == "multiimage" || feature == "mipmap");
         // N.B. No support for arbitrary metadata.
     }
     bool open(const std::string& name, ImageSpec& newspec) override;


### PR DESCRIPTION
ImageOutput::supports() recognized queries for "multiimage" and "mipmap".  But ImageInput::supports() only recognized "multiimage". Add "mipmap" to make it easier for client software to know if the image file format they're reading from allows the possibility of MIP-mapping.

As far as I can tell, only OpenEXR, TIFF, Ptex, and DDS do, among the file types we currently support.
