### PR TITLE
ci: Bump 'latest releases' tests to use pybind11 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
             fmt_ver: 7.0.1
             opencolorio_ver: v2.2.1
             openexr_ver: v3.1.0
-            pybind11_ver: v2.4.2
+            pybind11_ver: v2.7.0
             python_ver: 3.7
             simd: 0
             setenvs: export  EMBEDPLUGINS=0
@@ -413,7 +413,7 @@ jobs:
             fmt_ver: 11.2.0
             opencolorio_ver: v2.4.2
             openexr_ver: v3.3.4
-            pybind11_ver: v2.13.6
+            pybind11_ver: v3.0.0
             python_ver: "3.12"
             simd: avx2,f16c
             setenvs: export LIBJPEGTURBO_VERSION=3.1.1
@@ -512,7 +512,7 @@ jobs:
             fmt_ver: 11.1.4
             opencolorio_ver: v2.4.2
             openexr_ver: v3.3.3
-            pybind11_ver: v2.13.6
+            pybind11_ver: v3.0.0
             python_ver: "3.12"
             setenvs: export LIBJPEGTURBO_VERSION=3.1.0
                             LIBRAW_VERSION=0.21.3
@@ -532,7 +532,7 @@ jobs:
             fmt_ver: 11.1.4
             opencolorio_ver: v2.4.2
             openexr_ver: v3.3.3
-            pybind11_ver: v2.13.6
+            pybind11_ver: v3.0.0
             python_ver: "3.12"
             setenvs: export LIBJPEGTURBO_VERSION=3.1.0
                             LIBRAW_VERSION=0.21.3

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,10 +42,10 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
      * Python >= 3.7 (tested through 3.13)
-     * pybind11 >= 2.7 (tested through 2.13)
+     * pybind11 >= 2.7 (tested through 3.0)
      * NumPy (tested through 2.2.4)
  * If you want support for PNG files:
-     * libPNG >= 1.6.0 (tested though 1.6.49)
+     * libPNG >= 1.6.0 (tested though 1.6.50)
  * If you want support for camera "RAW" formats:
      * LibRaw >= 0.20 (tested though 0.21.4 and master)
  * If you want support for a wide variety of video formats:


### PR DESCRIPTION
Also found one stray test that was using a pybind11 version older than we claim to use, so bump that up to the advertised minimum.
