### PR TITLE
fix: correct docs and type of "resident_memory_used_MB" attribute

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3974,7 +3974,7 @@ inline bool attribute (string_view name, string_view val) {
 ///   List of library dependencieis (where known) and versions, separatd by
 ///   semicolons. (Added in OpenImageIO 2.5.8.)
 ///
-/// - `float resident_memory_used_MB`
+/// - `int resident_memory_used_MB`
 ///
 ///   This read-only attribute can be used for debugging purposes to report
 ///   the approximate process memory used (resident) by the application, in

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -634,6 +634,10 @@ getattribute(string_view name, TypeDesc type, void* val)
         *(int*)val = int(Sysutil::memory_used(true) >> 20);
         return true;
     }
+    if (name == "resident_memory_used_MB" && type == TypeFloat) {
+        *(float*)val = float(Sysutil::memory_used(true) >> 20);
+        return true;
+    }
     if (name == "missingcolor" && type.basetype == TypeDesc::FLOAT
         && oiio_missingcolor.size()) {
         // missingcolor as float array


### PR DESCRIPTION
It was implemented as int, documented as float.  Change the docs to match what was always indended (int), and also switch the implementation so that either int or float will be transparently accepted.
