### PR TITLE
Switch to posix_spawnp for macOS background launch to enable PATH lookup

### DIFF
--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -525,6 +525,8 @@ Term::ansi_bgcolor(int r, int g, int b)
     return ret;
 }
 
+
+
 bool
 Sysutil::put_in_background()
 {
@@ -547,7 +549,7 @@ Sysutil::put_in_background()
     posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSID);
     char** argv    = *_NSGetArgv();
     char** environ = *_NSGetEnviron();
-    int status     = posix_spawn(&pid, argv[0], nullptr, &attr, argv, environ);
+    int status     = posix_spawnp(&pid, argv[0], nullptr, &attr, argv, environ);
     posix_spawnattr_destroy(&attr);
     if (status == 0)
         exit(0);
@@ -562,6 +564,7 @@ Sysutil::put_in_background()
     return false;
 #endif
 }
+
 
 
 bool


### PR DESCRIPTION
Switch to posix_spawnp for macOS background launch to enable PATH lookup, this is a fix for:
https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4640

Description:
Previously, the code used posix_spawn with argv[0] as the executable name. This failed when argv[0] was not an absolute or relative path (e.g., just "iv"), because posix_spawn does not perform PATH lookups.

Switched to posix_spawnp, which behaves like execvp and searches PATH when argv[0] does not contain a '/' character. This allows the program to re-spawn in the background using the original command name, without requiring _NSGetExecutablePath() to resolve the full path.