### PR TITLE
api: image_span-ify ImageBuf

### DIFF
--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -62,6 +62,9 @@ Constructing a writable ImageBuf
 Constructing an ImageBuf that "wraps" an application buffer
 -------------------------------------------------------------
 
+.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec &spec, const image_span<T>&)
+.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec &spec, const image_span<T>&)
+
 .. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec &spec, void *buffer, stride_t xstride = AutoStride, stride_t ystride = AutoStride, stride_t zstride = AutoStride)
 .. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec &spec, void *buffer, stride_t xstride = AutoStride, stride_t ystride = AutoStride, stride_t zstride = AutoStride)
 
@@ -175,6 +178,16 @@ Getting and setting pixel values
 |
 
 **Getting and setting regions of pixels -- fast**
+
+.. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, const image_span<T>&) const
+.. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, TypeDesc, const image_span<std::byte>&) const
+
+|
+
+**Getting and setting regions of pixels -- deprecated**
+
+These raw pointer versions of `get_pixels()` and `set_pixels()` should be
+converted to the `span` and `image_span` based versions.
 
 .. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, span<T>, stride_t, stride_t, stride_t) const
 .. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, span<T>, T*, stride_t, stride_t, stride_t) const

--- a/src/include/OpenImageIO/image_span.h
+++ b/src/include/OpenImageIO/image_span.h
@@ -70,7 +70,6 @@ public:
         // Validations:
         // - an image_span<byte> can have any chansize, but any other T must
         //   have the chansize equal to the data type size.
-        OIIO_DASSERT(nchannels > 0 && width > 0 && height > 0 && depth > 0);
         OIIO_DASSERT((std::is_same<std::remove_const_t<T>, std::byte>::value)
                      || chansize == sizeof(T));
 
@@ -380,10 +379,11 @@ template<typename T, size_t Rank>
 image_span<std::byte>
 as_image_span_writable_bytes(const image_span<T, Rank>& src) noexcept
 {
-    return image_span<std::byte>(reinterpret_cast<std::byte*>(src.data()),
-                                 src.nchannels(), src.width(), src.height(),
-                                 src.depth(), src.chanstride(), src.xstride(),
-                                 src.ystride(), src.zstride(), src.chansize());
+    return image_span<std::byte>(
+        const_cast<std::byte*>(reinterpret_cast<const std::byte*>(src.data())),
+        src.nchannels(), src.width(), src.height(), src.depth(),
+        src.chanstride(), src.xstride(), src.ystride(), src.zstride(),
+        src.chansize());
 }
 
 

--- a/src/include/OpenImageIO/image_span.h
+++ b/src/include/OpenImageIO/image_span.h
@@ -373,19 +373,17 @@ as_image_span_bytes(const image_span<T, Rank>& src) noexcept
 }
 
 
-/// Convert an image_span of any type to a mutable span of bytes covering
-/// the same range of memory.
+/// Convert an image_span of any nonconst type to a mutable span of bytes
+/// covering the same range of memory.
 template<typename T, size_t Rank>
 image_span<std::byte>
 as_image_span_writable_bytes(const image_span<T, Rank>& src) noexcept
 {
-    return image_span<std::byte>(
-        const_cast<std::byte*>(reinterpret_cast<const std::byte*>(src.data())),
-        src.nchannels(), src.width(), src.height(), src.depth(),
-        src.chanstride(), src.xstride(), src.ystride(), src.zstride(),
-        src.chansize());
+    return image_span<std::byte>(reinterpret_cast<std::byte*>(src.data()),
+                                 src.nchannels(), src.width(), src.height(),
+                                 src.depth(), src.chanstride(), src.xstride(),
+                                 src.ystride(), src.zstride(), src.chansize());
 }
-
 
 /// Verify that the image_span has all its contents lying within the
 /// contiguous span.

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -286,7 +286,7 @@ public:
     /// will not free/delete that memory, even when the ImageBuf is destroyed.
     /// Upon successful initialization, the storage will be reported as
     /// `APPBUFFER`. Note that the ImageBuf will be writable if passed an
-    /// `image_span<T>` with a mutable type `T`, but if will be "read-only" if
+    /// `image_span<T>` with a mutable type `T`, but it will be "read-only" if
     /// passed an `image_span<const T>`.
     ///
     /// @param spec

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1008,7 +1008,7 @@ public:
     }
 
     /// Base case of get_pixels: read into an image_span of generic bytes. The
-    /// requested data type is supplied by `format.
+    /// requested data type is supplied by `format`.
     bool get_pixels(ROI roi, TypeDesc format,
                     const image_span<std::byte>& buffer) const;
 
@@ -1064,13 +1064,13 @@ public:
 
 #ifndef OIIO_DOXYGEN
     /// Base case of get_pixels: read into a span of generic bytes. The
-    /// requested data type is supplied by `format.
+    /// requested data type is supplied by `format`.
     bool get_pixels(ROI roi, TypeDesc format, span<std::byte> buffer,
                     void* buforigin = nullptr, stride_t xstride = AutoStride,
                     stride_t ystride = AutoStride,
                     stride_t zstride = AutoStride) const;
 
-    /// Potentially unsafe get_pixels() using raw pointers. Use with catution!
+    /// Potentially unsafe get_pixels() using raw pointers. Use with caution!
     OIIO_IB_DEPRECATE_RAW_PTR
     bool get_pixels(ROI roi, TypeDesc format, void* result,
                     stride_t xstride = AutoStride,
@@ -1136,7 +1136,7 @@ public:
 
 #ifndef OIIO_DOXYGEN
     /// Base case of get_pixels: read into a span of generic bytes. The
-    /// requested data type is supplied by `format.
+    /// requested data type is supplied by `format`.
     bool set_pixels(ROI roi, TypeDesc format, cspan<std::byte> buffer,
                     const void* buforigin = nullptr,
                     stride_t xstride      = AutoStride,

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -281,6 +281,40 @@ public:
              void* buforigin = nullptr, stride_t xstride = AutoStride,
              stride_t ystride = AutoStride, stride_t zstride = AutoStride);
 
+    /// Construct an ImageBuf that "wraps" existing pixel memory owned by the
+    /// calling application. The ImageBuf does not own the pixel storage and
+    /// will not free/delete that memory, even when the ImageBuf is destroyed.
+    /// Upon successful initialization, the storage will be reported as
+    /// `APPBUFFER`. Note that the ImageBuf will be writable if passed an
+    /// `image_span<T>` with a mutable type `T`, but if will be "read-only" if
+    /// passed an `image_span<const T>`.
+    ///
+    /// @param spec
+    ///             An ImageSpec describing the image and its metadata. If
+    ///             not enough information is given to know the "shape" of
+    ///             the image (width, height, depth, channels, and data
+    ///             format), the ImageBuf will remain in an UNINITIALIZED
+    ///             state.
+    /// @param buffer
+    ///             An image_span delineating the extent and striding of the
+    ///             safely accessible memory comprising the pixel data.
+    template<typename T>
+    ImageBuf(const ImageSpec& spec, const image_span<T>& buffer)
+        : ImageBuf(spec, as_image_span_writable_bytes(buffer))
+    {
+    }
+    template<typename T>
+    ImageBuf(const ImageSpec& spec, const image_span<const T>& buffer)
+        : ImageBuf(spec, as_image_span_bytes(buffer))
+    {
+    }
+    // Special base case for read-only byte image_spans, this one does the
+    // hard work.
+    ImageBuf(const ImageSpec& spec, const image_span<const std::byte>& buffer);
+    // Special base case for mutable byte image_spans, this one does the hard
+    // work.
+    ImageBuf(const ImageSpec& spec, const image_span<std::byte>& buffer);
+
     // Unsafe constructor of an ImageBuf that wraps an existing buffer, where
     // only the origin pointer and the strides are given. Use with caution!
     OIIO_IB_DEPRECATE_RAW_PTR
@@ -332,6 +366,28 @@ public:
         set_name(name);
     }
 
