### PR TITLE
perf: Speed up maketx --envlatl when multithreaded by over 10x.

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -2961,7 +2961,8 @@ ImageBuf::xbegin() const
 int
 ImageBuf::xend() const
 {
-    return spec().x + spec().width;
+    const ImageSpec& spec(m_impl->spec());
+    return spec.x + spec.width;
 }
 
 
@@ -2977,7 +2978,8 @@ ImageBuf::ybegin() const
 int
 ImageBuf::yend() const
 {
-    return spec().y + spec().height;
+    const ImageSpec& spec(m_impl->spec());
+    return spec.y + spec.height;
 }
 
 
@@ -2993,7 +2995,8 @@ ImageBuf::zbegin() const
 int
 ImageBuf::zend() const
 {
-    return spec().z + std::max(spec().depth, 1);
+    const ImageSpec& spec(m_impl->spec());
+    return spec.z + std::max(spec.depth, 1);
 }
 
 
@@ -3009,7 +3012,8 @@ ImageBuf::xmin() const
 int
 ImageBuf::xmax() const
 {
-    return spec().x + spec().width - 1;
+    const ImageSpec& spec(m_impl->spec());
+    return spec.x + spec.width - 1;
 }
 
 
@@ -3025,7 +3029,8 @@ ImageBuf::ymin() const
 int
 ImageBuf::ymax() const
 {
-    return spec().y + spec().height - 1;
+    const ImageSpec& spec(m_impl->spec());
+    return spec.y + spec.height - 1;
 }
 
 
@@ -3041,7 +3046,8 @@ ImageBuf::zmin() const
 int
 ImageBuf::zmax() const
 {
-    return spec().z + std::max(spec().depth, 1) - 1;
+    const ImageSpec& spec(m_impl->spec());
+    return spec.z + std::max(spec.depth, 1) - 1;
 }
 
 


### PR DESCRIPTION
As reported on Slack
(https://academysoftwarefdn.slack.com/archives/C05782U3806/p1751642730171029), between OIIO 2.5 and 3.0, we had a big slowdown when doing a multithreaded `maketx --envlatl`, which was traced almost entirely to the new mutex lock in ImageBuf::IteratorBase::init_ib(), which were all happening inside the call stack of `resize_block_<float>()`.

The reason was that it was calling ImageBuf::interppixel_NDC for every pixel, which in turn works by creating (internally) an ImageBuf::ConstIterator to sample the 4 nearby pixels. But every one of those ConstIterator constructors called init_ib, which briefly grabbed the mutex for the IB, which in addition to being wasteful on its own, caused the threads to block on each other.

The solution is straightforward: there is no need to construct a new Iterator for every pixel. We can create the iterator once (a single call to the init_ib for each thread region of the image) and then for each pixel, just call its `rerange()` method to reset the set of pixels to loop over for the samples needed for that pixel.

I also opportunistically eliminated a few redundant spec() calls in various routines in imagebuf.cpp.

On my Mac laptop, when doing a maketx --latlong on a 16k image with 16 threads, it was previously taking 170.5s (including 117.8s for the initial resize and 42.8s for the MIP computations). With this change, the same operation takes 12.4s (including 3.7s for the initial resize and 1.6s for he MIP computationss). That's almost a 14x speedup. YMMV, depending on platform, compiler, image size, and number of threads.
