### PR TITLE
ffmpeg: Replace deprecated and soon removed avcodec_close with avcodec_free_context in ffmpeg plugin.

### DIFF
--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -581,7 +581,7 @@ bool
 FFmpegInput::close(void)
 {
     if (m_codec_context)
-        avcodec_close(m_codec_context);
+        avcodec_free_context(&m_codec_context);
     if (m_format_context) {
         avformat_close_input(&m_format_context);
         av_free(m_format_context);  // will free m_codec and m_codec_context


### PR DESCRIPTION
avcodec_close (AVCodecContext *avctx) removing in ffmpeg 7.2 and was deprecated for couple years

## Description

Global avcodec_close (AVCodecContext *avctx)
Do not use this function. Use avcodec_free_context() to destroy a codec context (either open or closed). Opening and closing a codec context multiple times is not supported anymore – use multiple codec contexts instead.

In ffmpeg master, it has already been removed. But still work in v7.1

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
