### PR TITLE
fix(python): got strides wrong passing 2D numpy pixel array

### DIFF
--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -138,7 +138,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
                 xstride = pybuf.strides[0];
             else if (pybuf.shape[0] == height
                      && pybuf.shape[1] == int64_t(width) * int64_t(nchans)) {
-                ystride = pybuf.strides[0];
+                ystride = pybuf.strides[1];
                 xstride = pybuf.strides[0] * nchans;
             } else {
                 format = TypeUnknown;  // error


### PR DESCRIPTION
When passing numpy arrays for pixel blocks (say, to ImageOutput.write_image), the sorting out of what the numpy arrays meant had an error for the 2D case. A typo (or maybe copy pasta) got the stride wrong.

This took a long time to be discovered because if there is more than one channel, it gets passed as a 3D numpy array (height, width, chans). So only for 1-channel images would it stumble across the bad code if it were passed as (height, width) with no dimension for channels.