### PR TITLE
build(jxl): Use correct cmake variables for the include directories

### DIFF
--- a/src/cmake/modules/FindJXL.cmake
+++ b/src/cmake/modules/FindJXL.cmake
@@ -41,5 +41,4 @@ find_package_handle_standard_args(JXL
 
 if(JXL_FOUND)
   set(JXL_LIBRARIES ${JXL_LIBRARY} ${JXL_THREADS_LIBRARY})
-  set(JXL_INCLUDES ${JXL_INCLUDE_DIR})
 endif(JXL_FOUND)

--- a/src/jpegxl.imageio/CMakeLists.txt
+++ b/src/jpegxl.imageio/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 if (JXL_FOUND)
     add_oiio_plugin (jxlinput.cpp jxloutput.cpp
-                     INCLUDE_DIRS ${JXL_INCLUDE_DIRS}
+                     INCLUDE_DIRS ${JXL_INCLUDE_DIR}
                      LINK_LIBRARIES ${JXL_LIBRARIES}
                      DEFINITIONS "USE_JXL")
 else()


### PR DESCRIPTION
I'm unsure how this could have worked correctly. There were three different variables used before, now there is only one.

<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
