### PR TITLE
build: wheel upload_pypi step should only run from main repo

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -414,7 +414,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v3.0.')
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v3.0.') && github.repository == 'AcademySoftwareFoundation/OpenImageIO'
     steps:
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
 


### PR DESCRIPTION
The upload_pypi step only happened for tags, not for other events like PRs. But it would TRY (and fail) if you pushed a v3.0.* tag to your own fork. This patch makes it not een attempt it, except when the tag is pushed to the offical repo.
