### PR TITLE
Fix HEIF stride type mismatch in input/output classes

### DIFF
--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -385,8 +385,11 @@ HeifInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
         return false;
     if (y < 0 || y >= m_spec.height)  // out of range scanline
         return false;
-
-    int ystride          = 0;
+#if LIBHEIF_NUMERIC_VERSION >= MAKE_LIBHEIF_VERSION(1, 20, 0, 0)
+    size_t ystride = 0;
+#else
+    int ystride = 0;
+#endif
     const uint8_t* hdata = m_himage.get_plane(heif_channel_interleaved,
                                               &ystride);
     if (!hdata) {

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -149,7 +149,7 @@ bool
 HeifOutput::write_scanline(int y, int /*z*/, TypeDesc format, const void* data,
                            stride_t xstride)
 {
-    data           = to_native_scanline(format, data, xstride, scratch);
+    data = to_native_scanline(format, data, xstride, scratch);
 #if LIBHEIF_NUMERIC_VERSION >= MAKE_LIBHEIF_VERSION(1, 20, 0, 0)
     size_t hystride = 0;
 #else

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -143,7 +143,11 @@ HeifOutput::write_scanline(int y, int /*z*/, TypeDesc format, const void* data,
                            stride_t xstride)
 {
     data           = to_native_scanline(format, data, xstride, scratch);
-    int hystride   = 0;
+#if LIBHEIF_NUMERIC_VERSION >= MAKE_LIBHEIF_VERSION(1, 20, 0, 0)
+    size_t hystride = 0;
+#else
+    int hystride = 0;
+#endif
     uint8_t* hdata = m_himage.get_plane(heif_channel_interleaved, &hystride);
     hdata += hystride * (y - m_spec.y);
     memcpy(hdata, data, hystride);

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -9,6 +9,13 @@
 
 #include <libheif/heif_cxx.h>
 
+#define MAKE_LIBHEIF_VERSION(a, b, c, d) \
+    (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
+
+#if LIBHEIF_NUMERIC_VERSION >= MAKE_LIBHEIF_VERSION(1, 17, 0, 0)
+#    include <libheif/heif_properties.h>
+#endif
+
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 


### PR DESCRIPTION
seeing build failures when building against libheif 1.19+

```
  /private/tmp/openimageio-20250701-18561-96sl0/OpenImageIO-3.0.8.0/src/heif.imageio/heifinput.cpp:390:37: error: no matching member function for call to 'get_plane'
    390 |     const uint8_t* hdata = m_himage.get_plane(heif_channel_interleaved,
        |                            ~~~~~~~~~^~~~~~~~~
  /opt/homebrew/include/libheif/heif_cxx.h:909:32: note: candidate function not viable: no known conversion from 'int *' to 'size_t *' (aka 'unsigned long *') for 2nd argument
    909 |   inline const uint8_t* Image::get_plane(enum heif_channel channel, size_t* out_stride) const noexcept
        |                                ^                                    ~~~~~~~~~~~~~~~~~~
  /opt/homebrew/include/libheif/heif_cxx.h:914:26: note: candidate function not viable: no known conversion from 'int *' to 'size_t *' (aka 'unsigned long *') for 2nd argument
    914 |   inline uint8_t* Image::get_plane(enum heif_channel channel, size_t* out_stride) noexcept
        |                          ^                                    ~~~~~~~~~~~~~~~~~~
  1 error generated.
```

relates to https://github.com/Homebrew/homebrew-core/pull/228740