### PR TITLE
build: Adjust pystring finding

### DIFF
--- a/src/cmake/build_pystring.cmake
+++ b/src/cmake/build_pystring.cmake
@@ -30,8 +30,10 @@ build_dependency_with_cmake(pystring
 )
 
 set (pystring_VERSION ${pystring_BUILD_VERSION})
+unset (PYSTRING_LIBRARY)
+unset (PYSTRING_INCLUDE_DIR)
 
-set (pystring_REFIND TRUE)
+set (pystring_REFIND FALSE)
 set (pystring_REFIND_VERSION ${pystring_BUILD_VERSION})
 
 


### PR DESCRIPTION
We have been having intermittent CI failures when the auto-build of OpenColorIO triggers the auto-build of Pystring, and then sometimes immediately seems to think the version it installed is not correct.

I'm jiggling some things here to see if I can get it to stop occasionally failing. I've run the testsuite on this patch several times without seeing any failures that in recent days had been happening typically in 1-2 jobs per CI run. So maybe this fixes it? I'd be lying if I claimed to have a coherent and full explanation for exactly why these changes help.