+    /// Destroy any previous contents of the ImageBuf and re-initialize it as
+    /// if newly constructed with the same arguments, to "wrap" existing pixel
+    /// memory owned by the calling application. See the ImageBuf constructor
+    /// from an image_span for more details.
+    template<typename T>
+    void reset(const ImageSpec& spec, const image_span<T>& buffer)
+    {
+        // The general case for non-byte data types just converts to bytes and
+        // calls the byte version.
+        if constexpr (std::is_const_v<T>)
+            reset(spec, as_image_span_bytes(buffer));
+        else
+            reset(spec, as_image_span_writable_bytes(buffer));
+    }
+    // Special base case for read-only byte spans, this one does the hard work.
+    void reset(const ImageSpec& spec,
+               const image_span<const std::byte>& buffer);
+    // Special base case for mutable byte spans, this one does the hard work.
+    void reset(const ImageSpec& spec, const image_span<std::byte>& buffer);
+
+    /// Slated for deprecation in favor of the image_span-based version.
+    ///
     /// Destroy any previous contents of the ImageBuf and re-initialize it as
     /// if newly constructed with the same arguments, to "wrap" existing pixel
     /// memory owned by the calling application.
@@ -928,6 +984,33 @@ public:
         int n = std::min(spec().nchannels, maxchannels);
         setpixel(i, make_cspan(pixel, size_t(n)));
     }
