### PR TITLE
build: For python stub generation, lock pybind11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ oiiotool = "OpenImageIO:_command_line"
 build-backend = "scikit_build_core.build"
 requires = [
     "scikit-build-core>=0.10.6,<1",
-    "pybind11",
+    "pybind11>=2.13,<3",
 ]
 
 [tool.scikit-build]


### PR DESCRIPTION
pybind11 3.0 seems to break this process, so lock down to no later than the last version before it broke.
