### PR TITLE
exr: Don't assume unlabeled OpenEXR files are lin_rec709

### DIFF
--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -6,6 +6,7 @@
 
 
 #include <OpenImageIO/Imath.h>
+#include <OpenImageIO/color.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/platform.h>
@@ -228,6 +229,7 @@ private:
     int m_nsubimages;                   ///< How many subimages are there?
     int m_miplevel;                     ///< What MIP level are we looking at?
     std::vector<float> m_missingcolor;  ///< Color for missing tile/scanline
+    std::string m_filename;             // filename, if known
 
     void init()
     {
@@ -243,6 +245,7 @@ private:
         m_io                       = nullptr;
         m_local_io.reset();
         m_missingcolor.clear();
+        m_filename.clear();
     }
 
     bool read_native_scanlines_individually(int subimage, int miplevel,

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -240,6 +240,8 @@ OpenEXRInput::open(const std::string& name, ImageSpec& newspec,
 
     // Check any other configuration hints
 
+    m_filename = name;
+
     // "missingcolor" gives fill color for missing scanlines or tiles.
     if (const ParamValue* m = config.find_attribute("oiio:missingcolor")) {
         if (m->type().basetype == TypeDesc::STRING) {
@@ -391,14 +393,6 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         return false;
 
     spec.deep = Strutil::istarts_with(header->type(), "deep");
-
-    // Unless otherwise specified, exr files are assumed to be linear Rec709
-    // if the channels appear to be R, G, B.  I know this suspect, but I'm
-    // betting that this heuristic will guess the right thing that users want
-    // more often than if we pretending we have no idea what the color space
-    // is.
-    if (pvt::channels_are_rgb(spec))
-        spec.set_colorspace("lin_rec709");
 
     if (levelmode != Imf::ONE_LEVEL)
         spec.attribute("openexr:roundingmode", roundingmode);
@@ -673,6 +667,17 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         spec.attribute("oiio:subimagename", header->name());
 
     spec.attribute("oiio:subimages", in->m_nsubimages);
+
+    // Try to figure out the color space
+    if (auto c = spec.find_attribute("colorInteropID", TypeString)) {
+        spec.set_colorspace(c->get_ustring());
+    } else {
+        string_view cs
+            = ColorConfig::default_colorconfig().getColorSpaceFromFilepath(
+                in->m_filename, "unknown");
+        if (cs.size() && cs != "unknown")
+            spec.set_colorspace(cs);
+    }
 
     // Squash some problematic texture metadata if we suspect it's wrong
     pvt::check_texture_metadata_sanity(spec);

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -668,15 +668,11 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
 
     spec.attribute("oiio:subimages", in->m_nsubimages);
 
-    // Try to figure out the color space
-    if (auto c = spec.find_attribute("colorInteropID", TypeString)) {
+    // Try to figure out the color space for some unambiguous cases
+    if (spec.get_int_attribute("acesImageContainerFlag") == 1) {
+        spec.set_colorspace("lin_ap0_scene");
+    } else if (auto c = spec.find_attribute("colorInteropID", TypeString)) {
         spec.set_colorspace(c->get_ustring());
-    } else {
-        string_view cs
-            = ColorConfig::default_colorconfig().getColorSpaceFromFilepath(
-                in->m_filename, "unknown");
-        if (cs.size() && cs != "unknown")
-            spec.set_colorspace(cs);
     }
 
     // Squash some problematic texture metadata if we suspect it's wrong

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -19,6 +19,7 @@
 #include <OpenEXR/openexr.h>
 
 #include "imageio_pvt.h"
+#include <OpenImageIO/color.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/filesystem.h>
@@ -208,6 +209,7 @@ private:
     std::unique_ptr<Filesystem::IOProxy> m_local_io;
     int m_nsubimages;                   ///< How many subimages are there?
     std::vector<float> m_missingcolor;  ///< Color for missing tile/scanline
+    std::string m_filename;             // filename, if known
 
     void init()
     {
@@ -216,6 +218,7 @@ private:
         m_userdata.m_io  = nullptr;
         m_local_io.reset();
         m_missingcolor.clear();
+        m_filename.clear();
     }
 
     bool valid_file(const std::string& filename, Filesystem::IOProxy* io) const;
@@ -357,6 +360,8 @@ OpenEXRCoreInput::open(const std::string& name, ImageSpec& newspec,
     //KDTDISABLE }
 
     // Check any other configuration hints
+
+    m_filename = name;
 
     // "missingcolor" gives fill color for missing scanlines or tiles.
     if (const ParamValue* m = config.find_attribute("oiio:missingcolor")) {
@@ -526,14 +531,6 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
 
     spec.deep = (storage == EXR_STORAGE_DEEP_TILED
                  || storage == EXR_STORAGE_DEEP_SCANLINE);
-
-    // Unless otherwise specified, exr files are assumed to be linear Rec709
-    // if the channels appear to be R, G, B.  I know this suspect, but I'm
-    // betting that this heuristic will guess the right thing that users want
-    // more often than if we pretending we have no idea what the color space
-    // is.
-    if (pvt::channels_are_rgb(spec))
-        spec.set_colorspace("lin_rec709");
 
     if (levelmode != EXR_TILE_ONE_LEVEL)
         spec.attribute("openexr:roundingmode", (int)roundingmode);
@@ -775,6 +772,17 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
     }
 
     spec.attribute("oiio:subimages", in->m_nsubimages);
+
+    // Try to figure out the color space
+    if (auto c = spec.find_attribute("colorInteropID", TypeString)) {
+        spec.set_colorspace(c->get_ustring());
+    } else {
+        string_view cs
+            = ColorConfig::default_colorconfig().getColorSpaceFromFilepath(
+                in->m_filename, "unknown");
+        if (cs.size() && cs != "unknown")
+            spec.set_colorspace(cs);
+    }
 
     // Squash some problematic texture metadata if we suspect it's wrong
     pvt::check_texture_metadata_sanity(spec);

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -773,15 +773,11 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
 
     spec.attribute("oiio:subimages", in->m_nsubimages);
 
-    // Try to figure out the color space
-    if (auto c = spec.find_attribute("colorInteropID", TypeString)) {
+    // Try to figure out the color space for some unambiguous cases
+    if (spec.get_int_attribute("acesImageContainerFlag") == 1) {
+        spec.set_colorspace("lin_ap0_scene");
+    } else if (auto c = spec.find_attribute("colorInteropID", TypeString)) {
         spec.set_colorspace(c->get_ustring());
-    } else {
-        string_view cs
-            = ColorConfig::default_colorconfig().getColorSpaceFromFilepath(
-                in->m_filename, "unknown");
-        if (cs.size() && cs != "unknown")
-            spec.set_colorspace(cs);
     }
 
     // Squash some problematic texture metadata if we suspect it's wrong

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -6,7 +6,6 @@ out.exr              :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading out2.exr
@@ -18,7 +17,6 @@ out2.exr             :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "Aimg"
     oiio:subimages: 1
     openexr:chunkCount: 4

--- a/testsuite/iinfo/ref/out-fmt6.txt
+++ b/testsuite/iinfo/ref/out-fmt6.txt
@@ -147,7 +147,6 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-src/tiny-az.exr :     oiio:ColorSpace: "lin_rec709"
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     openexr:lineOrder: "increasingY"
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
@@ -175,7 +174,6 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000

--- a/testsuite/iinfo/ref/out.txt
+++ b/testsuite/iinfo/ref/out.txt
@@ -147,7 +147,6 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-src/tiny-az.exr :     oiio:ColorSpace: "lin_rec709"
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     openexr:lineOrder: "increasingY"
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
@@ -175,7 +174,6 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000

--- a/testsuite/maketx/ref/out-macarm.txt
+++ b/testsuite/maketx/ref/out-macarm.txt
@@ -315,7 +315,6 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -344,7 +343,6 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -315,7 +315,6 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -344,7 +343,6 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -86,7 +86,6 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -100,7 +99,6 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -116,7 +114,6 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -129,7 +126,6 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -86,7 +86,6 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -100,7 +99,6 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -116,7 +114,6 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -129,7 +126,6 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -13,7 +13,6 @@ allhalf.exr          :   38 x   38, 5 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading rgbahalf-zfloat.exr
@@ -27,7 +26,6 @@ rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 explicit -d uint save result: 
@@ -68,7 +66,6 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading green.exr
@@ -80,7 +77,6 @@ green.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-replace.exr
@@ -96,7 +92,6 @@ greenmeta-replace.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge.exr
@@ -112,7 +107,6 @@ greenmeta-merge.exr  :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge-override.exr
@@ -128,7 +122,6 @@ greenmeta-merge-override.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge-camera.exr
@@ -142,7 +135,6 @@ greenmeta-merge-camera.exr :   64 x   64, 3 channel, half openexr
     screenWindowWidth: 1
     camera:lens: "AX30"
     camera:shutter: 0.0125
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge-2.exr
@@ -161,7 +153,6 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage00"
     oiio:subimages: 3
     openexr:chunkCount: 4
@@ -179,7 +170,6 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage01"
     oiio:subimages: 3
     openexr:chunkCount: 4
@@ -197,7 +187,6 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "subimage02"
     oiio:subimages: 3
     openexr:chunkCount: 4
@@ -211,7 +200,6 @@ nometamerge.exr      :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading metamerge.exr
@@ -224,7 +212,6 @@ metamerge.exr        :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Testing -o with no image

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -9,7 +9,6 @@ src/bad.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -29,7 +28,6 @@ black.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -49,7 +47,6 @@ box3.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)

--- a/testsuite/oiiotool-maketx/ref/out-macarm.txt
+++ b/testsuite/oiiotool-maketx/ref/out-macarm.txt
@@ -277,7 +277,6 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -307,7 +306,6 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
-    oiio:ColorSpace: "lin_rec709"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
@@ -351,7 +349,6 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -277,7 +277,6 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -305,7 +304,6 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     openexr:roundingmode: 0
 Reading grid.tx

--- a/testsuite/oiiotool-maketx/ref/out-win.txt
+++ b/testsuite/oiiotool-maketx/ref/out-win.txt
@@ -277,7 +277,6 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -307,7 +306,6 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
-    oiio:ColorSpace: "lin_rec709"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
@@ -351,7 +349,6 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -277,7 +277,6 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -307,7 +306,6 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
-    oiio:ColorSpace: "lin_rec709"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
@@ -351,7 +349,6 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-subimage/ref/out.txt
+++ b/testsuite/oiiotool-subimage/ref/out.txt
@@ -10,7 +10,6 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerA"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -24,7 +23,6 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerB"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -38,7 +36,6 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerC"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -52,7 +49,6 @@ gpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "layerD"
     oiio:subimages: 4
     openexr:chunkCount: 4

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -40,7 +40,6 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 dumpdata:

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -7,7 +7,6 @@ Reading ../openexr-images/Chromaticities/Rec709.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Chromaticities/Rec709.exr" and "Rec709.exr"
@@ -22,7 +21,6 @@ Reading ../openexr-images/Chromaticities/XYZ.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Chromaticities/XYZ.exr" and "XYZ.exr"

--- a/testsuite/openexr-decreasingy/ref/out.txt
+++ b/testsuite/openexr-decreasingy/ref/out.txt
@@ -9,7 +9,6 @@ increasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading increasingY-copy.exr
@@ -23,7 +22,6 @@ increasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading decreasingY-resize.exr
@@ -37,7 +35,6 @@ decreasingY-resize.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "decreasingY"
 Reading decreasingY-copy.exr
@@ -51,7 +48,6 @@ decreasingY-copy.exr : 4080 x 3072, 3 channel, half openexr
     screenWindowWidth: 1
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "decreasingY"
 Comparing "increasingY-copy.exr" and "decreasingY-copy.exr"

--- a/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
@@ -7,7 +7,6 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -23,7 +22,6 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -39,7 +37,6 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -54,7 +51,6 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -69,7 +65,6 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -84,7 +79,6 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1

--- a/testsuite/openexr-luminance-chroma/ref/out.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out.txt
@@ -7,7 +7,6 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -23,7 +22,6 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -39,7 +37,6 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -54,7 +51,6 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -69,7 +65,6 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -84,7 +79,6 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -12,7 +12,6 @@ Reading ../openexr-images/MultiResolution/Bonita.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -32,7 +31,6 @@ Reading ../openexr-images/MultiResolution/ColorCodedLevels.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -52,7 +50,6 @@ Reading ../openexr-images/MultiResolution/KernerEnvCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -71,7 +68,6 @@ Reading ../openexr-images/MultiResolution/KernerEnvLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -92,7 +88,6 @@ Reading ../openexr-images/MultiResolution/MirrorPattern.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "mirror,mirror"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -112,7 +107,6 @@ Reading ../openexr-images/MultiResolution/OrientationCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -131,7 +125,6 @@ Reading ../openexr-images/MultiResolution/OrientationLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -152,7 +145,6 @@ Reading ../openexr-images/MultiResolution/PeriodicPattern.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -172,7 +164,6 @@ Reading ../openexr-images/MultiResolution/StageEnvCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -191,7 +182,6 @@ Reading ../openexr-images/MultiResolution/StageEnvLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -213,7 +203,6 @@ Reading ../openexr-images/MultiResolution/WavyLinesCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -232,7 +221,6 @@ Reading ../openexr-images/MultiResolution/WavyLinesLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
-    oiio:ColorSpace: "lin_rec709"
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -249,7 +237,6 @@ Reading ../openexr-images/MultiResolution/WavyLinesSphere.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"
@@ -267,7 +254,6 @@ Reading ../openexr-images/MultiView/Adjuster.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Adjuster.exr" and "Adjuster.exr"
@@ -284,7 +270,6 @@ Reading ../openexr-images/MultiView/Balls.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Balls.exr" and "Balls.exr"
@@ -327,7 +312,6 @@ Reading ../openexr-images/MultiView/Impact.exr
     wrapmodes: "clamp,clamp"
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -348,7 +332,6 @@ Reading ../openexr-images/MultiView/LosPadres.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/LosPadres.exr" and "LosPadres.exr"

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -14,7 +14,6 @@ Reading ../openexr-images/ScanLines/Blobbies.exr
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 50
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "decreasingY"
 Comparing "../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
@@ -32,7 +31,6 @@ Reading ../openexr-images/ScanLines/CandleGlass.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/CandleGlass.exr" and "CandleGlass.exr"
@@ -46,7 +44,6 @@ Reading ../openexr-images/ScanLines/Cannon.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
@@ -59,7 +56,6 @@ Reading ../openexr-images/ScanLines/Desk.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Desk.exr" and "Desk.exr"
@@ -79,7 +75,6 @@ Reading ../openexr-images/ScanLines/MtTamWest.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     utcOffset: 25200
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/MtTamWest.exr" and "MtTamWest.exr"
@@ -97,7 +92,6 @@ Reading ../openexr-images/ScanLines/PrismsLenses.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/PrismsLenses.exr" and "PrismsLenses.exr"
@@ -113,7 +107,6 @@ Reading ../openexr-images/ScanLines/StillLife.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 0.45
     utcOffset: 25200
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/StillLife.exr" and "StillLife.exr"
@@ -132,7 +125,6 @@ Reading ../openexr-images/ScanLines/Tree.exr
     screenWindowWidth: 0.48
     utcOffset: 25200
     whiteLuminance: 621
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Tree.exr" and "Tree.exr"
@@ -145,7 +137,6 @@ Reading ../openexr-images/TestImages/AllHalfValues.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/AllHalfValues.exr" and "AllHalfValues.exr"
@@ -158,7 +149,6 @@ Reading ../openexr-images/TestImages/BrightRings.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/BrightRings.exr" and "BrightRings.exr"
@@ -171,7 +161,6 @@ Reading ../openexr-images/TestImages/BrightRingsNanInf.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/BrightRingsNanInf.exr" and "BrightRingsNanInf.exr"
@@ -184,7 +173,6 @@ Reading ../openexr-images/TestImages/GammaChart.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/GammaChart.exr" and "GammaChart.exr"
@@ -221,7 +209,6 @@ Reading ../openexr-images/TestImages/RgbRampsDiagonal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/RgbRampsDiagonal.exr" and "RgbRampsDiagonal.exr"
@@ -234,7 +221,6 @@ Reading ../openexr-images/TestImages/SquaresSwirls.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/SquaresSwirls.exr" and "SquaresSwirls.exr"
@@ -248,7 +234,6 @@ Reading ../openexr-images/TestImages/WideColorGamut.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/WideColorGamut.exr" and "WideColorGamut.exr"
@@ -285,7 +270,6 @@ Reading ../openexr-images/Tiles/GoldenGate.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1.15
     utcOffset: 28800
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/GoldenGate.exr" and "GoldenGate.exr"
@@ -301,7 +285,6 @@ Reading ../openexr-images/Tiles/Ocean.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
@@ -323,7 +306,6 @@ Reading ../openexr-images/Tiles/Spirals.exr
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 90
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
@@ -341,7 +323,6 @@ Reading ../openexr-images/Beachball/singlepart.0001.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -358,6 +339,5 @@ negoverscan.exr      :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -15,7 +15,6 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -50,7 +49,6 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -101,7 +99,6 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     screenWindowWidth: 1
     version: 1
     view: "left"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 761
@@ -120,7 +117,6 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     screenWindowWidth: 1
     version: 1
     view: "right"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 761
@@ -162,7 +158,6 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     screenWindowWidth: 1
     version: 1
     view: "left"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 1080
@@ -178,7 +173,6 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     screenWindowWidth: 1
     version: 1
     view: "right"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 1080
@@ -221,7 +215,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -286,7 +279,6 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimagename: "rgba_left"
     oiio:subimages: 10
     openexr:chunkCount: 876

--- a/testsuite/openexr-window/ref/out.txt
+++ b/testsuite/openexr-window/ref/out.txt
@@ -6,7 +6,6 @@ Reading ../openexr-images/DisplayWindow/t01.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t01.exr" and "t01.exr"
@@ -21,7 +20,6 @@ Reading ../openexr-images/DisplayWindow/t02.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t02.exr" and "t02.exr"
@@ -36,7 +34,6 @@ Reading ../openexr-images/DisplayWindow/t03.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t03.exr" and "t03.exr"
@@ -51,7 +48,6 @@ Reading ../openexr-images/DisplayWindow/t04.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t04.exr" and "t04.exr"
@@ -66,7 +62,6 @@ Reading ../openexr-images/DisplayWindow/t05.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t05.exr" and "t05.exr"
@@ -81,7 +76,6 @@ Reading ../openexr-images/DisplayWindow/t06.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t06.exr" and "t06.exr"
@@ -96,7 +90,6 @@ Reading ../openexr-images/DisplayWindow/t07.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t07.exr" and "t07.exr"
@@ -112,7 +105,6 @@ Reading ../openexr-images/DisplayWindow/t08.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t08.exr" and "t08.exr"
@@ -127,7 +119,6 @@ Reading ../openexr-images/DisplayWindow/t09.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t09.exr" and "t09.exr"
@@ -142,7 +133,6 @@ Reading ../openexr-images/DisplayWindow/t10.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t10.exr" and "t10.exr"
@@ -157,7 +147,6 @@ Reading ../openexr-images/DisplayWindow/t11.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t11.exr" and "t11.exr"
@@ -172,7 +161,6 @@ Reading ../openexr-images/DisplayWindow/t12.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t12.exr" and "t12.exr"
@@ -187,7 +175,6 @@ Reading ../openexr-images/DisplayWindow/t13.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t13.exr" and "t13.exr"
@@ -202,7 +189,6 @@ Reading ../openexr-images/DisplayWindow/t14.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t14.exr" and "t14.exr"
@@ -217,7 +203,6 @@ Reading ../openexr-images/DisplayWindow/t15.exr
     PixelAspectRatio: 1.5
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t15.exr" and "t15.exr"
@@ -232,7 +217,6 @@ Reading ../openexr-images/DisplayWindow/t16.exr
     PixelAspectRatio: 0.666667
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t16.exr" and "t16.exr"

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -62,7 +62,6 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     Software: "OpenImageIO 1.8.5dev : oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     timecodeRate: 24
     Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     smpte:TimeCode: 01:18:19:06
@@ -77,6 +76,5 @@ rat2.exr             :   64 x   64, 3 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
-    oiio:ColorSpace: "lin_rec709"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -62,6 +62,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     Software: "OpenImageIO 1.8.5dev : oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     timecodeRate: 24
     Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
+    oiio:ColorSpace: "lin_ap0_scene"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     smpte:TimeCode: 01:18:19:06


### PR DESCRIPTION
New logic for reading OpenEXR files:

1. If the new colorInteropID is present, that's the color space.
2. Use the OCIO file naming rules, if that indicates a color space.
3. Otherwise, leave it blank, don't mae any assumptions.

It was a mistake for 3.0 to assume that completely unlabeled openexr files are lin_rec709.