+
+    /// Retrieve the rectangle of pixels spanning the ROI (including
+    /// channels) at the current subimage and MIP-map level, storing the
+    /// pixel values into the `buffer`.
+    ///
+    /// @param roi
+    ///             The region of interest to copy into. A default
+    ///             uninitialized ROI means the entire image.
+    /// @param buffer
+    ///             An image_span delineating the extent of the safely
+    ///             accessible memory where the results should be stored.
+    /// @returns
+    ///             Return true if the operation could be completed,
+    ///             otherwise return false.
+    ///
+    template<typename T>
+    bool get_pixels(ROI roi, const image_span<T>& buffer) const
+    {
+        static_assert(!std::is_const_v<T>);
+        return get_pixels(roi, TypeDescFromC<T>::value(),
+                          as_image_span_writable_bytes(buffer));
+    }
+
+    /// Base case of get_pixels: read into an image_span of generic bytes. The
+    /// requested data type is supplied by `format.
+    bool get_pixels(ROI roi, TypeDesc format,
+                    const image_span<std::byte>& buffer) const;
 
     /// Retrieve the rectangle of pixels spanning the ROI (including
     /// channels) at the current subimage and MIP-map level, storing the

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -496,7 +496,7 @@ ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
         m_nativespec = *spec;
         if (buforigin || bufspan.size()) {
             if (!buforigin)
-                buforigin = bufspan.data();
+                buforigin = static_cast<const void*>(bufspan.data());
             set_bufspan((char*)buforigin, xstride, ystride, zstride);
             m_storage      = ImageBuf::APPBUFFER;
             m_pixels_valid = true;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -139,9 +139,14 @@ class ImageBufImpl {
 public:
     ImageBufImpl(string_view filename, int subimage, int miplevel,
                  std::shared_ptr<ImageCache> imagecache = {},
-                 const ImageSpec* spec = nullptr, span<std::byte> bufspan = {},
-                 const void* buforigin = nullptr, bool readonly = false,
-                 const ImageSpec* config      = nullptr,
+                 const ImageSpec* spec                  = nullptr,
+                 const image_span<std::byte>& bufspan   = {},
+                 bool readonly = false, const ImageSpec* config = nullptr,
+                 Filesystem::IOProxy* ioproxy = nullptr);
+    ImageBufImpl(string_view filename, int subimage, int miplevel,
+                 std::shared_ptr<ImageCache> imagecache, const ImageSpec* spec,
+                 span<std::byte> bufspan, const void* buforigin = nullptr,
+                 bool readonly = false, const ImageSpec* config = nullptr,
                  Filesystem::IOProxy* ioproxy = nullptr,
                  stride_t xstride = AutoStride, stride_t ystride = AutoStride,
                  stride_t zstride = AutoStride);
@@ -156,12 +161,27 @@ public:
     // supplied, use it for the "native" spec, otherwise make the nativespec
     // just copy the regular spec.
     void reset(string_view name, const ImageSpec& spec,
-               const ImageSpec* nativespec = nullptr,
-               span<std::byte> bufspan = {}, const void* buforigin = {},
-               bool readonly = false, stride_t xstride = AutoStride,
-               stride_t ystride = AutoStride, stride_t zstride = AutoStride);
+               const ImageSpec* nativespec          = nullptr,
+               const image_span<std::byte>& bufspan = {},
+               bool readonly                        = false);
+    // alloc() resets the internal spec and nativespec, does some sanity
+    // checks on the image sizes, and calls realloc.
     void alloc(const ImageSpec& spec, const ImageSpec* nativespec = nullptr);
+    // realloc() calls new_pixels to allocate private owned memory to hold local
+    // pixels, then sets up all the strides, storage class, etc. It also sets
+    // up m_bufspan.
     void realloc();
+
+    void set_bufspan(void* data, stride_t xstride = AutoStride,
+                     stride_t ystride = AutoStride,
+                     stride_t zstride = AutoStride)
+    {
+        m_bufspan = image_span(reinterpret_cast<std::byte*>(data),
+                               m_spec.nchannels, m_spec.width, m_spec.height,
+                               m_spec.depth, m_spec.format.size(), xstride,
+                               ystride, zstride);
+    }
+
     bool init_spec(string_view filename, int subimage, int miplevel,
                    DoLock do_lock);
     bool read(int subimage, int miplevel, int chbegin = 0, int chend = -1,
@@ -172,11 +192,6 @@ public:
     void copy_metadata(const ImageBufImpl& src);
     void merge_metadata(const ImageBufImpl& src, bool override = false,
                         string_view pattern = {});
-
-    // At least one of bufspan or buforigin is supplied. Set this->m_bufspan
-    // and this->m_localpixels appropriately.
-    void set_bufspan_localpixels(span<std::byte> bufspan,
-                                 const void* buforigin);
 
     // Note: Uses std::format syntax
     template<typename... Args>
@@ -218,6 +233,7 @@ public:
         return m_spec_valid && m_storage != ImageBuf::UNINITIALIZED;
     }
     bool cachedpixels() const { return m_storage == ImageBuf::IMAGECACHE; }
+    void* localpixels() const { return m_bufspan.data(); }
 
     const void* pixeladdr(int x, int y, int z, int ch) const;
     void* pixeladdr(int x, int y, int z, int ch);
@@ -328,12 +344,10 @@ public:
 
     void eval_contiguous()
     {
-        m_contiguous = m_localpixels
+        m_contiguous = m_bufspan.data() != nullptr
                        && (m_storage == ImageBuf::LOCALBUFFER
                            || m_storage == ImageBuf::APPBUFFER)
-                       && m_xstride == m_spec.nchannels * m_channel_stride
-                       && m_ystride == m_xstride * m_spec.width
-                       && m_zstride == m_ystride * m_spec.height;
+                       && m_bufspan.is_contiguous();
     }
 
     bool has_thumbnail(DoLock do_lock = DoLock(true)) const;
@@ -342,53 +356,51 @@ public:
     std::shared_ptr<ImageBuf> get_thumbnail(DoLock do_lock = DoLock(true)) const;
 
 private:
-    ImageBuf::IBStorage m_storage;  ///< Pixel storage class
-    ustring m_name;                 ///< Filename of the image
-    ustring m_fileformat;           ///< File format name
-    int m_nsubimages;               ///< How many subimages are there?
-    int m_current_subimage;         ///< Current subimage we're viewing
-    int m_current_miplevel;         ///< Current miplevel we're viewing
-    int m_nmiplevels;               ///< # of MIP levels in the current subimage
-    mutable int m_threads;          ///< thread policy for this image
-    ImageSpec m_spec;               ///< Describes the image (size, etc)
-    ImageSpec m_nativespec;         ///< Describes the true native image
-    std::unique_ptr<char[]> m_pixels;  ///< Pixel data, if local and we own it
-    char* m_localpixels;               ///< Pointer to local pixels
-    span<std::byte> m_bufspan;         ///< Bounded buffer for local pixels
+    ImageBuf::IBStorage m_storage
+        = ImageBuf::UNINITIALIZED;  // Pixel storage class
+    ustring m_name;                 // Filename of the image
+    ustring m_fileformat;           // File format name
+    int m_nsubimages       = 0;     // How many subimages are there?
+    int m_current_subimage = 0;     // Current subimage we're viewing
+    int m_current_miplevel = 0;     // Current miplevel we're viewing
+    int m_nmiplevels       = 0;     // # of MIP levels in the current subimage
+    mutable int m_threads  = 0;     // thread policy for this image
+    ImageSpec m_spec;               // Describes the image (size, etc)
+    ImageSpec m_nativespec;         // Describes the true native image
+    std::unique_ptr<char[]> m_pixels;  // Pixel data, if local and we own it
+    image_span<std::byte> m_bufspan;   // Bounded buffer for local pixels
     typedef std::recursive_mutex mutex_t;
     typedef std::unique_lock<mutex_t> lock_t;
-    mutable mutex_t m_mutex;      ///< Thread safety for this ImageBuf
-    mutable bool m_spec_valid;    ///< Is the spec valid
-    mutable bool m_pixels_valid;  ///< Image is valid
-    mutable bool m_pixels_read;   ///< Is file already in the local pixels?
-    bool m_readonly;              ///< The bufspan is read-only
-    bool m_badfile;               ///< File not found
-    float m_pixelaspect;          ///< Pixel aspect ratio of the image
-    stride_t m_xstride;
-    stride_t m_ystride;
-    stride_t m_zstride;
-    stride_t m_channel_stride;
-    bool m_contiguous;
-    std::shared_ptr<ImageCache> m_imagecache;  ///< ImageCache to use
-    TypeDesc m_cachedpixeltype;            ///< Data type stored in the cache
-    DeepData m_deepdata;                   ///< Deep data
-    size_t m_allocated_size;               ///< How much memory we've allocated
-    std::vector<char> m_blackpixel;        ///< Pixel-sized zero bytes
-    std::vector<TypeDesc> m_write_format;  /// Pixel data format to use for write()
-    int m_write_tile_width;
-    int m_write_tile_height;
-    int m_write_tile_depth;
+    mutable mutex_t m_mutex;              // Thread safety for this ImageBuf
+    mutable bool m_spec_valid   = false;  // Is the spec valid
+    mutable bool m_pixels_valid = false;  // Image is valid
+    mutable bool m_pixels_read = false;  // Is file already in the local pixels?
+    bool m_readonly            = true;   // The bufspan is read-only
+    bool m_badfile             = false;  // File not found
+    float m_pixelaspect        = 1.0f;   // Pixel aspect ratio of the image
+    bool m_contiguous          = false;
+    std::shared_ptr<ImageCache> m_imagecache;  // ImageCache to use
+    TypeDesc m_cachedpixeltype;                // Data type stored in the cache
+    DeepData m_deepdata;                       // Deep data
+    size_t m_allocated_size = 0;           // How much memory we've allocated
+    std::vector<char> m_blackpixel;        // Pixel-sized zero bytes
+    std::vector<TypeDesc> m_write_format;  // Pixel data format to use for write()
+    int m_write_tile_width  = 0;
+    int m_write_tile_height = 0;
+    int m_write_tile_depth  = 1;
     std::unique_ptr<ImageSpec> m_configspec;  // Configuration spec
     Filesystem::IOProxy* m_rioproxy = nullptr;
     Filesystem::IOProxy* m_wioproxy = nullptr;
-    mutable std::string m_err;  ///< Last error message
+    mutable std::string m_err;  // Last error message
     bool m_has_thumbnail = false;
     std::shared_ptr<ImageBuf> m_thumbnail;
 
-    // Private reset m_pixels to new allocation of new size, copy if
-    // data is not nullptr. Return nullptr if an allocation of that size
-    // was not possible.
-    char* new_pixels(size_t size, const void* data = nullptr);
+    // Private reset m_pixels to new allocation for a size implied by the
+    // m_spec, copy if data is not nullptr. Return nullptr if an allocation of
+    // that size was not possible. This also sets the m_bufspan, and the
+    // strides.
+    char* new_pixels(ImageBuf::IBStorage storage, size_t size,
+                     const void* data = nullptr);
     // Private release of m_pixels.
     void free_pixels();
 
@@ -420,6 +432,50 @@ ImageBuf::impl_deleter(ImageBufImpl* todel)
 
 ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
                            std::shared_ptr<ImageCache> imagecache,
+                           const ImageSpec* spec,
+                           const image_span<std::byte>& bufspan, bool readonly,
+                           const ImageSpec* config,
+                           Filesystem::IOProxy* ioproxy)
+    : m_storage(ImageBuf::UNINITIALIZED)
+    , m_name(filename)
+    , m_current_subimage(subimage)
+    , m_current_miplevel(miplevel)
+    , m_readonly(readonly)
+    , m_imagecache(imagecache)
+{
+    if (spec) {
+        // spec != nullptr means we're constructing an ImageBuf that either
+        // wraps a buffer or owns its own memory.
+        m_spec       = *spec;
+        m_nativespec = *spec;
+        if (bufspan.data()) {
+            m_bufspan      = bufspan;
+            m_storage      = ImageBuf::APPBUFFER;
+            m_pixels_valid = true;
+        } else {
+            m_storage  = ImageBuf::LOCALBUFFER;
+            m_readonly = false;
+            alloc(*spec);
+        }
+        m_spec_valid = true;
+        m_blackpixel.resize(
+            round_to_multiple(spec->pixel_bytes(), OIIO_SIMD_MAX_SIZE_BYTES));
+        // NB make it big enough for SSE
+    } else if (filename.length() > 0) {
+        // filename being nonempty means this ImageBuf refers to a file.
+        OIIO_DASSERT(bufspan.data() == nullptr);
+        reset(filename, subimage, miplevel, std::move(imagecache), config,
+              ioproxy);
+    } else {
+        OIIO_DASSERT(bufspan.data() == nullptr);
+    }
+    eval_contiguous();
+}
+
+
+
+ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
+                           std::shared_ptr<ImageCache> imagecache,
                            const ImageSpec* spec, span<std::byte> bufspan,
                            const void* buforigin, bool readonly,
                            const ImageSpec* config,
@@ -427,52 +483,32 @@ ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
                            stride_t ystride, stride_t zstride)
     : m_storage(ImageBuf::UNINITIALIZED)
     , m_name(filename)
-    , m_nsubimages(0)
     , m_current_subimage(subimage)
     , m_current_miplevel(miplevel)
-    , m_nmiplevels(0)
-    , m_threads(0)
-    , m_localpixels(NULL)
-    , m_spec_valid(false)
-    , m_pixels_valid(false)
-    , m_pixels_read(false)
     , m_readonly(readonly)
-    , m_badfile(false)
-    , m_pixelaspect(1)
-    , m_xstride(0)
-    , m_ystride(0)
-    , m_zstride(0)
-    , m_channel_stride(0)
     , m_contiguous(false)
     , m_imagecache(imagecache)
-    , m_allocated_size(0)
-    , m_write_tile_width(0)
-    , m_write_tile_height(0)
-    , m_write_tile_depth(1)
 {
     if (spec) {
         // spec != nullptr means we're constructing an ImageBuf that either
         // wraps a buffer or owns its own memory.
-        m_spec           = *spec;
-        m_nativespec     = *spec;
-        m_channel_stride = stride_t(spec->format.size());
-        m_xstride        = xstride;
-        m_ystride        = ystride;
-        m_zstride        = zstride;
-        ImageSpec::auto_stride(m_xstride, m_ystride, m_zstride, m_spec.format,
-                               m_spec.nchannels, m_spec.width, m_spec.height);
-        m_blackpixel.resize(round_to_multiple(spec->pixel_bytes(),
-                                              OIIO_SIMD_MAX_SIZE_BYTES),
-                            0);
-        // NB make it big enough for SSE
+        m_spec       = *spec;
+        m_nativespec = *spec;
         if (buforigin || bufspan.size()) {
-            set_bufspan_localpixels(bufspan, buforigin);
+            if (!buforigin)
+                buforigin = bufspan.data();
+            set_bufspan((char*)buforigin, xstride, ystride, zstride);
             m_storage      = ImageBuf::APPBUFFER;
             m_pixels_valid = true;
         } else {
-            m_storage = ImageBuf::LOCALBUFFER;
+            m_storage  = ImageBuf::LOCALBUFFER;
+            m_readonly = false;
+            alloc(*spec);
         }
         m_spec_valid = true;
+        m_blackpixel.resize(
+            round_to_multiple(spec->pixel_bytes(), OIIO_SIMD_MAX_SIZE_BYTES));
+        // NB make it big enough for SSE
     } else if (filename.length() > 0) {
         // filename being nonempty means this ImageBuf refers to a file.
         OIIO_DASSERT(buforigin == nullptr);
@@ -502,10 +538,6 @@ ImageBufImpl::ImageBufImpl(const ImageBufImpl& src)
     , m_readonly(src.m_readonly)
     , m_badfile(src.m_badfile)
     , m_pixelaspect(src.m_pixelaspect)
-    , m_xstride(src.m_xstride)
-    , m_ystride(src.m_ystride)
-    , m_zstride(src.m_zstride)
-    , m_channel_stride(src.m_channel_stride)
     , m_contiguous(src.m_contiguous)
     , m_imagecache(src.m_imagecache)
     , m_cachedpixeltype(src.m_cachedpixeltype)
@@ -522,24 +554,22 @@ ImageBufImpl::ImageBufImpl(const ImageBufImpl& src)
     m_spec_valid   = src.m_spec_valid;
     m_pixels_valid = src.m_pixels_valid;
     m_pixels_read  = src.m_pixels_read;
-    if (src.m_localpixels) {
+    if (src.localpixels()) {
         // Source had the image fully in memory (no cache)
         if (m_storage == ImageBuf::APPBUFFER) {
             // Source just wrapped the client app's pixels, we do the same
-            m_localpixels = src.m_localpixels;
-            m_bufspan     = src.m_bufspan;
+            m_bufspan = src.m_bufspan;
         } else {
             // We own our pixels -- copy from source
-            new_pixels(src.m_spec.image_bytes(), src.m_pixels.get());
+            new_pixels(m_storage, src.m_spec.image_bytes(), src.m_pixels.get());
             // N.B. new_pixels will set m_bufspan
         }
     } else {
         // Source was cache-based or deep
         // nothing else to do
-        m_localpixels = nullptr;
-        m_bufspan     = span<std::byte>();
+        m_bufspan = {};
     }
-    if (m_localpixels || m_spec.deep) {
+    if (localpixels() || m_spec.deep) {
         // A copied ImageBuf is no longer a direct file reference, so clear
         // some of the fields that are only meaningful for file references.
         m_fileformat.clear();
@@ -622,6 +652,28 @@ ImageBuf::ImageBuf(const ImageSpec& spec, void* buffer, stride_t xstride,
 
 
 
+ImageBuf::ImageBuf(const ImageSpec& spec,
+                   const image_span<const std::byte>& buffer)
+    : m_impl(new ImageBufImpl("", 0, 0, nullptr /*imagecache*/, &spec,
+                              as_image_span_writable_bytes(buffer),
+                              true /*readonly*/, nullptr /*config*/,
+                              nullptr /*ioproxy*/),
+             &impl_deleter)
+{
+}
+
+
+
+ImageBuf::ImageBuf(const ImageSpec& spec, const image_span<std::byte>& buffer)
+    : m_impl(new ImageBufImpl("", 0, 0, nullptr /*imagecache*/, &spec, buffer,
+                              true /*readonly*/, nullptr /*config*/,
+                              nullptr /*ioproxy*/),
+             &impl_deleter)
+{
+}
+
+
+
 ImageBuf::ImageBuf(const ImageSpec& spec, cspan<std::byte> buffer,
                    void* buforigin, stride_t xstride, stride_t ystride,
                    stride_t zstride)
@@ -685,20 +737,29 @@ ImageBuf::operator=(ImageBuf&& src)
 
 
 char*
-ImageBufImpl::new_pixels(size_t size, const void* data)
+ImageBufImpl::new_pixels(ImageBuf::IBStorage storage, size_t size,
+                         const void* data)
 {
+    m_storage = storage;
+    if (storage == ImageBuf::LOCALBUFFER && !m_spec.deep)
+        OIIO_ASSERT(size == m_spec.image_bytes());
+    size = (storage == ImageBuf::LOCALBUFFER && !m_spec.deep)
+               ? m_spec.image_bytes()
+               : 0;
+    // FIXME: this can be cleaned up a bit. If we're reallocating the same
+    // size that we previously had, we shouldn't need to free and then
+    // immediatel re-allocate again, right?
     if (m_allocated_size)
         free_pixels();
     try {
         m_pixels.reset(size ? new char[size] : nullptr);
-        // Set bufspan to the allocated memory
-        m_bufspan = { reinterpret_cast<std::byte*>(m_pixels.get()), size };
+        // Set m_bufspan to the allocated memory
+        set_bufspan(m_pixels.get());
     } catch (const std::exception& e) {
         // Could not allocate enough memory. So don't allocate anything,
         // consider this an uninitialized ImageBuf, issue an error, and hope
         // it's handled well downstream.
         m_pixels.reset();
-        m_bufspan = make_span<std::byte>(nullptr, 0);
         OIIO::debugfmt("ImageBuf unable to allocate {} bytes ({})\n", size,
                        e.what());
         error("ImageBuf unable to allocate {} bytes ({})\n", size, e.what());
@@ -710,13 +771,11 @@ ImageBufImpl::new_pixels(size_t size, const void* data)
     atomic_max(pvt::IB_local_mem_peak, (long long)pvt::IB_local_mem_current);
     if (data && size)
         memcpy(m_pixels.get(), data, size);
-    m_localpixels = m_pixels.get();
-    m_storage     = size ? ImageBuf::LOCALBUFFER : ImageBuf::UNINITIALIZED;
     if (pvt::oiio_print_debug > 1)
         OIIO::debugfmt("IB allocated {} MB, global IB memory now {} MB\n",
                        size >> 20, pvt::IB_local_mem_current >> 20);
     eval_contiguous();
-    return m_localpixels;
+    return m_pixels.get();
 }
 
 
@@ -733,7 +792,7 @@ ImageBufImpl::free_pixels()
     }
     m_pixels.reset();
     // print("IB Freed pixels of length {}\n", m_bufspan.size());
-    m_bufspan = make_span<std::byte>(nullptr, 0);
+    m_bufspan = {};
     m_deepdata.free();
     m_storage = ImageBuf::UNINITIALIZED;
     m_blackpixel.clear();
@@ -820,18 +879,13 @@ ImageBufImpl::clear()
     m_spec             = ImageSpec();
     m_nativespec       = ImageSpec();
     m_pixels.reset();
-    m_bufspan        = make_span<std::byte>(nullptr, 0);
-    m_localpixels    = nullptr;
-    m_spec_valid     = false;
-    m_pixels_valid   = false;
-    m_badfile        = false;
-    m_pixels_read    = false;
-    m_pixelaspect    = 1;
-    m_xstride        = 0;
-    m_ystride        = 0;
-    m_zstride        = 0;
-    m_channel_stride = 0;
-    m_contiguous     = false;
+    m_bufspan      = {};
+    m_spec_valid   = false;
+    m_pixels_valid = false;
+    m_badfile      = false;
+    m_pixels_read  = false;
+    m_pixelaspect  = 1;
+    m_contiguous   = false;
     m_imagecache.reset();
     m_deepdata.free();
     m_blackpixel.clear();
@@ -903,32 +957,13 @@ ImageBuf::reset(string_view filename, int subimage, int miplevel,
 
 
 void
-ImageBufImpl::set_bufspan_localpixels(span<std::byte> bufspan,
-                                      const void* buforigin)
-{
-    if (bufspan.size() && !buforigin) {
-        buforigin = bufspan.data();
-    } else if (buforigin && (!bufspan.data() || bufspan.empty())) {
-        bufspan = span_from_buffer(const_cast<void*>(buforigin), m_spec.format,
-                                   m_spec.nchannels, m_spec.width,
-                                   m_spec.height, m_spec.depth, m_xstride,
-                                   m_ystride, m_zstride);
-    }
-    m_bufspan     = bufspan;
-    m_localpixels = (char*)buforigin;
-    OIIO_ASSERT(check_span(m_bufspan, m_localpixels, spec().format));
-}
-
-
-
-void
 ImageBufImpl::reset(string_view filename, const ImageSpec& spec,
-                    const ImageSpec* nativespec, span<std::byte> bufspan,
-                    const void* buforigin, bool readonly, stride_t xstride,
-                    stride_t ystride, stride_t zstride)
+                    const ImageSpec* nativespec,
+                    const image_span<std::byte>& bufspan, bool readonly)
 {
     clear();
     if (!spec.image_bytes()) {
+        free_pixels();
         m_storage = ImageBuf::UNINITIALIZED;
         error(
             "Could not initialize ImageBuf: the provided ImageSpec needs a valid width, height, depth, nchannels, format.");
@@ -937,22 +972,16 @@ ImageBufImpl::reset(string_view filename, const ImageSpec& spec,
     m_name             = ustring(filename);
     m_current_subimage = 0;
     m_current_miplevel = 0;
-    if (buforigin || bufspan.size()) {
-        m_spec           = spec;
-        m_nativespec     = nativespec ? *nativespec : spec;
-        m_channel_stride = stride_t(spec.format.size());
-        m_xstride        = xstride;
-        m_ystride        = ystride;
-        m_zstride        = zstride;
-        m_readonly       = readonly;
-        ImageSpec::auto_stride(m_xstride, m_ystride, m_zstride, m_spec.format,
-                               m_spec.nchannels, m_spec.width, m_spec.height);
+    if (bufspan.data()) {
+        m_spec         = spec;
+        m_nativespec   = nativespec ? *nativespec : spec;
+        m_readonly     = readonly;
+        m_bufspan      = bufspan;
+        m_storage      = ImageBuf::APPBUFFER;
+        m_pixels_valid = true;
         m_blackpixel.resize(round_to_multiple(spec.pixel_bytes(),
                                               OIIO_SIMD_MAX_SIZE_BYTES),
                             0);
-        set_bufspan_localpixels(bufspan, buforigin);
-        m_storage      = ImageBuf::APPBUFFER;
-        m_pixels_valid = true;
     } else {
         m_storage  = ImageBuf::LOCALBUFFER;
         m_readonly = false;
@@ -979,7 +1008,28 @@ void
 ImageBuf::reset(const ImageSpec& spec, void* buffer, stride_t xstride,
                 stride_t ystride, stride_t zstride)
 {
-    m_impl->reset("", spec, nullptr, {}, buffer, xstride, ystride, zstride);
+    image_span ispan((std::byte*)buffer, spec.nchannels, spec.width,
+                     spec.height, spec.depth, spec.format.size(), xstride,
+                     ystride, zstride);
+    m_impl->reset("", spec, nullptr, ispan, false /*readonly*/);
+}
+
+
+
+void
+ImageBuf::reset(const ImageSpec& spec,
+                const image_span<const std::byte>& buffer)
+{
+    m_impl->reset("", spec, nullptr, as_image_span_writable_bytes(buffer),
+                  true /*readonly*/);
+}
+
+
+
+void
+ImageBuf::reset(const ImageSpec& spec, const image_span<std::byte>& buffer)
+{
+    m_impl->reset("", spec, nullptr, buffer, false /*readonly*/);
 }
 
 
@@ -989,9 +1039,13 @@ ImageBuf::reset(const ImageSpec& spec, cspan<std::byte> buffer,
                 const void* buforigin, stride_t xstride, stride_t ystride,
                 stride_t zstride)
 {
-    m_impl->reset("", spec, nullptr,
-                  { const_cast<std::byte*>(buffer.data()), buffer.size() },
-                  buforigin, true /*readonly*/, xstride, ystride, zstride);
+    if (!buforigin)
+        buforigin = buffer.data();
+    image_span ispan((std::byte*)buforigin, spec.nchannels, spec.width,
+                     spec.height, spec.depth, spec.format.size(), xstride,
+                     ystride, zstride);
+    OIIO_ASSERT(image_span_within_span(ispan, buffer));
+    m_impl->reset("", spec, nullptr, ispan, true /*readonly*/);
 }
 
 
@@ -1001,8 +1055,13 @@ ImageBuf::reset(const ImageSpec& spec, span<std::byte> buffer,
                 const void* buforigin, stride_t xstride, stride_t ystride,
                 stride_t zstride)
 {
-    m_impl->reset("", spec, nullptr, buffer, buforigin, false /*readonly*/,
-                  xstride, ystride, zstride);
+    if (!buforigin)
+        buforigin = buffer.data();
+    image_span ispan((std::byte*)buforigin, spec.nchannels, spec.width,
+                     spec.height, spec.depth, spec.format.size(), xstride,
+                     ystride, zstride);
+    OIIO_ASSERT(image_span_within_span(ispan, buffer));
+    m_impl->reset("", spec, nullptr, ispan, false /*readonly*/);
 }
 
 
@@ -1010,15 +1069,11 @@ ImageBuf::reset(const ImageSpec& spec, span<std::byte> buffer,
 void
 ImageBufImpl::realloc()
 {
-    new_pixels(m_spec.deep ? size_t(0) : m_spec.image_bytes());
+    new_pixels(ImageBuf::LOCALBUFFER,
+               m_spec.deep ? size_t(0) : m_spec.image_bytes());
     // N.B. new_pixels will set m_bufspan
-    m_channel_stride = m_spec.format.size();
-    m_xstride        = AutoStride;
-    m_ystride        = AutoStride;
-    m_zstride        = AutoStride;
-    ImageSpec::auto_stride(m_xstride, m_ystride, m_zstride, m_spec.format,
-                           m_spec.nchannels, m_spec.width, m_spec.height);
-    m_blackpixel.resize(round_to_multiple(m_xstride, OIIO_SIMD_MAX_SIZE_BYTES),
+    m_blackpixel.resize(round_to_multiple(m_spec.pixel_bytes(),
+                                          OIIO_SIMD_MAX_SIZE_BYTES),
                         0);
     // NB make it big enough for SSE
     if (m_allocated_size) {
@@ -1028,6 +1083,8 @@ ImageBufImpl::realloc()
     if (m_spec.deep) {
         m_deepdata.init(m_spec);
         m_storage = ImageBuf::LOCALBUFFER;
+        // FIXME -- I think we should have a separate storage tag for
+        // deep data.
     }
     m_readonly    = false;
     m_pixels_read = false;
@@ -1140,11 +1197,10 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
             return false;
         }
 
-        m_xstride = m_spec.pixel_bytes();
-        m_ystride = m_spec.scanline_bytes();
-        m_zstride = clamped_mult64(m_ystride, (imagesize_t)m_spec.height);
-        m_channel_stride = m_spec.format.size();
-        m_blackpixel.resize(round_to_multiple(m_xstride,
+        m_bufspan = image_span<std::byte>(nullptr, m_spec.nchannels,
+                                          m_spec.width, m_spec.height,
+                                          m_spec.depth, m_spec.format.size());
+        m_blackpixel.resize(round_to_multiple(m_spec.pixel_bytes(),
                                               OIIO_SIMD_MAX_SIZE_BYTES),
                             0);
         // ^^^ NB make it big enough for SIMD
@@ -1224,12 +1280,12 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
         m_badfile    = false;
         m_spec_valid = true;
         m_fileformat = ustring(input->format_name());
-        m_xstride    = m_spec.pixel_bytes();
-        m_ystride    = m_spec.scanline_bytes();
-        m_zstride    = clamped_mult64(m_ystride, (imagesize_t)m_spec.height);
-        m_channel_stride = m_spec.format.size();
+        m_nativespec = m_spec;
+        m_bufspan    = image_span<std::byte>(nullptr, m_spec.nchannels,
+                                          m_spec.width, m_spec.height,
+                                          m_spec.depth, m_spec.format.size());
         m_blackpixel.resize(
-            round_to_multiple(m_xstride, OIIO_SIMD_MAX_SIZE_BYTES));
+            round_to_multiple(m_spec.pixel_bytes(), OIIO_SIMD_MAX_SIZE_BYTES));
         // ^^^ NB make it big enough for SIMD
         m_nsubimages = input->supports("multiimage")
                            ? m_spec.get_int_attribute("oiio:subimages")
@@ -1340,15 +1396,15 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
                                      ustring("cachedpixeltype"), TypeInt,
                                      &peltype);
         m_cachedpixeltype = TypeDesc((TypeDesc::BASETYPE)peltype);
-        if (!m_localpixels && !force && !use_channel_subset
+        if (!localpixels() && !force && !use_channel_subset
             && (convert == m_cachedpixeltype || convert == TypeDesc::UNKNOWN)) {
             m_spec.format = m_cachedpixeltype;
-            m_xstride     = m_spec.pixel_bytes();
-            m_ystride     = m_spec.scanline_bytes();
-            m_zstride = clamped_mult64(m_ystride, (imagesize_t)m_spec.height);
-            m_blackpixel.resize(round_to_multiple(m_xstride,
-                                                  OIIO_SIMD_MAX_SIZE_BYTES),
-                                0);
+            m_bufspan     = image_span<std::byte>(nullptr, m_spec.nchannels,
+                                              m_spec.width, m_spec.height,
+                                              m_spec.depth,
+                                              m_spec.format.size());
+            m_blackpixel.resize(round_to_multiple(m_spec.pixel_bytes(),
+                                                  OIIO_SIMD_MAX_SIZE_BYTES));
             // NB make it big enough for SSE
             m_pixels_valid = true;
             m_storage      = ImageBuf::IMAGECACHE;
@@ -1422,7 +1478,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         if (in) {
             in->threads(threads());  // Pass on our thread policy
             bool ok = in->read_image(subimage, miplevel, chbegin, chend,
-                                     m_spec.format, m_localpixels, AutoStride,
+                                     m_spec.format, localpixels(), AutoStride,
                                      AutoStride, AutoStride, progress_callback,
                                      progress_callback_data);
             in->close();
@@ -1467,7 +1523,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
                                  m_spec.x + m_spec.width, m_spec.y,
                                  m_spec.y + m_spec.height, m_spec.z,
                                  m_spec.z + m_spec.depth, chbegin, chend,
-                                 m_spec.format, m_localpixels)) {
+                                 m_spec.format, localpixels())) {
         m_imagecache->close(m_name);
         m_pixels_valid = true;
     } else {
@@ -1558,9 +1614,9 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
     const ImageSpec& bufspec(m_impl->m_spec);
     const ImageSpec& outspec(out->spec());
     TypeDesc bufformat = spec().format;
-    if (m_impl->m_localpixels) {
+    if (m_impl->localpixels()) {
         // In-core pixel buffer for the whole image
-        ok = out->write_image(bufformat, m_impl->m_localpixels, pixel_stride(),
+        ok = out->write_image(bufformat, m_impl->localpixels(), pixel_stride(),
                               scanline_stride(), z_stride(), progress_callback,
                               progress_callback_data);
     } else if (deep()) {
@@ -1615,7 +1671,6 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
             int chunk = clamp(round_to_multiple(int(budget / slsize), 64), 1,
                               1024);
             std::unique_ptr<std::byte[]> tmp(new std::byte[chunk * slsize]);
-            auto tmpspan = make_span(tmp.get(), chunk * slsize);
 
             // Special handling for flipped vertical scanline order. Right now, OpenEXR
             // is the only format that allows it, so we special case it by name. For
@@ -1631,26 +1686,36 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
             const int yDelta     = isDecreasingY ? -chunk : chunk;
             const int yLoopEnd   = yLoopStart + numChunks * yDelta;
 
-            for (int z = 0; z < outspec.depth; ++z) {
-                for (int y = yLoopStart; y != yLoopEnd && ok; y += yDelta) {
-                    int yend = std::min(y + outspec.y + chunk,
-                                        outspec.y + outspec.height);
-                    ok &= get_pixels(ROI(outspec.x, outspec.x + outspec.width,
-                                         outspec.y + y, yend, outspec.z,
-                                         outspec.z + outspec.depth),
-                                     bufformat, tmpspan);
-                    ok &= out->write_scanlines(y + outspec.y, yend,
-                                               z + outspec.z, bufformat,
-                                               &tmp[0]);
-                    if (progress_callback
-                        && progress_callback(
-                            progress_callback_data,
-                            (float)(z * outspec.height
-                                    + (isDecreasingY ? (outspec.height - 1 - y)
-                                                     : y))
-                                / (outspec.height * outspec.depth)))
-                        return ok;
+            OIIO_ASSERT(outspec.depth == 1
+                        && "scanline output is only for 2D images");
+            for (int y = yLoopStart; y != yLoopEnd && ok; y += yDelta) {
+                int ybegin = y + outspec.y;
+                int yend = std::min(ybegin + chunk, outspec.y + outspec.height);
+                auto tmpspan = image_span(tmp.get(), bufspec.nchannels,
+                                          bufspec.width, yend - ybegin, 1,
+                                          bufspec.format.size(), AutoStride,
+                                          AutoStride, AutoStride,
+                                          bufspec.format.size());
+
+                size_t sz = bufspec.scanline_bytes() * size_t(yend - ybegin);
+                if (sz != tmpspan.size_bytes()) {
+                    errorfmt(
+                        "write_scanlines: Buffer size is incorrect ({} bytes vs {} needed) slb={} sls={} fmt={} w={} ch={}, buffer w={}, nc={}, chansize={}",
+                        sz, tmpspan.size_bytes(), bufspec.scanline_bytes(),
+                        yend - ybegin, bufspec.format, bufspec.width,
+                        bufspec.nchannels, tmpspan.width(), tmpspan.nchannels(),
+                        tmpspan.chansize());
                 }
+                ok &= get_pixels(ROI(outspec.x, outspec.x + outspec.width,
+                                     ybegin, yend, 0, 1, 0, outspec.nchannels),
+                                 bufformat, tmpspan);
+                ok &= out->write_scanlines(ybegin, yend, bufformat, tmpspan);
+                if (progress_callback
+                    && progress_callback(
+                        progress_callback_data,
+                        (float)(isDecreasingY ? (outspec.height - 1 - y) : y)
+                            / (outspec.height * outspec.depth)))
+                    return ok;
             }
         }
     }
@@ -2093,7 +2158,7 @@ void*
 ImageBuf::localpixels()
 {
     m_impl->validate_pixels();
-    return m_impl->m_localpixels;
+    return m_impl->localpixels();
 }
 
 
@@ -2102,7 +2167,7 @@ const void*
 ImageBuf::localpixels() const
 {
     m_impl->validate_pixels();
-    return m_impl->m_localpixels;
+    return m_impl->localpixels();
 }
 
 
@@ -2110,7 +2175,7 @@ ImageBuf::localpixels() const
 stride_t
 ImageBuf::pixel_stride() const
 {
-    return m_impl->m_xstride;
+    return m_impl->m_bufspan.xstride();
 }
 
 
@@ -2118,7 +2183,7 @@ ImageBuf::pixel_stride() const
 stride_t
 ImageBuf::scanline_stride() const
 {
-    return m_impl->m_ystride;
+    return m_impl->m_bufspan.ystride();
 }
 
 
@@ -2126,7 +2191,7 @@ ImageBuf::scanline_stride() const
 stride_t
 ImageBuf::z_stride() const
 {
-    return m_impl->m_zstride;
+    return m_impl->m_bufspan.zstride();
 }
 
 
@@ -2594,6 +2659,17 @@ get_pixels_(const ImageBuf& buf, const ImageBuf& /*dummy*/, ROI whole_roi,
                 ok = false;
         });
     return ok;
+}
+
+
+
+bool
+ImageBuf::get_pixels(ROI roi, TypeDesc format,
+                     const image_span<std::byte>& buffer) const
+{
+    // FIXME: for now, just wrap the pointer based one
+    return get_pixels(roi, format, buffer.data(), buffer.xstride(),
+                      buffer.ystride(), buffer.zstride());
 }
 
 
@@ -3090,12 +3166,7 @@ ImageBufImpl::pixeladdr(int x, int y, int z, int ch) const
     if (cachedpixels())
         return nullptr;
     validate_pixels();
-    x -= m_spec.x;
-    y -= m_spec.y;
-    z -= m_spec.z;
-    stride_t p = y * m_ystride + x * m_xstride + z * m_zstride
-                 + ch * m_channel_stride;
-    return &(m_localpixels[p]);
+    return m_bufspan.getptr(ch, x - m_spec.x, y - m_spec.y, z - m_spec.z);
 }
 
 
@@ -3106,12 +3177,7 @@ ImageBufImpl::pixeladdr(int x, int y, int z, int ch)
     validate_pixels();
     if (cachedpixels())
         return nullptr;
-    x -= m_spec.x;
-    y -= m_spec.y;
-    z -= m_spec.z;
-    size_t p = y * m_ystride + x * m_xstride + z * m_zstride
-               + ch * m_channel_stride;
-    return &(m_localpixels[p]);
+    return m_bufspan.getptr(ch, x - m_spec.x, y - m_spec.y, z - m_spec.z);
 }
 
 
@@ -3291,9 +3357,10 @@ ImageBufImpl::retile(int x, int y, int z, ImageCache::Tile*& tile,
     size_t offset = ((z - tilezbegin) * (size_t)th + (y - tileybegin))
                         * (size_t)tw
                     + (x - tilexbegin);
-    offset *= m_spec.pixel_bytes();
-    OIIO_DASSERT_MSG(m_spec.pixel_bytes() == size_t(m_xstride), "%d vs %d",
-                     (int)m_spec.pixel_bytes(), (int)m_xstride);
+    offset *= m_bufspan.xstride();
+    OIIO_DASSERT_MSG(m_spec.pixel_bytes() == size_t(m_bufspan.xstride()),
+                     "%d vs %d", (int)m_spec.pixel_bytes(),
+                     (int)m_bufspan.xstride());
 
     TypeDesc format;
     const void* pixeldata = m_imagecache->tile_pixels(tile, format);

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -115,9 +115,11 @@ bool
 ImageOutput::write_scanline(int y, TypeDesc format,
                             const image_span<const std::byte>& data)
 {
-    size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
-                                       : format.size() * m_spec.nchannels)
-                * size_t(m_spec.width);
+    if (y < 0 || y >= m_spec.height) {
+        errorfmt("write_scanlines: Invalid scanline index {}", y);
+        return false;
+    }
+    size_t sz = m_spec.scanline_bytes(format);
     if (sz != data.size_bytes()) {
         errorfmt(
             "write_scanline: Buffer size is incorrect ({} bytes vs {} needed)",
@@ -157,9 +159,11 @@ bool
 ImageOutput::write_scanlines(int ybegin, int yend, TypeDesc format,
                              const image_span<const std::byte>& data)
 {
-    size_t sz = (format == TypeUnknown ? m_spec.pixel_bytes(true /*native*/)
-                                       : format.size() * m_spec.nchannels)
-                * size_t(yend - ybegin) * size_t(m_spec.width);
+    if (ybegin < 0 || yend > m_spec.height || ybegin >= yend) {
+        errorfmt("write_scanlines: Invalid scanline range {}-{}", ybegin, yend);
+        return false;
+    }
+    size_t sz = m_spec.scanline_bytes(format) * size_t(yend - ybegin);
     if (sz != data.size_bytes()) {
         errorfmt(
             "write_scanlines: Buffer size is incorrect ({} bytes vs {} needed)",


### PR DESCRIPTION
We've already done ImageInput, ImageOutput, ImageCache, TextureSystem.

This applies the analogous set of changes to the public APIs of ImageBuf -- adding span and image_span versions of all the API calls that previously required raw pointers and strides. Many of the internals are still using the old versions, but at least this takes care of the interface.
