### PR TITLE
build: C++23 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,12 +425,12 @@ jobs:
                             WEBP_VERSION=v1.5.0
                             FREETYPE_VERSION=VER-2-13-3
                             USE_OPENVDB=0
-          - desc: bleeding edge gcc14 C++20 py3.12 OCIO/libtiff/exr-main avx2
+          - desc: bleeding edge gcc14 C++23 py3.12 OCIO/libtiff/exr-main avx2
             nametag: linux-bleeding-edge
             runner: ubuntu-24.04
             cc_compiler: gcc-14
             cxx_compiler: g++-14
-            cxx_std: 20
+            cxx_std: 23
             fmt_ver: master
             opencolorio_ver: main
             openexr_ver: main

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 
 ### Required dependencies -- OIIO will not build at all without these
 
- * C++17 or higher (also builds with C++20)
+ * C++17 or higher (also builds with C++20 and C++23)
      * The default build mode is C++17. This can be controlled by via the
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=20`, etc.
  * Compilers: gcc 9.3 - 14.2, clang 5 - 19, MSVS 2017 - 2022 (v19.14

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -20,7 +20,6 @@
 
 
 using namespace OIIO;
-using OIIO::Strutil::print;
 
 static std::string uninitialized  = "uninitialized \001 HHRU dfvAS: efjl";
 static std::string dataformatname = "";
@@ -103,7 +102,7 @@ getargs(int argc, char* argv[])
                 nullptr);
     // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
-        print(stderr, "{}\n", ap.geterror());
+        OIIO::print(stderr, "{}\n", ap.geterror());
         ap.usage();
         ap.abort();
         return_code = EXIT_FAILURE;
@@ -117,7 +116,7 @@ getargs(int argc, char* argv[])
     }
 
     if (filenames.size() != 2 && !inplace) {
-        print(
+        OIIO::print(
             stderr,
             "iconvert: Must have both an input and output filename specified.\n");
         ap.usage();
@@ -126,14 +125,14 @@ getargs(int argc, char* argv[])
         return;
     }
     if (filenames.size() == 0 && inplace) {
-        print(stderr, "iconvert: Must have at least one filename\n");
+        OIIO::print(stderr, "iconvert: Must have at least one filename\n");
         ap.usage();
         ap.abort();
         return_code = EXIT_FAILURE;
         return;
     }
     if (((int)rotcw + (int)rotccw + (int)rot180 + (orientation > 0)) > 1) {
-        print(
+        OIIO::print(
             stderr,
             "iconvert: more than one of --rotcw, --rotccw, --rot180, --orientation\n");
         ap.usage();
@@ -151,7 +150,7 @@ DateTime_to_time_t(string_view datetime, time_t& timet)
     int year, month, day, hour, min, sec;
     if (!Strutil::scan_datetime(datetime, year, month, day, hour, min, sec))
         return false;
-    // print("{}:{}:{} {}:{}:{}\n", year, month, day, hour, min, sec);
+    // OIIO::print("{}:{}:{} {}:{}:{}\n", year, month, day, hour, min, sec);
     struct tm tmtime;
     time_t now;
     Sysutil::get_local_time(&now, &tmtime);  // fill in defaults
@@ -314,13 +313,14 @@ static bool
 convert_file(const std::string& in_filename, const std::string& out_filename)
 {
     if (noclobber && Filesystem::exists(out_filename)) {
-        print(stderr, "iconvert ERROR: Output file already exists \"{}\"\n",
-              out_filename);
+        OIIO::print(stderr,
+                    "iconvert ERROR: Output file already exists \"{}\"\n",
+                    out_filename);
         return false;
     }
 
     if (verbose) {
-        print("Converting {} to {}\n", in_filename, out_filename);
+        OIIO::print("Converting {} to {}\n", in_filename, out_filename);
         fflush(stdout);
     }
 
@@ -333,10 +333,11 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
     auto in = ImageInput::open(in_filename);
     if (!in) {
         std::string err = geterror();
-        print(stderr, "iconvert ERROR: {}\n",
-              (err.length() ? err
-                            : Strutil::fmt::format("Could not open \"{}\"",
-                                                   in_filename)));
+        OIIO::print(stderr, "iconvert ERROR: {}\n",
+                    (err.length()
+                         ? err
+                         : Strutil::fmt::format("Could not open \"{}\"",
+                                                in_filename)));
         return false;
     }
     ImageSpec inspec         = in->spec();
@@ -345,7 +346,7 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
     // Find an ImageIO plugin that can open the output file, and open it
     auto out = ImageOutput::create(tempname);
     if (!out) {
-        print(
+        OIIO::print(
             stderr,
             "iconvert ERROR: Could not find an ImageIO plugin to write \"{}\": {}\n",
             out_filename, geterror());
@@ -375,10 +376,11 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
     bool mip_to_subimage_warning = false;
     for (int subimage = 0; ok && in->seek_subimage(subimage, 0); ++subimage) {
         if (subimage > 0 && !out->supports("multiimage")) {
-            print(stderr,
-                  "iconvert WARNING: {} does not support multiple subimages.\n"
-                  "\tOnly the first subimage has been copied.\n",
-                  out->format_name());
+            OIIO::print(
+                stderr,
+                "iconvert WARNING: {} does not support multiple subimages.\n"
+                "\tOnly the first subimage has been copied.\n",
+                out->format_name());
             break;  // we're done
         }
 
@@ -398,17 +400,18 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
                     mode = ImageOutput::AppendSubimage;  // use if we must
                     if (!mip_to_subimage_warning
                         && strcmp(out->format_name(), "tiff")) {
-                        print(stderr,
-                              "iconvert WARNING: {} does not support MIPmaps.\n"
-                              "\tStoring the MIPmap levels in subimages.\n",
-                              out->format_name());
+                        OIIO::print(
+                            stderr,
+                            "iconvert WARNING: {} does not support MIPmaps.\n"
+                            "\tStoring the MIPmap levels in subimages.\n",
+                            out->format_name());
                     }
                     mip_to_subimage_warning = true;
                 } else {
-                    print(stderr,
-                          "iconvert WARNING: {} does not support MIPmaps.\n"
-                          "\tOnly the first level has been copied.\n",
-                          out->format_name());
+                    OIIO::print(stderr,
+                                "iconvert WARNING: {} does not support MIPmaps.\n"
+                                "\tOnly the first level has been copied.\n",
+                                out->format_name());
                     break;  // on to the next subimage
                 }
                 ok = out->open(tempname.c_str(), outspec, mode);
@@ -427,11 +430,11 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
             }
             if (!ok) {
                 std::string err = out->geterror();
-                print(stderr, "iconvert ERROR: {}\n",
-                      (err.length()
-                           ? err
-                           : Strutil::fmt::format("Could not open \"{}\"",
-                                                  out_filename)));
+                OIIO::print(stderr, "iconvert ERROR: {}\n",
+                            (err.length()
+                                 ? err
+                                 : Strutil::fmt::format("Could not open \"{}\"",
+                                                        out_filename)));
                 ok = false;
                 break;
             }
@@ -450,9 +453,10 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
             if (!nocopy) {
                 ok = out->copy_image(in.get());
                 if (!ok)
-                    print(stderr,
-                          "iconvert ERROR copying \"{}\" to \"{}\" :\n\t{}\n",
-                          in_filename, out_filename, out->geterror());
+                    OIIO::print(
+                        stderr,
+                        "iconvert ERROR copying \"{}\" to \"{}\" :\n\t{}\n",
+                        in_filename, out_filename, out->geterror());
             } else {
                 // Need to do it by hand for some reason.  Future expansion in which
                 // only a subset of channels are copied, or some such.
@@ -460,13 +464,14 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
                 ok = in->read_image(subimage, miplevel, 0, outspec.nchannels,
                                     outspec.format, &pixels[0]);
                 if (!ok) {
-                    print(stderr, "iconvert ERROR reading \"{}\": {}\n",
-                          in_filename, in->geterror());
+                    OIIO::print(stderr, "iconvert ERROR reading \"{}\": {}\n",
+                                in_filename, in->geterror());
                 } else {
                     ok = out->write_image(outspec.format, &pixels[0]);
                     if (!ok)
-                        print(stderr, "iconvert ERROR writing \"{}\": {}\n",
-                              out_filename, out->geterror());
+                        OIIO::print(stderr,
+                                    "iconvert ERROR writing \"{}\": {}\n",
+                                    out_filename, out->geterror());
                 }
             }
 

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -22,7 +22,6 @@
 
 
 using namespace OIIO;
-using OIIO::Strutil::print;
 
 
 enum idiffErrors {
@@ -131,8 +130,8 @@ read_input(const std::string& filename, ImageBuf& img,
     if (img.read(subimage, miplevel, false, TypeFloat))
         return true;
 
-    print(stderr, "idiff ERROR: Could not read {}:\n\t{}\n", filename,
-          img.geterror());
+    OIIO::print(stderr, "idiff ERROR: Could not read {}:\n\t{}\n", filename,
+                img.geterror());
     return false;
 }
 
@@ -145,11 +144,11 @@ inline void
 safe_double_print(double val)
 {
     if (std::isnan(val))
-        print("nan\n");
+        OIIO::print("nan\n");
     else if (std::isinf(val))
-        print("inf\n");
+        OIIO::print("inf\n");
     else
-        print("{:g}\n", val);
+        OIIO::print("{:g}\n", val);
 }
 
 
@@ -158,15 +157,15 @@ inline void
 print_subimage(ImageBuf& img0, int subimage, int miplevel)
 {
     if (img0.nsubimages() > 1)
-        print("Subimage {} ", subimage);
+        OIIO::print("Subimage {} ", subimage);
     if (img0.nmiplevels() > 1)
-        print(" MIP level {} ", miplevel);
+        OIIO::print(" MIP level {} ", miplevel);
     if (img0.nsubimages() > 1 || img0.nmiplevels() > 1)
-        print(": ");
-    print("{} x {}", img0.spec().width, img0.spec().height);
+        OIIO::print(": ");
+    OIIO::print("{} x {}", img0.spec().width, img0.spec().height);
     if (img0.spec().depth > 1)
-        print(" x {}", img0.spec().depth);
-    print(", {} channels\n", img0.spec().nchannels);
+        OIIO::print(" x {}", img0.spec().depth);
+    OIIO::print(", {} channels\n", img0.spec().nchannels);
 }
 
 
@@ -203,8 +202,8 @@ main(int argc, char* argv[])
     if (filenames.size() == 2) {
         add_filename_to_directory(filenames[0], filenames[1]);
     } else {
-        print(stderr, "idiff: Must have two input filenames.\n");
-        print(stderr, "> {}\n", Strutil::join(filenames, ", "));
+        OIIO::print(stderr, "idiff: Must have two input filenames.\n");
+        OIIO::print(stderr, "> {}\n", Strutil::join(filenames, ", "));
         ap.usage();
         return EXIT_FAILURE;
     }
@@ -227,7 +226,8 @@ main(int argc, char* argv[])
     int allowfailures     = ap["allowfailures"].get<int>();
 
     if (!quiet) {
-        print("Comparing \"{}\" and \"{}\"\n", filenames[0], filenames[1]);
+        OIIO::print("Comparing \"{}\" and \"{}\"\n", filenames[0],
+                    filenames[1]);
         fflush(stdout);
     }
 
@@ -259,21 +259,23 @@ main(int argc, char* argv[])
 
         if (!read_input(filenames[0], img0, imagecache, subimage)
             || !read_input(filenames[1], img1, imagecache, subimage)) {
-            print(stderr, "Failed to read subimage {}\n", subimage);
+            OIIO::print(stderr, "Failed to read subimage {}\n", subimage);
             return ErrFile;
         }
 
         if (img0.nmiplevels() != img1.nmiplevels()) {
             if (!quiet)
-                print("Files do not match in their number of MIPmap levels\n");
+                OIIO::print(
+                    "Files do not match in their number of MIPmap levels\n");
         }
 
         for (int m = 0; m < img0.nmiplevels(); ++m) {
             if (m > 0 && !compareall)
                 break;
             if (m > 0 && img0.nmiplevels() != img1.nmiplevels()) {
-                print(stderr,
-                      "Files do not match in their number of MIPmap levels\n");
+                OIIO::print(
+                    stderr,
+                    "Files do not match in their number of MIPmap levels\n");
                 ret = ErrDifferentSize;
                 break;
             }
@@ -283,8 +285,9 @@ main(int argc, char* argv[])
                 return ErrFile;
 
             if (img0.deep() != img1.deep()) {
-                print(stderr,
-                      "One image contains deep data, the other does not\n");
+                OIIO::print(
+                    stderr,
+                    "One image contains deep data, the other does not\n");
                 ret = ErrDifferentSize;
                 break;
             }
@@ -324,50 +327,51 @@ main(int argc, char* argv[])
             if (verbose || (ret != ErrOK && !quiet)) {
                 if (compareall)
                     print_subimage(img0, subimage, m);
-                print("  Mean error = ");
+                OIIO::print("  Mean error = ");
                 safe_double_print(cr.meanerror);
-                print("  RMS error = ");
+                OIIO::print("  RMS error = ");
                 safe_double_print(cr.rms_error);
-                print("  Peak SNR = ");
+                OIIO::print("  Peak SNR = ");
                 safe_double_print(cr.PSNR);
-                print("  Max error  = {:g}", cr.maxerror);
+                OIIO::print("  Max error  = {:g}", cr.maxerror);
                 if (cr.maxerror != 0) {
-                    print(" @ ({}, {}", cr.maxx, cr.maxy);
+                    OIIO::print(" @ ({}, {}", cr.maxx, cr.maxy);
                     if (img0.spec().depth > 1)
-                        print(", {}", cr.maxz);
+                        OIIO::print(", {}", cr.maxz);
                     if (cr.maxc < (int)img0.spec().channelnames.size())
-                        print(", {})", img0.spec().channelnames[cr.maxc]);
+                        OIIO::print(", {})", img0.spec().channelnames[cr.maxc]);
                     else if (cr.maxc < (int)img1.spec().channelnames.size())
-                        print(", {})", img1.spec().channelnames[cr.maxc]);
+                        OIIO::print(", {})", img1.spec().channelnames[cr.maxc]);
                     else
-                        print(", channel {})", cr.maxc);
+                        OIIO::print(", channel {})", cr.maxc);
                     if (!img0.deep()) {
-                        print("  values are ");
+                        OIIO::print("  values are ");
                         for (int c = 0; c < img0.spec().nchannels; ++c)
-                            print("{}{}", (c ? ", " : ""),
-                                  img0.getchannel(cr.maxx, cr.maxy, 0, c));
+                            OIIO::print("{}{}", (c ? ", " : ""),
+                                        img0.getchannel(cr.maxx, cr.maxy, 0, c));
                         ;
-                        print(" vs ");
+                        OIIO::print(" vs ");
                         for (int c = 0; c < img1.spec().nchannels; ++c)
-                            print("{}{}", (c ? ", " : ""),
-                                  img1.getchannel(cr.maxx, cr.maxy, 0, c));
+                            OIIO::print("{}{}", (c ? ", " : ""),
+                                        img1.getchannel(cr.maxx, cr.maxy, 0, c));
                         ;
                     }
                 }
-                print("\n");
+                OIIO::print("\n");
 #if OIIO_MSVS_BEFORE_2015
                 // When older Visual Studio is used, float values in
                 // scientific format are printed with three digit exponent.
                 // We change this behaviour to fit Linux way.
                 _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
-                print("  {} pixels ({:1.3g}%) over {}\n", cr.nwarn,
-                      (100.0 * cr.nwarn / npels), warnthresh);
-                print("  {} pixels ({:1.3g}%) over {}\n", cr.nfail,
-                      (100.0 * cr.nfail / npels), failthresh);
+                OIIO::print("  {} pixels ({:1.3g}%) over {}\n", cr.nwarn,
+                            (100.0 * cr.nwarn / npels), warnthresh);
+                OIIO::print("  {} pixels ({:1.3g}%) over {}\n", cr.nfail,
+                            (100.0 * cr.nfail / npels), failthresh);
                 if (perceptual)
-                    print("  {} pixels ({:3g}%) failed the perceptual test\n",
-                          yee_failures, (100.0 * yee_failures / npels));
+                    OIIO::print(
+                        "  {} pixels ({:3g}%) failed the perceptual test\n",
+                        yee_failures, (100.0 * yee_failures / npels));
             }
 
             // If the user requested that a difference image be output,
@@ -393,29 +397,29 @@ main(int argc, char* argv[])
 
     if (compareall && img0.nsubimages() != img1.nsubimages()) {
         if (!quiet)
-            print(stderr,
-                  "Images had differing numbers of subimages ({} vs {})\n",
-                  img0.nsubimages(), img1.nsubimages());
+            OIIO::print(stderr,
+                        "Images had differing numbers of subimages ({} vs {})\n",
+                        img0.nsubimages(), img1.nsubimages());
         ret = ErrFail;
     }
     if (!compareall && (img0.nsubimages() > 1 || img1.nsubimages() > 1)) {
         if (!quiet)
-            print(
+            OIIO::print(
                 "Only compared the first subimage (of {} and {}, respectively)\n",
                 img0.nsubimages(), img1.nsubimages());
     }
 
     if (ret == ErrOK) {
         if (!quiet)
-            print("PASS\n");
+            OIIO::print("PASS\n");
     } else if (ret == ErrWarn) {
         if (!quiet)
-            print("WARNING\n");
+            OIIO::print("WARNING\n");
     } else if (ret) {
         if (quiet)
-            print(stderr, "FAILURE\n");
+            OIIO::print(stderr, "FAILURE\n");
         else
-            print("FAILURE\n");
+            OIIO::print("FAILURE\n");
     }
 
     imagecache->invalidate_all(true);

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -39,8 +39,6 @@ static bool subimages     = false;
 static bool compute_sha1  = false;
 static bool compute_stats = false;
 
-using OIIO::print;
-
 
 
 static void
@@ -48,7 +46,7 @@ print_sha1(ImageInput* input, int subimage, int miplevel)
 {
     std::string err;
     std::string s1 = pvt::compute_sha1(input, subimage, miplevel, err);
-    print("    SHA-1: {}\n", err.size() ? err : s1);
+    OIIO::print("    SHA-1: {}\n", err.size() ? err : s1);
 }
 
 
@@ -84,7 +82,7 @@ print_stats(const std::string& filename, const ImageSpec& originalspec,
 
     std::string err;
     if (!pvt::print_stats(std::cout, indent, input, originalspec, ROI(), err)) {
-        print("{}Stats: (unable to compute)\n", indent);
+        OIIO::print("{}Stats: (unable to compute)\n", indent);
         if (err.size())
             std::cerr << "Error: " << err << "\n";
         return;
@@ -100,30 +98,30 @@ print_metadata(const ImageSpec& spec, const std::string& filename)
     if (metamatch.empty() || std::regex_search("channels", field_re)
         || std::regex_search("channel list", field_re)) {
         if (filenameprefix)
-            print("{} : ", filename);
-        print("    channel list: ");
+            OIIO::print("{} : ", filename);
+        OIIO::print("    channel list: ");
         for (int i = 0; i < spec.nchannels; ++i) {
             if (i < (int)spec.channelnames.size())
-                print("{}", spec.channelnames[i]);
+                OIIO::print("{}", spec.channelnames[i]);
             else
-                print("unknown");
+                OIIO::print("unknown");
             if (i < (int)spec.channelformats.size())
-                print(" ({})", spec.channelformats[i]);
+                OIIO::print(" ({})", spec.channelformats[i]);
             if (i < spec.nchannels - 1)
-                print(", ");
+                OIIO::print(", ");
         }
-        print("\n");
+        OIIO::print("\n");
         printed = true;
     }
     if (spec.x || spec.y || spec.z) {
         if (metamatch.empty()
             || std::regex_search("pixel data origin", field_re)) {
             if (filenameprefix)
-                print("{} : ", filename);
-            print("    pixel data origin: x={}, y={}", spec.x, spec.y);
+                OIIO::print("{} : ", filename);
+            OIIO::print("    pixel data origin: x={}, y={}", spec.x, spec.y);
             if (spec.depth > 1)
-                print(", z={}", spec.z);
-            print("\n");
+                OIIO::print(", z={}", spec.z);
+            OIIO::print("\n");
             printed = true;
         }
     }
@@ -134,33 +132,35 @@ print_metadata(const ImageSpec& spec, const std::string& filename)
         if (metamatch.empty()
             || std::regex_search("full/display size", field_re)) {
             if (filenameprefix)
-                print("{} : ", filename);
-            print("    full/display size: {} x {}", spec.full_width,
-                  spec.full_height);
+                OIIO::print("{} : ", filename);
+            OIIO::print("    full/display size: {} x {}", spec.full_width,
+                        spec.full_height);
             if (spec.depth > 1)
-                print(" x {}", spec.full_depth);
-            print("\n");
+                OIIO::print(" x {}", spec.full_depth);
+            OIIO::print("\n");
             printed = true;
         }
         if (metamatch.empty()
             || std::regex_search("full/display origin", field_re)) {
             if (filenameprefix)
-                print("{} : ", filename);
-            print("    full/display origin: {}, {}", spec.full_x, spec.full_y);
+                OIIO::print("{} : ", filename);
+            OIIO::print("    full/display origin: {}, {}", spec.full_x,
+                        spec.full_y);
             if (spec.depth > 1)
-                print(", {}", spec.full_z);
-            print("\n");
+                OIIO::print(", {}", spec.full_z);
+            OIIO::print("\n");
             printed = true;
         }
     }
     if (spec.tile_width) {
         if (metamatch.empty() || std::regex_search("tile", field_re)) {
             if (filenameprefix)
-                print("{} : ", filename);
-            print("    tile size: {} x {}", spec.tile_width, spec.tile_height);
+                OIIO::print("{} : ", filename);
+            OIIO::print("    tile size: {} x {}", spec.tile_width,
+                        spec.tile_height);
             if (spec.depth > 1)
-                print(" x {}", spec.tile_depth);
-            print("\n");
+                OIIO::print(" x {}", spec.tile_depth);
+            OIIO::print("\n");
             printed = true;
         }
     }
@@ -176,20 +176,20 @@ print_metadata(const ImageSpec& spec, const std::string& filename)
             continue;
         std::string s = spec.metadata_val(p, true);
         if (filenameprefix)
-            print("{} : ", filename);
-        print("    {}: ", p.name());
+            OIIO::print("{} : ", filename);
+        OIIO::print("    {}: ", p.name());
         if (s == "1.#INF")
-            print("inf");
+            OIIO::print("inf");
         else
-            print("{}", s);
-        print("\n");
+            OIIO::print("{}", s);
+        OIIO::print("\n");
         printed = true;
     }
 
     if (!printed && !metamatch.empty()) {
         if (filenameprefix)
-            print("{} : ", filename);
-        print("    {}: <unknown>\n", metamatch);
+            OIIO::print("{} : ", filename);
+        OIIO::print("    {}: <unknown>\n", metamatch);
     }
 }
 
@@ -260,34 +260,35 @@ print_info_subimage(int current_subimage, int max_subimages, ImageSpec& spec,
               || std::regex_search("resolution, width, height, depth, channels",
                                    field_re));
     if (printres && max_subimages > 1 && subimages) {
-        print(" subimage {:2}: ", current_subimage);
-        print("{:4} x {:4}", spec.width, spec.height);
+        OIIO::print(" subimage {:2}: ", current_subimage);
+        OIIO::print("{:4} x {:4}", spec.width, spec.height);
         if (spec.depth > 1)
-            print(" x {:4}", spec.depth);
+            OIIO::print(" x {:4}", spec.depth);
         int bits = spec.get_int_attribute("oiio:BitsPerSample", 0);
-        print(", {} channel, {}{}{}", spec.nchannels, spec.deep ? "deep " : "",
-              spec.depth > 1 ? "volume " : "",
-              extended_format_name(spec.format, bits));
-        print(" {}", input->format_name());
-        print("\n");
+        OIIO::print(", {} channel, {}{}{}", spec.nchannels,
+                    spec.deep ? "deep " : "", spec.depth > 1 ? "volume " : "",
+                    extended_format_name(spec.format, bits));
+        OIIO::print(" {}", input->format_name());
+        OIIO::print("\n");
     }
     // Count MIP levels
     while (input->seek_subimage(current_subimage, nmip)) {
         if (printres) {
             ImageSpec mipspec = input->spec_dimensions(current_subimage, nmip);
             if (nmip == 1)
-                print("    MIP-map levels: {}x{}", spec.width, spec.height);
-            print(" {}x{}", mipspec.width, mipspec.height);
+                OIIO::print("    MIP-map levels: {}x{}", spec.width,
+                            spec.height);
+            OIIO::print(" {}x{}", mipspec.width, mipspec.height);
         }
         ++nmip;
     }
     if (printres && nmip > 1)
-        print("\n");
+        OIIO::print("\n");
 
     if (compute_sha1
         && (metamatch.empty() || std::regex_search("sha-1", field_re))) {
         if (filenameprefix)
-            print("{} : ", filename);
+            OIIO::print("{} : ", filename);
         // Before sha-1, be sure to point back to the highest-res MIP level
         input->seek_subimage(current_subimage, 0);
         print_sha1(input, current_subimage, 0);
@@ -301,10 +302,10 @@ print_info_subimage(int current_subimage, int max_subimages, ImageSpec& spec,
         for (int m = 0; m < nmip; ++m) {
             ImageSpec mipspec = input->spec_dimensions(current_subimage, m);
             if (filenameprefix)
-                print("{} : ", filename);
+                OIIO::print("{} : ", filename);
             if (nmip > 1 && (subimages || m == 0)) {
-                print("    MIP {} of {} ({} x {}):\n", m, nmip, mipspec.width,
-                      mipspec.height);
+                OIIO::print("    MIP {} of {} ({} x {}):\n", m, nmip,
+                            mipspec.width, mipspec.height);
             }
             print_stats(filename, spec, current_subimage, m, nmip > 1);
         }
@@ -352,57 +353,58 @@ print_info(const std::string& filename, size_t namefieldlength,
     if (metamatch.empty()
         || std::regex_search("resolution, width, height, depth, channels",
                              field_re)) {
-        print("{}{} : {:4} x {:4}", filename, padding, spec.width, spec.height);
+        OIIO::print("{}{} : {:4} x {:4}", filename, padding, spec.width,
+                    spec.height);
         if (spec.depth > 1)
-            print(" x {:4}", spec.depth);
-        print(", {} channel, {}{}", spec.nchannels, spec.deep ? "deep " : "",
-              spec.depth > 1 ? "volume " : "");
+            OIIO::print(" x {:4}", spec.depth);
+        OIIO::print(", {} channel, {}{}", spec.nchannels,
+                    spec.deep ? "deep " : "", spec.depth > 1 ? "volume " : "");
         if (spec.channelformats.size()) {
             for (size_t c = 0; c < spec.channelformats.size(); ++c)
-                print("{}{}", c ? "/" : "", spec.channelformat(c));
+                OIIO::print("{}{}", c ? "/" : "", spec.channelformat(c));
         } else {
             int bits = spec.get_int_attribute("oiio:BitsPerSample", 0);
-            print("{}", extended_format_name(spec.format, bits));
+            OIIO::print("{}", extended_format_name(spec.format, bits));
         }
-        print(" {}", input->format_name());
+        OIIO::print(" {}", input->format_name());
         if (sum) {
             imagesize_t imagebytes = spec.image_bytes(true);
             totalsize += imagebytes;
-            print(" ({:.2f} MB)", (float)imagebytes / (1024.0 * 1024.0));
+            OIIO::print(" ({:.2f} MB)", (float)imagebytes / (1024.0 * 1024.0));
         }
         // we print info about how many subimages are stored in file
         // only when we have more then one subimage
         if (!verbose && num_of_subimages != 1)
-            print(" ({} subimages{})", num_of_subimages,
-                  any_mipmapping ? " +mipmap)" : "");
+            OIIO::print(" ({} subimages{})", num_of_subimages,
+                        any_mipmapping ? " +mipmap)" : "");
         if (!verbose && num_of_subimages == 1 && any_mipmapping)
-            print(" (+mipmap)");
-        print("\n");
+            OIIO::print(" (+mipmap)");
+        OIIO::print("\n");
     }
 
     int movie = spec.get_int_attribute("oiio:Movie");
     if (verbose && num_of_subimages != 1) {
         // info about num of subimages and their resolutions
-        print("    {} subimages: ", num_of_subimages);
+        OIIO::print("    {} subimages: ", num_of_subimages);
         for (int i = 0; i < num_of_subimages; ++i) {
             spec     = input->spec(i, 0);
             int bits = spec.get_int_attribute("oiio:BitsPerSample",
                                               spec.format.size() * 8);
             if (i)
-                print(", ");
+                OIIO::print(", ");
             if (spec.depth > 1)
-                print("{}x{}x{} ", spec.width, spec.height, spec.depth);
+                OIIO::print("{}x{}x{} ", spec.width, spec.height, spec.depth);
             else
-                print("{}x{} ", spec.width, spec.height);
-            // print("[");
+                OIIO::print("{}x{} ", spec.width, spec.height);
+            // OIIO::print("[");
             for (int c = 0; c < spec.nchannels; ++c)
-                print("{:c}{}", c ? ',' : '[',
-                      brief_format_name(spec.channelformat(c), bits));
-            print("]");
+                OIIO::print("{:c}{}", c ? ',' : '[',
+                            brief_format_name(spec.channelformat(c), bits));
+            OIIO::print("]");
             if (movie)
                 break;
         }
-        print("\n");
+        OIIO::print("\n");
     }
 
     // if the '-a' flag is not set we print info
@@ -472,8 +474,8 @@ main(int argc, const char* argv[])
         auto in = ImageInput::open(s);
         if (!in) {
             std::string err = geterror();
-            print(std::cerr, "iinfo ERROR: \"{}\" : {}\n", s,
-                  err.size() ? err : std::string("Could not open file."));
+            OIIO::print(std::cerr, "iinfo ERROR: \"{}\" : {}\n", s,
+                        err.size() ? err : std::string("Could not open file."));
             returncode = EXIT_FAILURE;
             continue;
         }
@@ -482,7 +484,7 @@ main(int argc, const char* argv[])
     }
 
     if (sum)
-        print("Total size: {}\n", Strutil::memformat(totalsize));
+        OIIO::print("Total size: {}\n", Strutil::memformat(totalsize));
 
     shutdown();
     return returncode;

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -139,6 +139,7 @@
 #endif
 
 // Tests for MSVS versions, always 0 if not MSVS at all.
+// https://learn.microsoft.com/en-us/cpp/overview/compiler-versions
 #if defined(_MSC_VER)
 #  define OIIO_MSVS_VERSION       _MSC_VER
 #  define OIIO_MSVS_AT_LEAST_2013 (_MSC_VER >= 1800)
@@ -186,12 +187,18 @@
 // package is compiling against OIIO and using these headers (OIIO may be
 // C++17 but the client package may be newer, or vice versa -- use these two
 // symbols to differentiate these cases, when important).
-#if (__cplusplus >= 202001L)
+#if (__cplusplus >= 202302L)
+#    define OIIO_CPLUSPLUS_VERSION 23
+#    define OIIO_CONSTEXPR20 constexpr
+#    define OIIO_CONSTEXPR23 constexpr
+#elif (__cplusplus >= 202001L)
 #    define OIIO_CPLUSPLUS_VERSION 20
 #    define OIIO_CONSTEXPR20 constexpr
+#    define OIIO_CONSTEXPR23 /* not constexpr before C++23 */
 #elif (__cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER >= 1914)
 #    define OIIO_CPLUSPLUS_VERSION 17
 #    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
+#    define OIIO_CONSTEXPR23 /* not constexpr before C++23 */
 #else
 #    error "This version of OIIO is meant to work only with C++17 and above"
 #endif

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -247,26 +247,26 @@ print_dir_entry(std::ostream& out, const TagMap& tagmap,
         return false;  // bogus! overruns the buffer
     mydata += offset_adjustment;
     const char* name = tagmap.name(dir.tdir_tag);
-    print(out,
-          "  Tag {}/0x{} ({}) type={} ({}) count={} offset={} = ", dir.tdir_tag,
-          dir.tdir_tag, (name ? name : "unknown"), dir.tdir_type,
-          tiff_datatype_to_typedesc(dir), dir.tdir_count, dir.tdir_offset);
+    OIIO::print(out, "  Tag {}/0x{} ({}) type={} ({}) count={} offset={} = ",
+                dir.tdir_tag, dir.tdir_tag, (name ? name : "unknown"),
+                dir.tdir_type, tiff_datatype_to_typedesc(dir), dir.tdir_count,
+                dir.tdir_offset);
 
     switch (dir.tdir_type) {
     case TIFF_ASCII:
-        print(out, "'{}'", string_view(mydata, dir.tdir_count));
+        OIIO::print(out, "'{}'", string_view(mydata, dir.tdir_count));
         break;
     case TIFF_RATIONAL: {
         const unsigned int* u = (unsigned int*)mydata;
         for (size_t i = 0; i < dir.tdir_count; ++i)
-            print(out, "{}/{} = {} ", u[2 * i], << u[2 * i + 1],
-                  (double)u[2 * i] / (double)u[2 * i + 1]);
+            OIIO::print(out, "{}/{} = {} ", u[2 * i], << u[2 * i + 1],
+                        (double)u[2 * i] / (double)u[2 * i + 1]);
     } break;
     case TIFF_SRATIONAL: {
         const int* u = (int*)mydata;
         for (size_t i = 0; i < dir.tdir_count; ++i)
-            print(out, "{}/{} = {} ", u[2 * i], u[2 * i + 1],
-                  (double)u[2 * i] / (double)u[2 * i + 1]);
+            OIIO::print(out, "{}/{} = {} ", u[2 * i], u[2 * i + 1],
+                        (double)u[2 * i] / (double)u[2 * i + 1]);
     } break;
     case TIFF_SHORT: out << ((unsigned short*)mydata)[0]; break;
     case TIFF_LONG: out << ((unsigned int*)mydata)[0]; break;
@@ -276,14 +276,15 @@ print_dir_entry(std::ostream& out, const TagMap& tagmap,
     default:
         if (len <= 4 && dir.tdir_count > 4) {
             // Request more data than is stored.
-            print(out, "Ignoring buffer with too much count of short data.\n");
+            OIIO::print(out,
+                        "Ignoring buffer with too much count of short data.\n");
             return false;
         }
         for (size_t i = 0; i < dir.tdir_count; ++i)
-            print(out, "{} ", (int)((unsigned char*)mydata)[i]);
+            OIIO::print(out, "{} ", (int)((unsigned char*)mydata)[i]);
         break;
     }
-    print(out, "\n");
+    OIIO::print(out, "\n");
     return true;
 }
 
@@ -299,11 +300,12 @@ dumpdata(cspan<uint8_t> blob, cspan<size_t> ifdoffsets, size_t start,
         bool at_ifd = (std::find(ifdoffsets.cbegin(), ifdoffsets.cend(), pos)
                        != ifdoffsets.end());
         if (pos == 0 || pos == start || at_ifd || (pos % 10) == 0) {
-            print(out, "\n@{}: ", pos);
+            OIIO::print(out, "\n@{}: ", pos);
             if (at_ifd) {
                 uint16_t n = *(uint16_t*)&blob[pos];
-                print(out, "\nNew IFD: {} tags:  [offset_adjustment={}]\n", n,
-                      offset_adjustment);
+                OIIO::print(out,
+                            "\nNew IFD: {} tags:  [offset_adjustment={}]\n", n,
+                            offset_adjustment);
                 TIFFDirEntry* td = (TIFFDirEntry*)&blob[pos + 2];
                 for (int i = 0; i < n; ++i, ++td)
                     print_dir_entry(out, tiff_tagmap_ref(), *td, blob,
@@ -312,10 +314,10 @@ dumpdata(cspan<uint8_t> blob, cspan<size_t> ifdoffsets, size_t start,
         }
         unsigned char c = (unsigned char)blob[pos];
         if (c >= ' ' && c < 127)
-            print(out, "{:c} ", c);
-        print(out, "({:d}) ", int(c));
+            OIIO::print(out, "{:c} ", c);
+        OIIO::print(out, "({:d}) ", int(c));
     }
-    print(out, "\n");
+    OIIO::print(out, "\n");
     return out.str();
 }
 #endif
@@ -924,7 +926,7 @@ read_exif_tag(ImageSpec& spec, const TIFFDirEntry* dirp, cspan<uint8_t> buf,
                                       offset_adjustment);
         } else {
 #if DEBUG_EXIF_READ || DEBUG_EXIF_UNHANDLED
-            print(
+            OIIO::print(
                 stderr,
                 "read_exif_tag: Unhandled {} tag={} (0x{:x}), type={} count={} ({}), offset={}\n",
                 tagmap.mapname(), dir.tdir_tag, dir.tdir_tag, dir.tdir_type,

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1093,50 +1093,50 @@ ImageSpec::serialize(SerialFormat fmt, SerialVerbose verbose) const
     std::stringstream out;
 
     if (depth > 1)
-        print(out, "{:4} x {:4} x {:4}", width, height, depth);
+        OIIO::print(out, "{:4} x {:4} x {:4}", width, height, depth);
     else
-        print(out, "{:4} x {:4}", width, height);
-    print(out, ", {} channel, {}{}", nchannels, deep ? "deep " : "",
-          depth > 1 ? "volume " : "");
+        OIIO::print(out, "{:4} x {:4}", width, height);
+    OIIO::print(out, ", {} channel, {}{}", nchannels, deep ? "deep " : "",
+                depth > 1 ? "volume " : "");
     if (channelformats.size()) {
         for (size_t c = 0; c < channelformats.size(); ++c)
-            print(out, "{}{}", c ? "/" : "", channelformats[c]);
+            OIIO::print(out, "{}{}", c ? "/" : "", channelformats[c]);
     } else {
         int bits = get_int_attribute("oiio:BitsPerSample", 0);
-        print(out, "{}", extended_format_name(this->format, bits));
+        OIIO::print(out, "{}", extended_format_name(this->format, bits));
     }
-    print(out, "\n");
+    OIIO::print(out, "\n");
 
     if (verbose >= SerialDetailed) {
-        print(out, "    channel list: ");
+        OIIO::print(out, "    channel list: ");
         for (int i = 0; i < nchannels; ++i) {
             if (i < (int)channelnames.size())
-                print(out, "{}", channelnames[i]);
+                OIIO::print(out, "{}", channelnames[i]);
             else
-                print(out, "unknown");
+                OIIO::print(out, "unknown");
             if (i < (int)channelformats.size())
-                print(out, " ({})", channelformats[i]);
+                OIIO::print(out, " ({})", channelformats[i]);
             if (i < nchannels - 1)
-                print(out, ", ");
+                OIIO::print(out, ", ");
         }
-        print(out, "\n");
+        OIIO::print(out, "\n");
         if (x || y || z) {
-            print(out, "    pixel data origin: {}\n",
-                  ((depth > 1) ? format("x={}, y={}, z={}", x, y, z)
-                               : format("x={}, y={}", x, y)));
+            OIIO::print(out, "    pixel data origin: {}\n",
+                        ((depth > 1) ? format("x={}, y={}, z={}", x, y, z)
+                                     : format("x={}, y={}", x, y)));
         }
         if (full_x || full_y || full_z
             || (full_width != width && full_width != 0)
             || (full_height != height && full_height != 0)
             || (full_depth != depth && full_depth != 0)) {
-            print(out, "    full/display size: {}\n",
-                  format_res(*this, full_width, full_height, full_depth));
-            print(out, "    full/display origin: {}\n",
-                  format_offset(*this, full_x, full_y, full_z));
+            OIIO::print(out, "    full/display size: {}\n",
+                        format_res(*this, full_width, full_height, full_depth));
+            OIIO::print(out, "    full/display origin: {}\n",
+                        format_offset(*this, full_x, full_y, full_z));
         }
         if (tile_width) {
-            print(out, "    tile size: {}\n",
-                  format_res(*this, tile_width, tile_height, tile_depth));
+            OIIO::print(out, "    tile size: {}\n",
+                        format_res(*this, tile_width, tile_height, tile_depth));
         }
 
         // Sort the metadata alphabetically, case-insensitive, but making
@@ -1146,11 +1146,11 @@ ImageSpec::serialize(SerialFormat fmt, SerialVerbose verbose) const
         attribs.sort(false /* sort case-insensitively */);
 
         for (auto&& p : attribs) {
-            print(out, "    {}: ", p.name());
+            OIIO::print(out, "    {}: ", p.name());
             std::string s = metadata_val(p, verbose == SerialDetailedHuman);
             if (s == "1.#INF")
                 s = "inf";
-            print(out, "{}\n", s);
+            OIIO::print(out, "{}\n", s);
         }
     }
 

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1037,10 +1037,10 @@ void
 benchmark_parallel_image(int res, int iters)
 {
     using namespace ImageBufAlgo;
-    print("\nTime old parallel_image for {}x{}\n", res, res);
+    OIIO::print("\nTime old parallel_image for {}x{}\n", res, res);
 
-    print("  threads time    rate   (best of {})\n", ntrials);
-    print("  ------- ------- -------\n");
+    OIIO::print("  threads time    rate   (best of {})\n", ntrials);
+    OIIO::print("  ------- ------- -------\n");
     ImageSpec spec(res, res, 3, TypeDesc::FLOAT);
     ImageBuf X(spec), Y(spec);
     ImageBufAlgo::zero(Y);
@@ -1064,16 +1064,16 @@ benchmark_parallel_image(int res, int iters)
         };
         double range;
         double t = time_trial(func, ntrials, iters, &range) / iters;
-        print("  {:4}   {:7.3f} ms  {:5.1f} Mpels/s\n", nt, t * 1000,
-              double(res * res) / t / 1.0e6);
+        OIIO::print("  {:4}   {:7.3f} ms  {:5.1f} Mpels/s\n", nt, t * 1000,
+                    double(res * res) / t / 1.0e6);
         if (!wedge)
             break;  // don't loop if we're not wedging
     }
 
-    print("\nTime new parallel_image for {}x{}\n", res, res);
+    OIIO::print("\nTime new parallel_image for {}x{}\n", res, res);
 
-    print("  threads time    rate   (best of {})\n", ntrials);
-    print("  ------- ------- -------\n");
+    OIIO::print("  threads time    rate   (best of {})\n", ntrials);
+    OIIO::print("  ------- ------- -------\n");
     for (int i = 0; threadcounts[i] <= numthreads; ++i) {
         int nt = wedge ? threadcounts[i] : numthreads;
         // default_thread_pool()->resize (nt);
@@ -1081,8 +1081,8 @@ benchmark_parallel_image(int res, int iters)
         auto func = [&]() { parallel_image(Y.roi(), nt, exercise); };
         double range;
         double t = time_trial(func, ntrials, iters, &range) / iters;
-        print("  {:4}   {:6.2f} ms  {:5.1f} Mpels/s\n", nt, t * 1000,
-              double(res * res) / t / 1.0e6);
+        OIIO::print("  {:4}   {:6.2f} ms  {:5.1f} Mpels/s\n", nt, t * 1000,
+                    double(res * res) / t / 1.0e6);
         if (!wedge)
             break;  // don't loop if we're not wedging
     }
@@ -1176,7 +1176,7 @@ test_color_management()
 static void
 test_yee()
 {
-    print("Testing Yee comparison\n");
+    OIIO::print("Testing Yee comparison\n");
     ImageSpec spec(1, 1, 3, TypeDesc::FLOAT);
     ImageBuf img1(spec);
     ImageBufAlgo::fill(img1, { 0.1f, 0.1f, 0.1f });
@@ -1219,9 +1219,9 @@ static void
 test_simple_perpixel()
 {
     TypeDesc td = TypeDescFromC<T>::value();
-    print("test_simple_perpixel {}\n", td);
+    OIIO::print("test_simple_perpixel {}\n", td);
     {
-        print("  unary op\n");
+        OIIO::print("  unary op\n");
         ImageBuf src = filled_image({ 0.25f, 0.5f, 0.75f, 1.0f }, 4, 4, td);
         ImageBuf result;
         // Test with raw function pointer
@@ -1259,7 +1259,7 @@ test_simple_perpixel()
         }
     }
     {
-        print("  binary op\n");
+        OIIO::print("  binary op\n");
         ImageBuf srcA   = filled_image({ 0.25f, 0.5f, 0.75f, 1.0f }, 4, 4, td);
         ImageBuf srcB   = filled_image({ 1.0f, 2.0f, 3.0f, 4.0f }, 4, 4, td);
         ImageBuf result = ImageBufAlgo::perpixel_op(
@@ -1475,7 +1475,7 @@ test_demosaic(const DemosaicTestConfig& config, const ImageBuf& src_image,
 static void
 test_demosaic()
 {
-    print("Testing Demosaicing\n");
+    OIIO::print("Testing Demosaicing\n");
 
     ImageSpec src_spec(256, 256, 3, TypeDesc::FLOAT);
     ImageBuf src_image(src_spec);

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -118,9 +118,10 @@ public:
             double time         = item.second.first;
             double percall      = time / ncalls;
             bool use_ms_percall = (percall < 0.1);
-            print(out, "{:25s}{:6d} {:7.3f}s  (avg {:6.2f}{})\n", item.first,
-                  ncalls, time, percall * (use_ms_percall ? 1000.0 : 1.0),
-                  use_ms_percall ? "ms" : "s");
+            OIIO::print(out, "{:25s}{:6d} {:7.3f}s  (avg {:6.2f}{})\n",
+                        item.first, ncalls, time,
+                        percall * (use_ms_percall ? 1000.0 : 1.0),
+                        use_ms_percall ? "ms" : "s");
         }
         return out.str();
     }

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -172,8 +172,8 @@ test_read(const std::string& explanation, void (*func)(), int autotile = 64,
     imagecache->attribute("autoscanline", autoscanline);
     double t    = time_trial(func, ntrials);
     double rate = double(total_image_pixels) / t;
-    print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
-          Strutil::timeintervalformat(t, 2), rate / 1.0e6);
+    OIIO::print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
+                Strutil::timeintervalformat(t, 2), rate / 1.0e6);
 }
 
 
@@ -297,8 +297,8 @@ test_write(const std::string& explanation, void (*func)(), int tilesize = 0)
     outspec.tile_depth  = 1;
     double t            = time_trial(func, ntrials);
     double rate         = double(total_image_pixels) / t;
-    print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
-          Strutil::timeintervalformat(t, 2), rate / 1.0e6);
+    OIIO::print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
+                Strutil::timeintervalformat(t, 2), rate / 1.0e6);
 }
 
 
@@ -444,8 +444,8 @@ test_pixel_iteration(const std::string& explanation,
     ib.read(0, 0, preload, TypeFloat);
     double t    = time_trial(std::bind(func, std::ref(ib), iters), ntrials);
     double rate = double(ib.spec().image_pixels()) / (t / iters);
-    print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
-          Strutil::timeintervalformat(t / iters, 3), rate / 1.0e6);
+    OIIO::print("  {}: {} = {:5.1f} Mpel/s\n", explanation,
+                Strutil::timeintervalformat(t / iters, 3), rate / 1.0e6);
 }
 
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -776,10 +776,10 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
 
     // Write out the image
     if (verbose) {
-        print(outstream, "  Writing file: {}\n", outputfilename);
-        print(outstream, "  Filter \"{}\"\n", filtername);
-        print(outstream, "  Top level is {}x{}\n", outspec.width,
-              outspec.height);
+        OIIO::print(outstream, "  Writing file: {}\n", outputfilename);
+        OIIO::print(outstream, "  Filter \"{}\"\n", filtername);
+        OIIO::print(outstream, "  Top level is {}x{}\n", outspec.width,
+                    outspec.height);
     }
 
     if (clamp_half) {
@@ -800,13 +800,14 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
     if (verbose) {
         size_t mem = Sysutil::memory_used(true);
         peak_mem   = std::max(peak_mem, mem);
-        print(outstream, "    {:15s} ({})  write {}\n", formatres(outspec),
-              Strutil::memformat(mem), Strutil::timeintervalformat(wtime, 2));
+        OIIO::print(outstream, "    {:15s} ({})  write {}\n",
+                    formatres(outspec), Strutil::memformat(mem),
+                    Strutil::timeintervalformat(wtime, 2));
     }
 
     if (mipmap) {  // Mipmap levels:
         if (verbose)
-            print(outstream, "  Mipmapping...\n");
+            OIIO::print(outstream, "  Mipmapping...\n");
         std::vector<std::string> mipimages;
         std::string mipimages_unsplit = configspec.get_string_attribute(
             "maketx:mipimages");
@@ -889,16 +890,16 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
                         return false;
                     }
                     if (verbose) {
-                        print(outstream,
-                              "  Downsampling filter \"{}\" width = {}",
-                              filter->name(), filter->width());
+                        OIIO::print(outstream,
+                                    "  Downsampling filter \"{}\" width = {}",
+                                    filter->name(), filter->width());
                         if (sharpen > 0.0f)
-                            print(
+                            OIIO::print(
                                 outstream,
                                 ", sharpening {} with {} unsharp mask {} the resize",
                                 sharpen, sharpenfilt,
                                 (sharpen_first ? "before" : "after"));
-                        print(outstream, "\n");
+                        OIIO::print(outstream, "\n");
                     }
                     if (do_highlight_compensation)
                         ImageBufAlgo::rangecompress(*img, *img);
@@ -965,18 +966,18 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
             if (verbose) {
                 size_t mem = Sysutil::memory_used(true);
                 peak_mem   = std::max(peak_mem, mem);
-                print(outstream, "    {:15s} ({})  downres {} write {}\n",
-                      formatres(smallspec), Strutil::memformat(mem),
-                      Strutil::timeintervalformat(this_miptime, 2),
-                      Strutil::timeintervalformat(wtime, 2));
+                OIIO::print(outstream, "    {:15s} ({})  downres {} write {}\n",
+                            formatres(smallspec), Strutil::memformat(mem),
+                            Strutil::timeintervalformat(this_miptime, 2),
+                            Strutil::timeintervalformat(wtime, 2));
             }
             std::swap(img, small);
         }
     }
 
     if (verbose)
-        print(outstream, "  Wrote file: {}  ({})\n", outputfilename,
-              Strutil::memformat(Sysutil::memory_used(true)));
+        OIIO::print(outstream, "  Wrote file: {}  ({})\n", outputfilename,
+                    Strutil::memformat(Sysutil::memory_used(true)));
     writetimer.reset();
     writetimer.start();
     if (!out->close()) {
@@ -1073,14 +1074,14 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     size_t peak_mem              = 0;
     Timer alltime;
 
-#define STATUS(task, timer)                                \
-    {                                                      \
-        size_t mem = Sysutil::memory_used(true);           \
-        peak_mem   = std::max(peak_mem, mem);              \
-        if (verbose)                                       \
-            print(outstream, "  {:25s} {}   ({})\n", task, \
-                  Strutil::timeintervalformat(timer, 2),   \
-                  Strutil::memformat(mem));                \
+#define STATUS(task, timer)                                      \
+    {                                                            \
+        size_t mem = Sysutil::memory_used(true);                 \
+        peak_mem   = std::max(peak_mem, mem);                    \
+        if (verbose)                                             \
+            OIIO::print(outstream, "  {:25s} {}   ({})\n", task, \
+                        Strutil::timeintervalformat(timer, 2),   \
+                        Strutil::memformat(mem));                \
     }
 
     ImageSpec configspec = _configspec;
@@ -1457,7 +1458,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         && pixel_stats.avg[0] == pixel_stats.avg[2]
         && ImageBufAlgo::isMonochrome(*src)) {
         if (verbose)
-            print(
+            OIIO::print(
                 outstream,
                 "  Monochrome image detected. Converting to single channel texture.\n");
         std::shared_ptr<ImageBuf> newsrc(new ImageBuf(src->spec()));
@@ -1822,15 +1823,16 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     } else if (!do_resize) {
         // Need format conversion, but no resize -- just copy the pixels
         if (verbose)
-            print(outstream, "  Copying for format conversion from {} to {}\n",
-                  src->spec().format, dstspec.format);
+            OIIO::print(outstream,
+                        "  Copying for format conversion from {} to {}\n",
+                        src->spec().format, dstspec.format);
         toplevel.reset(new ImageBuf(dstspec));
         toplevel->copy_pixels(*src);
     } else {
         // Resize
         if (verbose)
-            print(outstream, "  Resizing image to {} x {}\n", dstspec.width,
-                  dstspec.height);
+            OIIO::print(outstream, "  Resizing image to {} x {}\n",
+                        dstspec.width, dstspec.height);
         string_view resize_filter(filtername);
         if (Strutil::istarts_with(resize_filter, "unsharp-"))
             resize_filter = "lanczos3";
@@ -2016,22 +2018,24 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     if (verbose || configspec.get_int_attribute("maketx:runstats")
         || configspec.get_int_attribute("maketx:stats")) {
         double all = alltime();
-        print(outstream, "maketx run time (seconds): {:5.2f}\n", all);
-        print(outstream, "  file read:       {:5.2f}\n", stat_readtime);
-        print(outstream, "  file write:      {:5.2f}\n", stat_writetime);
-        print(outstream, "  initial resize:  {:5.2f}\n", stat_resizetime);
-        print(outstream, "  hash:            {:5.2f}\n", stat_hashtime);
-        print(outstream, "  pixelstats:      {:5.2f}\n", stat_pixelstatstime);
-        print(outstream, "  mip computation: {:5.2f}\n", stat_miptime);
-        print(outstream, "  color convert:   {:5.2f}\n", stat_colorconverttime);
-        print(
+        OIIO::print(outstream, "maketx run time (seconds): {:5.2f}\n", all);
+        OIIO::print(outstream, "  file read:       {:5.2f}\n", stat_readtime);
+        OIIO::print(outstream, "  file write:      {:5.2f}\n", stat_writetime);
+        OIIO::print(outstream, "  initial resize:  {:5.2f}\n", stat_resizetime);
+        OIIO::print(outstream, "  hash:            {:5.2f}\n", stat_hashtime);
+        OIIO::print(outstream, "  pixelstats:      {:5.2f}\n",
+                    stat_pixelstatstime);
+        OIIO::print(outstream, "  mip computation: {:5.2f}\n", stat_miptime);
+        OIIO::print(outstream, "  color convert:   {:5.2f}\n",
+                    stat_colorconverttime);
+        OIIO::print(
             outstream,
             "  unaccounted:     {:5.2f}  ({:5.2f} {:5.2f} {:5.2f} {:5.2f} {:5.2f})\n",
             all - stat_readtime - stat_writetime - stat_resizetime
                 - stat_hashtime - stat_miptime,
             misc_time_1, misc_time_2, misc_time_3, misc_time_4, misc_time_5);
-        print(outstream, "maketx peak memory used: {}\n",
-              Strutil::memformat(peak_mem));
+        OIIO::print(outstream, "maketx peak memory used: {}\n",
+                    Strutil::memformat(peak_mem));
     }
 
 #undef STATUS

--- a/src/libOpenImageIO/printinfo.cpp
+++ b/src/libOpenImageIO/printinfo.cpp
@@ -152,47 +152,47 @@ print_stats_summary(std::ostream& out, string_view indent,
 {
     unsigned int maxval = (unsigned int)get_intsample_maxval(spec);
 
-    print(out, "{}Stats Min: ", indent);
+    OIIO::print(out, "{}Stats Min: ", indent);
     for (unsigned int i = 0; i < stats.min.size(); ++i) {
         Strutil::print(out, "{} ", stats_num(stats.min[i], maxval, true));
     }
     Strutil::print(out, "{}\n", stats_footer(maxval));
 
-    print(out, "{}Stats Max: ", indent);
+    OIIO::print(out, "{}Stats Max: ", indent);
     for (unsigned int i = 0; i < stats.max.size(); ++i) {
         Strutil::print(out, "{} ", stats_num(stats.max[i], maxval, true));
     }
-    print(out, "{}\n", stats_footer(maxval));
+    OIIO::print(out, "{}\n", stats_footer(maxval));
 
-    print(out, "{}Stats Avg: ", indent);
+    OIIO::print(out, "{}Stats Avg: ", indent);
     for (unsigned int i = 0; i < stats.avg.size(); ++i) {
-        print(out, "{} ", stats_num(stats.avg[i], maxval, false));
+        OIIO::print(out, "{} ", stats_num(stats.avg[i], maxval, false));
     }
-    print(out, "{}\n", stats_footer(maxval));
+    OIIO::print(out, "{}\n", stats_footer(maxval));
 
-    print(out, "{}Stats StdDev: ", indent);
+    OIIO::print(out, "{}Stats StdDev: ", indent);
     for (unsigned int i = 0; i < stats.stddev.size(); ++i) {
-        print(out, "{} ", stats_num(stats.stddev[i], maxval, false));
+        OIIO::print(out, "{} ", stats_num(stats.stddev[i], maxval, false));
     }
-    print(out, "{}\n", stats_footer(maxval));
+    OIIO::print(out, "{}\n", stats_footer(maxval));
 
-    print(out, "{}Stats NanCount: ", indent);
+    OIIO::print(out, "{}Stats NanCount: ", indent);
     for (unsigned int i = 0; i < stats.nancount.size(); ++i) {
-        print(out, "{} ", (unsigned long long)stats.nancount[i]);
+        OIIO::print(out, "{} ", (unsigned long long)stats.nancount[i]);
     }
-    print(out, "\n");
+    OIIO::print(out, "\n");
 
-    print(out, "{}Stats InfCount: ", indent);
+    OIIO::print(out, "{}Stats InfCount: ", indent);
     for (unsigned int i = 0; i < stats.infcount.size(); ++i) {
-        print(out, "{} ", (unsigned long long)stats.infcount[i]);
+        OIIO::print(out, "{} ", (unsigned long long)stats.infcount[i]);
     }
-    print(out, "\n");
+    OIIO::print(out, "\n");
 
-    print(out, "{}Stats FiniteCount: ", indent);
+    OIIO::print(out, "{}Stats FiniteCount: ", indent);
     for (unsigned int i = 0; i < stats.finitecount.size(); ++i) {
-        print(out, "{} ", (unsigned long long)stats.finitecount[i]);
+        OIIO::print(out, "{} ", (unsigned long long)stats.finitecount[i]);
     }
-    print(out, "\n");
+    OIIO::print(out, "\n");
 }
 
 
@@ -267,20 +267,23 @@ print_deep_stats(std::ostream& out, string_view indent, const ImageBuf& input,
             }
         }
     }
-    print(out, "{}Min deep samples in any pixel : {}\n", indent, minsamples);
-    print(out, "{}Max deep samples in any pixel : {}\n", indent, maxsamples);
-    print(out,
-          "{}{} pixel{} had the max of {} samples, including (x={}, y={})\n",
-          indent, maxsamples_npixels, maxsamples_npixels > 1 ? "s" : "",
-          maxsamples, maxsamples_pixel.x, maxsamples_pixel.y);
-    print(out, "{}Average deep samples per pixel: {:.2f}\n", indent,
-          double(totalsamples) / double(npixels));
-    print(out, "{}Total deep samples in all pixels: {}\n", indent,
-          totalsamples);
-    print(out, "{}Pixels with deep samples   : {}\n", indent,
-          (npixels - emptypixels));
-    print(out, "{}Pixels with no deep samples: {}\n", indent, emptypixels);
-    print(out, "{}Samples/pixel histogram:\n", indent);
+    OIIO::print(out, "{}Min deep samples in any pixel : {}\n", indent,
+                minsamples);
+    OIIO::print(out, "{}Max deep samples in any pixel : {}\n", indent,
+                maxsamples);
+    OIIO::print(
+        out, "{}{} pixel{} had the max of {} samples, including (x={}, y={})\n",
+        indent, maxsamples_npixels, maxsamples_npixels > 1 ? "s" : "",
+        maxsamples, maxsamples_pixel.x, maxsamples_pixel.y);
+    OIIO::print(out, "{}Average deep samples per pixel: {:.2f}\n", indent,
+                double(totalsamples) / double(npixels));
+    OIIO::print(out, "{}Total deep samples in all pixels: {}\n", indent,
+                totalsamples);
+    OIIO::print(out, "{}Pixels with deep samples   : {}\n", indent,
+                (npixels - emptypixels));
+    OIIO::print(out, "{}Pixels with no deep samples: {}\n", indent,
+                emptypixels);
+    OIIO::print(out, "{}Samples/pixel histogram:\n", indent);
     size_t grandtotal = 0;
     for (size_t i = 0, e = nsamples_histogram.size(); i < e; ++i)
         grandtotal += nsamples_histogram[i];
@@ -290,23 +293,23 @@ print_deep_stats(std::ostream& out, string_view indent, const ImageBuf& input,
         if (i < 8 || i == (e - 1) || OIIO::ispow2(i + 1)) {
             // batch by powers of 2, unless it's a small number
             if (i == binstart)
-                print(out, "{}  {:3}    ", indent, i);
+                OIIO::print(out, "{}  {:3}    ", indent, i);
             else
-                print(out, "{}  {:3}-{:3}", indent, binstart, i);
-            print(out, " : {:8} ({:4.1f}%)\n", bintotal,
-                  (100.0 * bintotal) / grandtotal);
+                OIIO::print(out, "{}  {:3}-{:3}", indent, binstart, i);
+            OIIO::print(out, " : {:8} ({:4.1f}%)\n", bintotal,
+                        (100.0 * bintotal) / grandtotal);
             binstart = i + 1;
             bintotal = 0;
         }
     }
     if (depthchannel >= 0) {
-        print(out, "{}Minimum depth was {:g} at ({}, {})\n", indent, mindepth,
-              mindepth_pixel.x, mindepth_pixel.y);
-        print(out, "{}Maximum depth was {:g} at ({}, {})\n", indent, maxdepth,
-              maxdepth_pixel.x, maxdepth_pixel.y);
+        OIIO::print(out, "{}Minimum depth was {:g} at ({}, {})\n", indent,
+                    mindepth, mindepth_pixel.x, mindepth_pixel.y);
+        OIIO::print(out, "{}Maximum depth was {:g} at ({}, {})\n", indent,
+                    maxdepth, maxdepth_pixel.x, maxdepth_pixel.y);
     }
     if (nonfinites > 0) {
-        print(
+        OIIO::print(
             out,
             "{}Nonfinite values: {}, including (x={}, y={}, chan={}, samp={})\n",
             indent, nonfinites, nonfinite_pixel.x, nonfinite_pixel.y,
@@ -341,20 +344,21 @@ print_stats(std::ostream& out, string_view indent, const ImageBuf& input,
     } else {
         std::vector<float> constantValues(input.spec().nchannels);
         if (isConstantColor(input, 0.0f, constantValues)) {
-            print(out, "{}Constant: Yes\n", indent);
-            print(out, "{}Constant Color: ", indent);
+            OIIO::print(out, "{}Constant: Yes\n", indent);
+            OIIO::print(out, "{}Constant Color: ", indent);
             for (unsigned int i = 0; i < constantValues.size(); ++i) {
-                print(out, "{} ", stats_num(constantValues[i], maxval, false));
+                OIIO::print(out, "{} ",
+                            stats_num(constantValues[i], maxval, false));
             }
-            print(out, "{}\n", stats_footer(maxval));
+            OIIO::print(out, "{}\n", stats_footer(maxval));
         } else {
-            print(out, "{}Constant: No\n", indent);
+            OIIO::print(out, "{}Constant: No\n", indent);
         }
 
         if (isMonochrome(input)) {
-            print(out, "{}Monochrome: Yes\n", indent);
+            OIIO::print(out, "{}Monochrome: Yes\n", indent);
         } else {
-            print(out, "{}Monochrome: No\n", indent);
+            OIIO::print(out, "{}Monochrome: No\n", indent);
         }
     }
     return true;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1139,7 +1139,7 @@ ImageCacheFile::read_tile(ImageCachePerThreadInfo* thread_info,
         m_bytesread += b;
         ++m_tilesread;
         if (id.colortransformid() > 0) {
-            // print("CONVERT id {} {},{} to cs {}\n", filename(), id.x(), id.y(),
+            // OIIO::print("CONVERT id {} {},{} to cs {}\n", filename(), id.x(), id.y(),
             //       id.colortransformid());
             ImageSpec tilespec(dims.tile_width, dims.tile_height,
                                dims.nchannels, format);
@@ -2062,35 +2062,35 @@ ImageCacheImpl::onefile_stat_line(const ImageCacheFileRef& file, int i,
     default: break;
     }
     if (i >= 0)
-        print(out, "{:7} ", i);
+        OIIO::print(out, "{:7} ", i);
     if (includestats) {
         unsigned long long redund_tiles = file->redundant_tiles();
         if (redund_tiles)
-            print(out, "{:4}  {:7}   {:8.1f}   ({:5} {:6.1f}) {:9}  ",
-                  file->timesopened(), file->tilesread(),
-                  file->bytesread() / 1024.0 / 1024.0, redund_tiles,
-                  file->redundant_bytesread() / 1024.0 / 1024.0,
-                  Strutil::timeintervalformat(file->iotime()));
+            OIIO::print(out, "{:4}  {:7}   {:8.1f}   ({:5} {:6.1f}) {:9}  ",
+                        file->timesopened(), file->tilesread(),
+                        file->bytesread() / 1024.0 / 1024.0, redund_tiles,
+                        file->redundant_bytesread() / 1024.0 / 1024.0,
+                        Strutil::timeintervalformat(file->iotime()));
         else
-            print(out, "{:4}  {:7}   {:8.1f}                  {:9}  ",
-                  file->timesopened(), file->tilesread(),
-                  file->bytesread() / 1024.0 / 1024.0,
-                  Strutil::timeintervalformat(file->iotime()));
+            OIIO::print(out, "{:4}  {:7}   {:8.1f}                  {:9}  ",
+                        file->timesopened(), file->tilesread(),
+                        file->bytesread() / 1024.0 / 1024.0,
+                        Strutil::timeintervalformat(file->iotime()));
     }
     if (file->subimages() > 1)
-        print(out, "{:3} face x{}.{}", file->subimages(), spec.nchannels,
-              formatcode);
+        OIIO::print(out, "{:3} face x{}.{}", file->subimages(), spec.nchannels,
+                    formatcode);
     else
-        print(out, "{:4}x{:4}x{}.{}", spec.width, spec.height, spec.nchannels,
-              formatcode);
-    print(out, "  {} ", file->filename());
+        OIIO::print(out, "{:4}x{:4}x{}.{}", spec.width, spec.height,
+                    spec.nchannels, formatcode);
+    OIIO::print(out, "  {} ", file->filename());
     if (file->duplicate()) {
-        print(out, " DUPLICATES {}", file->duplicate()->filename());
+        OIIO::print(out, " DUPLICATES {}", file->duplicate()->filename());
         return out.str();
     }
     for (int s = 0; s < file->subimages(); ++s)
         if (file->subimageinfo(s).untiled) {
-            print(out, " UNTILED");
+            OIIO::print(out, " UNTILED");
             break;
         }
     if (automip()) {
@@ -2098,23 +2098,23 @@ ImageCacheImpl::onefile_stat_line(const ImageCacheFileRef& file, int i,
         // this file.  This is a little inexact.
         for (int s = 0; s < file->subimages(); ++s)
             if (file->subimageinfo(s).unmipped) {
-                print(out, " UNMIPPED");
+                OIIO::print(out, " UNMIPPED");
                 break;
             }
     }
     if (!file->mipused()) {
         for (int s = 0; s < file->subimages(); ++s)
             if (!file->subimageinfo(s).unmipped) {
-                print(out, " MIP-UNUSED");
+                OIIO::print(out, " MIP-UNUSED");
                 break;
             }
     }
     if (file->mipreadcount().size() > 1) {
-        print(out, " MIP-COUNT[");
+        OIIO::print(out, " MIP-COUNT[");
         int nmip = (int)file->mipreadcount().size();
         for (int c = 0; c < nmip; c++)
-            print(out, "{}{}", (c ? "," : ""), file->mipreadcount()[c]);
-        print(out, "]");
+            OIIO::print(out, "{}{}", (c ? "," : ""), file->mipreadcount()[c]);
+        OIIO::print(out, "]");
     }
 
     return out.str();
@@ -2210,90 +2210,97 @@ ImageCacheImpl::getstats(int level) const
 #undef BOOLOPT
 #undef INTOPT
 #undef STROPT
-        print(out, "  Options:  {}\n", Strutil::wordwrap(opt, 75, 12));
+        OIIO::print(out, "  Options:  {}\n", Strutil::wordwrap(opt, 75, 12));
 
         if (stats.unique_files) {
-            print(out, "  Images : {} unique\n", stats.unique_files);
-            print(out, "    ImageInputs : {} created, {} current, {} peak\n",
-                  int(m_stat_open_files_created),
-                  int(m_stat_open_files_current), int(m_stat_open_files_peak));
-            print(out,
-                  "    Total pixel data size of all images referenced : {}\n",
-                  Strutil::memformat(stats.files_totalsize));
-            print(out,
-                  "    Total actual file size of all images referenced : {}\n",
-                  Strutil::memformat(stats.files_totalsize_ondisk));
-            print(out, "    Pixel data read : {}\n",
-                  Strutil::memformat(stats.bytes_read));
+            OIIO::print(out, "  Images : {} unique\n", stats.unique_files);
+            OIIO::print(out,
+                        "    ImageInputs : {} created, {} current, {} peak\n",
+                        int(m_stat_open_files_created),
+                        int(m_stat_open_files_current),
+                        int(m_stat_open_files_peak));
+            OIIO::print(
+                out,
+                "    Total pixel data size of all images referenced : {}\n",
+                Strutil::memformat(stats.files_totalsize));
+            OIIO::print(
+                out,
+                "    Total actual file size of all images referenced : {}\n",
+                Strutil::memformat(stats.files_totalsize_ondisk));
+            OIIO::print(out, "    Pixel data read : {}\n",
+                        Strutil::memformat(stats.bytes_read));
         } else {
-            print(out, "  No images opened\n");
+            OIIO::print(out, "  No images opened\n");
         }
         if (stats.find_file_time > 0.001 || level > 2)
-            print(out, "    Find file time : {}\n",
-                  Strutil::timeintervalformat(stats.find_file_time));
+            OIIO::print(out, "    Find file time : {}\n",
+                        Strutil::timeintervalformat(stats.find_file_time));
         if (stats.fileio_time > 0.001 || level > 2) {
-            print(out, "    File I/O time : {}",
-                  Strutil::timeintervalformat(stats.fileio_time));
+            OIIO::print(out, "    File I/O time : {}",
+                        Strutil::timeintervalformat(stats.fileio_time));
             {
                 spin_lock lock(m_perthread_info_mutex);
                 size_t nthreads = m_all_perthread_info.size();
                 if (nthreads > 1 || level > 2) {
                     double perthreadtime = stats.fileio_time
                                            / std::max(size_t(1), nthreads);
-                    print(out, " ({} average per thread, for {} threads)",
-                          Strutil::timeintervalformat(perthreadtime), nthreads);
+                    OIIO::print(out, " ({} average per thread, for {} threads)",
+                                Strutil::timeintervalformat(perthreadtime),
+                                nthreads);
                 }
             }
-            print(out, "\n");
-            print(out, "    File open time only : {}\n",
-                  Strutil::timeintervalformat(stats.fileopen_time));
+            OIIO::print(out, "\n");
+            OIIO::print(out, "    File open time only : {}\n",
+                        Strutil::timeintervalformat(stats.fileopen_time));
         }
         if (stats.file_locking_time > 0.001 || level > 2)
-            print(out, "    File mutex locking time : {}\n",
-                  Strutil::timeintervalformat(stats.file_locking_time));
+            OIIO::print(out, "    File mutex locking time : {}\n",
+                        Strutil::timeintervalformat(stats.file_locking_time));
         if (total_input_mutex_wait_time > 0.001 || level > 2)
-            print(out, "    ImageInput mutex locking time : {}\n",
-                  Strutil::timeintervalformat(total_input_mutex_wait_time));
+            OIIO::print(out, "    ImageInput mutex locking time : {}\n",
+                        Strutil::timeintervalformat(
+                            total_input_mutex_wait_time));
         if (m_stat_tiles_created > 0 || level > 2) {
-            print(out, "  Tiles: {} created, {} current, {} peak\n",
-                  int(m_stat_tiles_created), int(m_stat_tiles_current),
-                  int(m_stat_tiles_peak));
-            print(out, "    total tile requests : {}\n", stats.find_tile_calls);
+            OIIO::print(out, "  Tiles: {} created, {} current, {} peak\n",
+                        int(m_stat_tiles_created), int(m_stat_tiles_current),
+                        int(m_stat_tiles_peak));
+            OIIO::print(out, "    total tile requests : {}\n",
+                        stats.find_tile_calls);
             if (stats.find_tile_microcache_misses)
-                print(out, "    micro-cache misses : {} ({:.1f}%)\n",
-                      stats.find_tile_microcache_misses,
-                      100.0 * stats.find_tile_microcache_misses
-                          / (double)stats.find_tile_calls);
+                OIIO::print(out, "    micro-cache misses : {} ({:.1f}%)\n",
+                            stats.find_tile_microcache_misses,
+                            100.0 * stats.find_tile_microcache_misses
+                                / (double)stats.find_tile_calls);
             if (stats.find_tile_cache_misses)
-                print(out, "    main cache misses : {} ({:.1f}%)\n",
-                      stats.find_tile_cache_misses,
-                      100.0 * stats.find_tile_cache_misses
-                          / (double)stats.find_tile_calls);
-            print(out, "    redundant reads: {} tiles, {}\n",
-                  total_redundant_tiles,
-                  Strutil::memformat(total_redundant_bytes));
+                OIIO::print(out, "    main cache misses : {} ({:.1f}%)\n",
+                            stats.find_tile_cache_misses,
+                            100.0 * stats.find_tile_cache_misses
+                                / (double)stats.find_tile_calls);
+            OIIO::print(out, "    redundant reads: {} tiles, {}\n",
+                        total_redundant_tiles,
+                        Strutil::memformat(total_redundant_bytes));
         }
-        print(out, "    Peak cache memory : {}\n",
-              Strutil::memformat(m_mem_used));
+        OIIO::print(out, "    Peak cache memory : {}\n",
+                    Strutil::memformat(m_mem_used));
         if (stats.tile_locking_time > 0.001 || level > 2)
-            print(out, "    Tile mutex locking time : {}\n",
-                  Strutil::timeintervalformat(stats.tile_locking_time));
+            OIIO::print(out, "    Tile mutex locking time : {}\n",
+                        Strutil::timeintervalformat(stats.tile_locking_time));
         if (stats.find_tile_time > 0.001 || level > 2)
-            print(out, "    Find tile time : {}\n",
-                  Strutil::timeintervalformat(stats.find_tile_time));
+            OIIO::print(out, "    Find tile time : {}\n",
+                        Strutil::timeintervalformat(stats.find_tile_time));
         if (stats.file_retry_success || stats.tile_retry_success)
-            print(out,
-                  "    Failure reads followed by unexplained success:"
-                  " {} files, {} tiles\n",
-                  stats.file_retry_success, stats.tile_retry_success);
+            OIIO::print(out,
+                        "    Failure reads followed by unexplained success:"
+                        " {} files, {} tiles\n",
+                        stats.file_retry_success, stats.tile_retry_success);
 
         printImageCacheMemory(out, *this);
     }
 
     if (level >= 2 && files.size()) {
-        print(out, "  Image file statistics:\n");
-        print(out, "        opens   tiles    MB read   --redundant--   "
-                   "I/O time  res              File\n");
+        OIIO::print(out, "  Image file statistics:\n");
+        OIIO::print(out, "        opens   tiles    MB read   --redundant--   "
+                         "I/O time  res              File\n");
         std::sort(files.begin(), files.end(), filename_compare);
         for (size_t i = 0; i < files.size(); ++i) {
             const ImageCacheFileRef& file(files[i]);
@@ -2301,70 +2308,72 @@ ImageCacheImpl::getstats(int level) const
             if (file->is_udim())
                 continue;
             if (file->broken() || file->subimages() == 0) {
-                print(out, "  {:76}{}\n", "BROKEN", file->filename());
+                OIIO::print(out, "  {:76}{}\n", "BROKEN", file->filename());
                 continue;
             }
-            print(out, "{}\n", onefile_stat_line(file, i + 1));
+            OIIO::print(out, "{}\n", onefile_stat_line(file, i + 1));
         }
-        print(out, "\n  Tot:  {:4}  {:7}   {:8.1f}   ({:5} {:6.1f}) {:9}\n",
-              total_opens, total_tiles, total_bytes / 1024.0 / 1024.0,
-              total_redundant_tiles, total_redundant_bytes / 1024.0 / 1024.0,
-              Strutil::timeintervalformat(total_iotime));
+        OIIO::print(out,
+                    "\n  Tot:  {:4}  {:7}   {:8.1f}   ({:5} {:6.1f}) {:9}\n",
+                    total_opens, total_tiles, total_bytes / 1024.0 / 1024.0,
+                    total_redundant_tiles,
+                    total_redundant_bytes / 1024.0 / 1024.0,
+                    Strutil::timeintervalformat(total_iotime));
     }
 
     // Try to point out hot spots
     if (level > 0) {
         if (total_duplicates || level > 2)
-            print(out, "  {} were exact duplicates of other images\n",
-                  total_duplicates);
+            OIIO::print(out, "  {} were exact duplicates of other images\n",
+                        total_duplicates);
         if (total_untiled || (total_unmipped && automip()) || level > 2) {
-            print(out, "  {} not tiled, {} not MIP-mapped\n", total_untiled,
-                  total_unmipped);
+            OIIO::print(out, "  {} not tiled, {} not MIP-mapped\n",
+                        total_untiled, total_unmipped);
 #if 0
             if (files.size() >= 50) {
-                print(out, "  Untiled/unmipped files were:\n");
+                OIIO::print(out, "  Untiled/unmipped files were:\n");
                 for (size_t i = 0;  i < files.size();  ++i) {
                     const ImageCacheFileRef &file (files[i]);
                     if (file->untiled() || (file->unmipped() && automip()))
-                        print(out, "{}\n", onefile_stat_line (file, -1));
+                        OIIO::print(out, "{}\n", onefile_stat_line (file, -1));
                 }
             }
 #endif
         }
         if (total_constant || level > 2)
-            print(out, "  {} {} constant-valued in all pixels\n",
-                  total_constant, (total_constant == 1 ? "was" : "were"));
+            OIIO::print(out, "  {} {} constant-valued in all pixels\n",
+                        total_constant, (total_constant == 1 ? "was" : "were"));
         if (files.size() >= 50 || level > 2) {
             const int topN = 3;
             int nprinted;
             std::sort(files.begin(), files.end(), bytesread_compare);
-            print(out, "  Top files by bytes read:\n");
+            OIIO::print(out, "  Top files by bytes read:\n");
             nprinted = 0;
             for (const ImageCacheFileRef& file : files) {
                 if (file->broken() || !file->validspec())
                     continue;
                 if (nprinted++ >= topN)
                     break;
-                print(out, "    {}   {:6.1f} MB ({:4.1f}%)  {}\n", nprinted,
-                      file->bytesread() / 1024.0 / 1024.0,
-                      100.0 * file->bytesread() / (double)total_bytes,
-                      onefile_stat_line(file, -1, false));
+                OIIO::print(out, "    {}   {:6.1f} MB ({:4.1f}%)  {}\n",
+                            nprinted, file->bytesread() / 1024.0 / 1024.0,
+                            100.0 * file->bytesread() / (double)total_bytes,
+                            onefile_stat_line(file, -1, false));
             }
             std::sort(files.begin(), files.end(), iotime_compare);
-            print(out, "  Top files by I/O time:\n");
+            OIIO::print(out, "  Top files by I/O time:\n");
             nprinted = 0;
             for (const ImageCacheFileRef& file : files) {
                 if (file->broken() || !file->validspec())
                     continue;
                 if (nprinted++ >= topN)
                     break;
-                print(out, "    {}   {:9} ({:4.1f}%)   {}\n", nprinted,
-                      Strutil::timeintervalformat(file->iotime()),
-                      100.0 * file->iotime() / total_iotime,
-                      onefile_stat_line(file, -1, false));
+                OIIO::print(out, "    {}   {:9} ({:4.1f}%)   {}\n", nprinted,
+                            Strutil::timeintervalformat(file->iotime()),
+                            100.0 * file->iotime() / total_iotime,
+                            onefile_stat_line(file, -1, false));
             }
             std::sort(files.begin(), files.end(), iorate_compare);
-            print(out, "  Files with slowest I/O rates:\n");
+            OIIO::print(out, "  Files with slowest I/O rates:\n");
             nprinted = 0;
             for (const ImageCacheFileRef& file : files) {
                 if (file->broken() || !file->validspec())
@@ -2375,31 +2384,33 @@ ImageCacheImpl::getstats(int level) const
                     break;
                 double mb = file->bytesread() / (1024.0 * 1024.0);
                 double r  = mb / file->iotime();
-                print(out, "    {}   {:6.2f} MB/s ({:.2f}MB/{:.2f}s)   {}\n",
-                      nprinted, r, mb, file->iotime(),
-                      onefile_stat_line(file, -1, false));
+                OIIO::print(out,
+                            "    {}   {:6.2f} MB/s ({:.2f}MB/{:.2f}s)   {}\n",
+                            nprinted, r, mb, file->iotime(),
+                            onefile_stat_line(file, -1, false));
             }
             if (nprinted == 0) {
-                print(out, "    (nothing took more than 0.25s)\n");
+                OIIO::print(out, "    (nothing took more than 0.25s)\n");
             } else {
                 double fast = files.back()->bytesread() / (1024.0 * 1024.0)
                               / files.back()->iotime();
-                print(out, "    (fastest was {:.1f} MB/s)\n", fast);
+                OIIO::print(out, "    (fastest was {:.1f} MB/s)\n", fast);
             }
             if (total_redundant_tiles > 0) {
                 std::sort(files.begin(), files.end(), redundantbytes_compare);
-                print(out, "  Top files by redundant I/O:\n");
+                OIIO::print(out, "  Top files by redundant I/O:\n");
                 nprinted = 0;
                 for (const ImageCacheFileRef& file : files) {
                     if (file->broken() || !file->validspec())
                         continue;
                     if (nprinted++ >= topN)
                         break;
-                    print(out, "    {}   {:6.1f} MB ({:4.1f}%)  {}\n", nprinted,
-                          file->redundant_bytesread() / 1024.0 / 1024.0,
-                          100.0 * file->redundant_bytesread()
-                              / (double)total_redundant_bytes,
-                          onefile_stat_line(file, -1, false));
+                    OIIO::print(out, "    {}   {:6.1f} MB ({:4.1f}%)  {}\n",
+                                nprinted,
+                                file->redundant_bytesread() / 1024.0 / 1024.0,
+                                100.0 * file->redundant_bytesread()
+                                    / (double)total_redundant_bytes,
+                                onefile_stat_line(file, -1, false));
                 }
             }
         }
@@ -2408,14 +2419,15 @@ ImageCacheImpl::getstats(int level) const
             if (file->broken())
                 ++nbroken;
         }
-        print(out, "  Broken or invalid files: {}\n", nbroken);
+        OIIO::print(out, "  Broken or invalid files: {}\n", nbroken);
         if (nbroken) {
             std::sort(files.begin(), files.end(), filename_compare);
             int nprinted = 0;
             for (const ImageCacheFileRef& file : files) {
                 if (file->broken()) {
                     ++nprinted;
-                    print(out, "   {:4}  {}\n", nprinted, file->filename());
+                    OIIO::print(out, "   {:4}  {}\n", nprinted,
+                                file->filename());
                 }
             }
         }
@@ -4063,7 +4075,7 @@ ImageCacheImpl::invalidate_all(bool force)
 
     // Now, invalidate all the files in our "needs invalidation" list
     for (auto f : all_files) {
-        // print(stderr, "Invalidating {}\n", f);
+        // OIIO::print(stderr, "Invalidating {}\n", f);
         invalidate(f, true);
     }
 

--- a/src/libtexture/imagecache_memory_print.h
+++ b/src/libtexture/imagecache_memory_print.h
@@ -98,18 +98,18 @@ printImageCacheMemory(std::ostream& out, const ImageCacheImpl& ic)
     footprint(ic, data);
 
     // print image cache memory usage
-    print(out, "  Cache : {}\n", Strutil::memformat(data.ic_mem));
-    print(out, "    Strings : {}, count : {}\n",
-          Strutil::memformat(data.ic_str_mem), data.ic_str_count);
-    print(out, "    Thread info : {}, count : {}\n",
-          Strutil::memformat(data.ic_thdi_mem), data.ic_thdi_count);
-    print(out, "    Fingerprints : {}, count : {}\n",
-          Strutil::memformat(data.ic_fgpt_mem), data.ic_fgpt_count);
-    print(out, "    Tiles : {}, count : {}\n",
-          Strutil::memformat(data.ic_tile_mem), data.ic_tile_count);
-    print(out, "    Files : {}, count : {}\n",
-          Strutil::memformat(data.fmap[ImageCacheFootprint::utotal][kMem]),
-          data.fmap[ImageCacheFootprint::utotal][kCount]);
+    OIIO::print(out, "  Cache : {}\n", Strutil::memformat(data.ic_mem));
+    OIIO::print(out, "    Strings : {}, count : {}\n",
+                Strutil::memformat(data.ic_str_mem), data.ic_str_count);
+    OIIO::print(out, "    Thread info : {}, count : {}\n",
+                Strutil::memformat(data.ic_thdi_mem), data.ic_thdi_count);
+    OIIO::print(out, "    Fingerprints : {}, count : {}\n",
+                Strutil::memformat(data.ic_fgpt_mem), data.ic_fgpt_count);
+    OIIO::print(out, "    Tiles : {}, count : {}\n",
+                Strutil::memformat(data.ic_tile_mem), data.ic_tile_count);
+    OIIO::print(out, "    Files : {}, count : {}\n",
+                Strutil::memformat(data.fmap[ImageCacheFootprint::utotal][kMem]),
+                data.fmap[ImageCacheFootprint::utotal][kCount]);
 
     // print file formats memory usage
     for (FileFootprintMap::const_iterator t = data.fmap.begin(),
@@ -117,24 +117,24 @@ printImageCacheMemory(std::ostream& out, const ImageCacheImpl& ic)
          t != e; ++t) {
         if (t.key() == ImageCacheFootprint::utotal)
             continue;
-        print(out, "      Format '{}' : {}, count : {}\n", t->first,
-              Strutil::memformat(t.value()[kMem]), t.value()[kCount]);
+        OIIO::print(out, "      Format '{}' : {}, count : {}\n", t->first,
+                    Strutil::memformat(t.value()[kMem]), t.value()[kCount]);
         if (t.value()[kInputMem] > 0ul)
-            print(out, "        Image inputs : {}, count : {}\n",
-                  Strutil::memformat(t.value()[kInputMem]),
-                  t.value()[kInputCount]);
+            OIIO::print(out, "        Image inputs : {}, count : {}\n",
+                        Strutil::memformat(t.value()[kInputMem]),
+                        t.value()[kInputCount]);
         if (t.value()[kSpecMem] > 0ul)
-            print(out, "        Image specs : {}, count : {}\n",
-                  Strutil::memformat(t.value()[kSpecMem]),
-                  t.value()[kSpecCount]);
+            OIIO::print(out, "        Image specs : {}, count : {}\n",
+                        Strutil::memformat(t.value()[kSpecMem]),
+                        t.value()[kSpecCount]);
         if (t.value()[kSubImageMem] > 0ul)
-            print(out, "        Subimages : {}, count : {}\n",
-                  Strutil::memformat(t.value()[kSubImageMem]),
-                  t.value()[kSubImageCount]);
+            OIIO::print(out, "        Subimages : {}, count : {}\n",
+                        Strutil::memformat(t.value()[kSubImageMem]),
+                        t.value()[kSubImageCount]);
         if (t.value()[kLevelInfoMem] > 0ul)
-            print(out, "          Levels : {}, count : {}\n",
-                  Strutil::memformat(t.value()[kLevelInfoMem]),
-                  t.value()[kLevelInfoCount]);
+            OIIO::print(out, "          Levels : {}, count : {}\n",
+                        Strutil::memformat(t.value()[kLevelInfoMem]),
+                        t.value()[kLevelInfoCount]);
     }
 }
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -773,31 +773,33 @@ TextureSystemImpl::getstats(int level, bool icstats) const
 #undef BOOLOPT
 #undef INTOPT
 #undef STROPT
-        print(out, "  Options:  {}\n", Strutil::wordwrap(opt, 75, 12));
+        OIIO::print(out, "  Options:  {}\n", Strutil::wordwrap(opt, 75, 12));
 
-        print(out, "  Queries/batches : \n");
-        print(out, "    texture     :  {} queries in {} batches\n",
-              stats.texture_queries, stats.texture_batches);
-        print(out, "    texture 3d  :  {} queries in {} batches\n",
-              stats.texture3d_queries, stats.texture3d_batches);
-        print(out, "    shadow      :  {} queries in {} batches\n",
-              stats.shadow_queries, stats.shadow_batches);
-        print(out, "    environment :  {} queries in {} batches\n",
-              stats.environment_queries, stats.environment_batches);
-        print(out, "    gettextureinfo :  {} queries\n",
-              stats.imageinfo_queries);
-        print(out, "  Interpolations :\n");
-        print(out, "    closest  : {}\n", stats.closest_interps);
-        print(out, "    bilinear : {}\n", stats.bilinear_interps);
-        print(out, "    bicubic  : {}\n", stats.cubic_interps);
+        OIIO::print(out, "  Queries/batches : \n");
+        OIIO::print(out, "    texture     :  {} queries in {} batches\n",
+                    stats.texture_queries, stats.texture_batches);
+        OIIO::print(out, "    texture 3d  :  {} queries in {} batches\n",
+                    stats.texture3d_queries, stats.texture3d_batches);
+        OIIO::print(out, "    shadow      :  {} queries in {} batches\n",
+                    stats.shadow_queries, stats.shadow_batches);
+        OIIO::print(out, "    environment :  {} queries in {} batches\n",
+                    stats.environment_queries, stats.environment_batches);
+        OIIO::print(out, "    gettextureinfo :  {} queries\n",
+                    stats.imageinfo_queries);
+        OIIO::print(out, "  Interpolations :\n");
+        OIIO::print(out, "    closest  : {}\n", stats.closest_interps);
+        OIIO::print(out, "    bilinear : {}\n", stats.bilinear_interps);
+        OIIO::print(out, "    bicubic  : {}\n", stats.cubic_interps);
         if (stats.aniso_queries)
-            print(out, "  Average anisotropic probes : {:.3g}\n",
-                  (double)stats.aniso_probes / (double)stats.aniso_queries);
+            OIIO::print(out, "  Average anisotropic probes : {:.3g}\n",
+                        (double)stats.aniso_probes
+                            / (double)stats.aniso_queries);
         else
-            print(out, "  Average anisotropic probes : 0\n");
-        print(out, "  Max anisotropy in the wild : {:.3g}\n", stats.max_aniso);
+            OIIO::print(out, "  Average anisotropic probes : 0\n");
+        OIIO::print(out, "  Max anisotropy in the wild : {:.3g}\n",
+                    stats.max_aniso);
         if (icstats)
-            print(out, "\n");
+            OIIO::print(out, "\n");
     }
     if (icstats)
         out << m_imagecache->getstats(level);

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -70,9 +70,12 @@ function (setup_oiio_util_library targetname)
             )
 
     if (GCC_VERSION VERSION_GREATER_EQUAL 12.0
-        AND CMAKE_CXX_STANDARD VERSION_GREATER_EQUAL 23)
-        target_link_libraries (${targetname}
-                               PRIVATE stdc++_libbacktrace)
+          AND GCC_VERSION VERSION_LESS 14.0
+          AND CMAKE_CXX_STANDARD VERSION_GREATER_EQUAL 23)
+        target_link_libraries (${targetname} PRIVATE stdc++_libbacktrace)
+    elseif (GCC_VERSION VERSION_GREATER_EQUAL 14.0
+            AND CMAKE_CXX_STANDARD VERSION_GREATER_EQUAL 23)
+        target_link_libraries (${targetname} PRIVATE stdc++exp)
     endif ()
 
     if (OIIO_INTERNALIZE_FMT OR fmt_LOCAL_BUILD)

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -142,34 +142,34 @@ operator<<(std::ostream& out, const Benchmarker& bench)
     range *= scale;
 
     if (bench.indent())
-        print(out, "{}", std::string(bench.indent(), ' '));
+        OIIO::print(out, "{}", std::string(bench.indent(), ' '));
     if (unit == int(Benchmarker::Unit::s))
-        print(out, "{:16}: {}", bench.m_name,
-              Strutil::timeintervalformat(avg, 2));
+        OIIO::print(out, "{:16}: {}", bench.m_name,
+                    Strutil::timeintervalformat(avg, 2));
     else
-        print(out, "{:16}: {:6.1f} {} (+/- {:.1f}{}), ", bench.name(), avg,
-              unitname, stddev, unitname);
+        OIIO::print(out, "{:16}: {:6.1f} {} (+/- {:.1f}{}), ", bench.name(),
+                    avg, unitname, stddev, unitname);
     if (bench.avg() < 0.25e-9) {
         // Less than 1/4 ns iteration time is probably an error
-        print(out, "unreliable");
+        OIIO::print(out, "unreliable");
         return out;
     }
     if (bench.work() == 1)
-        print(out, "{:6.1f} {:c}/s", (1.0f / ratescale) / bench.avg(),
-              rateunit);
+        OIIO::print(out, "{:6.1f} {:c}/s", (1.0f / ratescale) / bench.avg(),
+                    rateunit);
     else
-        print(out, "{:6.1f} {:c}vals/s, {:.1} {:c}calls/s",
-              (bench.work() / ratescale) / bench.avg(), rateunit,
-              (1.0f / ratescale) / bench.avg(), rateunit);
+        OIIO::print(out, "{:6.1f} {:c}vals/s, {:.1} {:c}calls/s",
+                    (bench.work() / ratescale) / bench.avg(), rateunit,
+                    (1.0f / ratescale) / bench.avg(), rateunit);
     if (bench.verbose() >= 2)
-        print(out, " ({}x{}, rng={:.1}%, med={:.1})", bench.trials(),
-              bench.iterations(), unitname, (range / avg) * 100.0,
-              bench.median() * scale);
+        OIIO::print(out, " ({}x{}, rng={:.1}%, med={:.1})", bench.trials(),
+                    bench.iterations(), unitname, (range / avg) * 100.0,
+                    bench.median() * scale);
 #if 0
     if (range > avg/10.0) {
         for (auto v : bench.m_times)
-            print(out, "{} ", v*scale/bench.iterations());
-        print(out, "\n");
+            OIIO::print(out, "{} ", v*scale/bench.iterations());
+        OIIO::print(out, "\n");
     }
 #endif
     return out;

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -31,16 +31,16 @@ inline void
 print_subimage(ImageRec& img0, int subimage, int miplevel)
 {
     if (img0.subimages() > 1)
-        print("Subimage {} ", subimage);
+        OIIO::print("Subimage {} ", subimage);
     if (img0.miplevels(subimage) > 1)
-        print(" MIP level {} ", miplevel);
+        OIIO::print(" MIP level {} ", miplevel);
     if (img0.subimages() > 1 || img0.miplevels(subimage) > 1)
-        print(": ");
+        OIIO::print(": ");
     const ImageSpec& spec(*img0.spec(subimage));
-    print("{} x {}", spec.width, spec.height);
+    OIIO::print("{} x {}", spec.width, spec.height);
     if (spec.depth > 1)
-        print(" x {}", spec.depth);
-    print(", {} channel\n", spec.nchannels);
+        OIIO::print(" x {}", spec.depth);
+    OIIO::print(", {} channel\n", spec.nchannels);
 }
 
 
@@ -49,8 +49,8 @@ int
 Oiiotool::do_action_diff(ImageRecRef ir0, ImageRecRef ir1, Oiiotool& ot,
                          int perceptual)
 {
-    print("Computing {}diff of \"{}\" vs \"{}\"\n",
-          perceptual ? "perceptual " : "", ir0->name(), ir1->name());
+    OIIO::print("Computing {}diff of \"{}\" vs \"{}\"\n",
+                perceptual ? "perceptual " : "", ir0->name(), ir1->name());
     read(ir0);
     read(ir1);
 
@@ -65,7 +65,8 @@ Oiiotool::do_action_diff(ImageRecRef ir0, ImageRecRef ir1, Oiiotool& ot,
             if (m > 0 && !ot.allsubimages)
                 break;
             if (m > 0 && ir0->miplevels(subimage) != ir1->miplevels(subimage)) {
-                print("Files do not match in their number of MIPmap levels\n");
+                OIIO::print(
+                    "Files do not match in their number of MIPmap levels\n");
                 ret = DiffErrDifferentSize;
                 break;
             }
@@ -108,62 +109,64 @@ Oiiotool::do_action_diff(ImageRecRef ir0, ImageRecRef ir1, Oiiotool& ot,
                 if (ot.allsubimages)
                     print_subimage(*ir0, subimage, m);
                 if (!perceptual) {
-                    print("  Mean error = {:.6g}\n", cr.meanerror);
-                    print("  RMS error = {:.6g}\n", cr.rms_error);
-                    print("  Peak SNR = {:.6g}\n", cr.PSNR);
+                    OIIO::print("  Mean error = {:.6g}\n", cr.meanerror);
+                    OIIO::print("  RMS error = {:.6g}\n", cr.rms_error);
+                    OIIO::print("  Peak SNR = {:.6g}\n", cr.PSNR);
                 }
-                print("  Max error  = {}", cr.maxerror);
+                OIIO::print("  Max error  = {}", cr.maxerror);
                 if (cr.maxerror != 0) {
-                    print(" @ ({}, {}", cr.maxx, cr.maxy);
+                    OIIO::print(" @ ({}, {}", cr.maxx, cr.maxy);
                     if (img0.spec().depth > 1)
-                        print(", {}", cr.maxz);
+                        OIIO::print(", {}", cr.maxz);
                     if (cr.maxc < (int)img0.spec().channelnames.size())
-                        print(", {})", img0.spec().channelnames[cr.maxc]);
+                        OIIO::print(", {})", img0.spec().channelnames[cr.maxc]);
                     else if (cr.maxc < (int)img1.spec().channelnames.size())
-                        print(", {})", img1.spec().channelnames[cr.maxc]);
+                        OIIO::print(", {})", img1.spec().channelnames[cr.maxc]);
                     else
-                        print(", channel {})", cr.maxc);
+                        OIIO::print(", channel {})", cr.maxc);
                     if (!img0.deep()) {
-                        print("  values are ");
+                        OIIO::print("  values are ");
                         for (int c = 0; c < img0.spec().nchannels; ++c)
-                            print("{}{}", (c ? ", " : ""),
-                                  img0.getchannel(cr.maxx, cr.maxy, 0, c));
-                        print(" vs ");
+                            OIIO::print("{}{}", (c ? ", " : ""),
+                                        img0.getchannel(cr.maxx, cr.maxy, 0, c));
+                        OIIO::print(" vs ");
                         for (int c = 0; c < img1.spec().nchannels; ++c)
-                            print("{}{}", (c ? ", " : ""),
-                                  img1.getchannel(cr.maxx, cr.maxy, 0, c));
+                            OIIO::print("{}{}", (c ? ", " : ""),
+                                        img1.getchannel(cr.maxx, cr.maxy, 0, c));
                     }
                 }
-                print("\n");
+                OIIO::print("\n");
                 if (perceptual == 1) {
-                    print("  {} pixels ({:.3g}%) failed the perceptual test\n",
-                          yee_failures, 100.0 * yee_failures / npels);
+                    OIIO::print(
+                        "  {} pixels ({:.3g}%) failed the perceptual test\n",
+                        yee_failures, 100.0 * yee_failures / npels);
                 } else {
-                    print("  {} pixels ({:.3g}%) over {}\n", cr.nwarn,
-                          (100.0 * cr.nwarn / npels), ot.diff_warnthresh);
-                    print("  {} pixels ({:.3g}%) over {}\n", cr.nfail,
-                          (100.0 * cr.nfail / npels), ot.diff_failthresh);
+                    OIIO::print("  {} pixels ({:.3g}%) over {}\n", cr.nwarn,
+                                (100.0 * cr.nwarn / npels), ot.diff_warnthresh);
+                    OIIO::print("  {} pixels ({:.3g}%) over {}\n", cr.nfail,
+                                (100.0 * cr.nfail / npels), ot.diff_failthresh);
                 }
             }
         }
     }
 
     if (ot.allsubimages && ir0->subimages() != ir1->subimages()) {
-        print("Images had differing numbers of subimages ({} vs {})\n",
-              ir0->subimages(), ir1->subimages());
+        OIIO::print("Images had differing numbers of subimages ({} vs {})\n",
+                    ir0->subimages(), ir1->subimages());
         ret = DiffErrFail;
     }
     if (!ot.allsubimages && (ir0->subimages() > 1 || ir1->subimages() > 1)) {
-        print("Only compared the first subimage (of {} and {}, respectively)\n",
-              ir0->subimages(), ir1->subimages());
+        OIIO::print(
+            "Only compared the first subimage (of {} and {}, respectively)\n",
+            ir0->subimages(), ir1->subimages());
     }
 
     if (ret == DiffErrOK)
-        print("PASS\n");
+        OIIO::print("PASS\n");
     else if (ret == DiffErrWarn)
-        print("WARNING\n");
+        OIIO::print("WARNING\n");
     else {
-        print("FAILURE\n");
+        OIIO::print("FAILURE\n");
         ot.return_value = ret;
     }
     fflush(stdout);

--- a/src/oiiotool/expressions.cpp
+++ b/src/oiiotool/expressions.cpp
@@ -49,7 +49,7 @@ bool
 Oiiotool::express_parse_atom(const string_view expr, string_view& s,
                              std::string& result)
 {
-    // print(" Entering express_parse_atom, s='{}'\n", s);
+    // OIIO::print(" Entering express_parse_atom, s='{}'\n", s);
 
     string_view orig = s;
     float floatval;
@@ -390,7 +390,7 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
     if (invert)
         result = Strutil::eval_as_bool(result) ? "0" : "1";
 
-    // print(" Exiting express_parse_atom, result='{}'\n", result);
+    // OIIO::print(" Exiting express_parse_atom, result='{}'\n", result);
 
     return true;
 }
@@ -401,7 +401,7 @@ bool
 Oiiotool::express_parse_factors(const string_view expr, string_view& s,
                                 std::string& result)
 {
-    // print(" Entering express_parse_factrors, s='{}'\n", s);
+    // OIIO::print(" Entering express_parse_factrors, s='{}'\n", s);
 
     string_view orig = s;
     std::string atom;
@@ -471,7 +471,7 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s,
         result = atom;
     }
 
-    // print(" Exiting express_parse_factors, result='{}'\n", result);
+    // OIIO::print(" Exiting express_parse_factors, result='{}'\n", result);
 
     return true;
 }
@@ -482,7 +482,7 @@ bool
 Oiiotool::express_parse_summands(const string_view expr, string_view& s,
                                  std::string& result)
 {
-    // print(" Entering express_parse_summands, s='{}'\n", s);
+    // OIIO::print(" Entering express_parse_summands, s='{}'\n", s);
 
     string_view orig = s;
     std::string atom;
@@ -555,7 +555,7 @@ Oiiotool::express_parse_summands(const string_view expr, string_view& s,
         result = atom;
     }
 
-    // print(" Exiting express_parse_summands, result='{}'\n", result);
+    // OIIO::print(" Exiting express_parse_summands, result='{}'\n", result);
 
     return true;
 }
@@ -603,6 +603,6 @@ Oiiotool::express(string_view str)
     ustring result = ustring::fmtformat("{}{}{}", prefix, express_impl(expr),
                                         express(s));
     if (debug)
-        print("Expanding expression \"{}\" -> \"{}\"\n", str, result);
+        OIIO::print("Expanding expression \"{}\" -> \"{}\"\n", str, result);
     return result;
 }

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -174,7 +174,7 @@ dump_data(std::ostream& out, ImageInput* input,
         // Special handling of deep data
         DeepData dd;
         if (!input->read_native_deep_image(subimage, 0, dd)) {
-            print(out, "    dump data: could not read image\n");
+            OIIO::print(out, "    dump data: could not read image\n");
             return;
         }
         int nc = spec.nchannels;
@@ -184,27 +184,28 @@ dump_data(std::ostream& out, ImageInput* input,
                     int nsamples = dd.samples(pixel);
                     if (nsamples == 0 && !opt.dumpdata_showempty)
                         continue;
-                    print(out, "    Pixel (");
+                    OIIO::print(out, "    Pixel (");
                     if (spec.depth > 1 || spec.z != 0)
-                        print(out, "{}, {}, {}", x + spec.x, y + spec.y,
-                              z + spec.z);
+                        OIIO::print(out, "{}, {}, {}", x + spec.x, y + spec.y,
+                                    z + spec.z);
                     else
-                        print(out, "{}, {}", x + spec.x, y + spec.y);
-                    print(out, "): {} samples {}", nsamples,
-                          nsamples ? ":" : "");
+                        OIIO::print(out, "{}, {}", x + spec.x, y + spec.y);
+                    OIIO::print(out, "): {} samples {}", nsamples,
+                                nsamples ? ":" : "");
                     for (int s = 0; s < nsamples; ++s) {
                         if (s)
-                            print(out, " / ");
+                            OIIO::print(out, " / ");
                         for (int c = 0; c < nc; ++c) {
-                            print(out, " {}=", spec.channel_name(c));
+                            OIIO::print(out, " {}=", spec.channel_name(c));
                             if (dd.channeltype(c) == TypeDesc::UINT)
-                                print(out, "{}",
-                                      dd.deep_value_uint(pixel, c, s));
+                                OIIO::print(out, "{}",
+                                            dd.deep_value_uint(pixel, c, s));
                             else
-                                print(out, "{}", dd.deep_value(pixel, c, s));
+                                OIIO::print(out, "{}",
+                                            dd.deep_value(pixel, c, s));
                         }
                     }
-                    print(out, "\n");
+                    OIIO::print(out, "\n");
                 }
             }
         }

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -112,10 +112,10 @@ private:
             swap_endian(s, 2);
             swap_endian(&i);
         }
-        print(out,
-              "{:d}/{:d} {:d}/{:d} {:d}/{:d} {:d}/{:d} ({:d} {:d}) ({:d})\n",
-              u.c[0], ((char*)u.c)[0], u.c[1], ((char*)u.c)[1], u.c[2],
-              ((char*)u.c)[2], u.c[3], ((char*)u.c)[3], s[0], s[1], i);
+        Strutil::print(
+            out, "{:d}/{:d} {:d}/{:d} {:d}/{:d} {:d}/{:d} ({:d} {:d}) ({:d})\n",
+            u.c[0], ((char*)u.c)[0], u.c[1], ((char*)u.c)[1], u.c[2],
+            ((char*)u.c)[2], u.c[3], ((char*)u.c)[3], s[0], s[1], i);
         ioseek(pos);
     }
 };

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -185,21 +185,23 @@ TermOutput::output()
         // special escape sequence that lets you transmit a base64-encoded
         // image file, so we convert to just a simple PPM and do so.
         std::ostringstream s;
-        print(s, "P3\n{} {}\n255\n", m_buf.spec().width, m_buf.spec().height);
+        OIIO::print(s, "P3\n{} {}\n255\n", m_buf.spec().width,
+                    m_buf.spec().height);
         for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; y += 1) {
             for (int x = m_buf.xbegin(), xe = m_buf.xend(); x < xe; ++x) {
                 uint8_t rgb[3];
                 m_buf.get_pixels(ROI(x, x + 1, y, y + 1, 0, 1, 0, 3),
                                  make_span(rgb));
-                print(s, "{} {} {}\n", int(rgb[0]), int(rgb[1]), int(rgb[2]));
+                OIIO::print(s, "{} {} {}\n", int(rgb[0]), int(rgb[1]),
+                            int(rgb[2]));
             }
         }
-        print(outfile, "\033]1337;File=inline=1;width=auto:{}\007\n",
-              Strutil::base64_encode(s.str()));
+        OIIO::print(outfile, "\033]1337;File=inline=1;width=auto:{}\007\n",
+                    Strutil::base64_encode(s.str()));
     }
 
     else if (method == "24bit") {
-        // Print two vertical pixels per character cell using the Unicode
+        // OIIO::Print two vertical pixels per character cell using the Unicode
         // "upper half block" glyph U+2580, with fg color set to the 24 bit
         // RGB value of the upper pixel, and bg color set to the 24-bit RGB
         // value the lower pixel.
@@ -209,17 +211,17 @@ TermOutput::output()
                 uint8_t rgb[2][3];
                 m_buf.get_pixels(ROI(x, x + 1, y, y + 2, z, z + 1, 0, 3),
                                  make_span((uint8_t*)rgb, 2 * 3));
-                print(outfile, "{}{}\x5C\x75\x32\x35\x38\x30",
-                      term.ansi_fgcolor(rgb[0][0], rgb[0][1], rgb[0][2]),
-                      term.ansi_bgcolor(rgb[1][0], rgb[1][1], rgb[1][2]));
+                OIIO::print(outfile, "{}{}\x5C\x75\x32\x35\x38\x30",
+                            term.ansi_fgcolor(rgb[0][0], rgb[0][1], rgb[0][2]),
+                            term.ansi_bgcolor(rgb[1][0], rgb[1][1], rgb[1][2]));
                 // the \x5C\x75\x32\x35\x38\x30 is utf8 encoding of "\u2580"
             }
-            print(outfile, "{}\n", term.ansi("default"));
+            OIIO::print(outfile, "{}\n", term.ansi("default"));
         }
     }
 
     else if (method == "24bit-space") {
-        // Print as space, with bg color set to the 24-bit RGB value of each
+        // OIIO::Print as space, with bg color set to the 24-bit RGB value of each
         // pixel.
         int z = m_buf.spec().z;
         for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; ++y) {
@@ -227,15 +229,15 @@ TermOutput::output()
                 uint8_t rgb[3];
                 m_buf.get_pixels(ROI(x, x + 1, y, y + 1, z, z + 1, 0, 3),
                                  make_span(rgb));
-                print(outfile, "{} ",
-                      term.ansi_bgcolor(rgb[0], rgb[1], rgb[2]));
+                OIIO::print(outfile, "{} ",
+                            term.ansi_bgcolor(rgb[0], rgb[1], rgb[2]));
             }
-            print(outfile, "{}\n", term.ansi("default"));
+            OIIO::print(outfile, "{}\n", term.ansi("default"));
         }
     }
 
     else if (method == "dither") {
-        // Print as space, with bg color set to the 6x6x6 RGB value of each
+        // OIIO::Print as space, with bg color set to the 6x6x6 RGB value of each
         // pixels. Try to make it better with horizontal dithering. But...
         // it still looks bad. Room for future improvement?
         int z = m_buf.spec().z;
@@ -251,15 +253,15 @@ TermOutput::output()
                 OIIO_MAYBE_UNUSED simd::vfloat4 frac = floorfrac(rgb, &rgbi);
                 leftover = rgborig - 0.2f * simd::vfloat4(rgbi);
                 rgbi     = clamp(rgbi, simd::vint4(0), simd::vint4(5));
-                print(outfile, "\033[48;5;{}m ",
-                      (0x10 + 36 * rgbi[0] + 6 * rgbi[1] + rgbi[2]));
+                OIIO::print(outfile, "\033[48;5;{}m ",
+                            (0x10 + 36 * rgbi[0] + 6 * rgbi[1] + rgbi[2]));
             }
-            print(outfile, "{}\n", term.ansi("default"));
+            OIIO::print(outfile, "{}\n", term.ansi("default"));
         }
     }
 
     else {
-        // Print as space, with bg color set to the 6x6x6 RGB value of each
+        // OIIO::Print as space, with bg color set to the 6x6x6 RGB value of each
         // pixels. This looks awful!
         int z = m_buf.spec().z;
         for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; ++y) {
@@ -271,10 +273,10 @@ TermOutput::output()
                 simd::vint4 rgbi;
                 OIIO_MAYBE_UNUSED simd::vfloat4 frac = floorfrac(rgb, &rgbi);
                 rgbi = clamp(rgbi, simd::vint4(0), simd::vint4(5));
-                print(outfile, "\033[48;5;{}m ",
-                      (0x10 + 36 * rgbi[0] + 6 * rgbi[1] + rgbi[2]));
+                OIIO::print(outfile, "\033[48;5;{}m ",
+                            (0x10 + 36 * rgbi[0] + 6 * rgbi[1] + rgbi[2]));
             }
-            print(outfile, "{}\n", term.ansi("default"));
+            OIIO::print(outfile, "{}\n", term.ansi("default"));
         }
     }
 


### PR DESCRIPTION
* CI build as C++23 for bleeding edge test

* Fixes to disambiguate OIIO::print from std::print.  Apparently, at least for gcc14, std::print ends up in the global namespace and really messes with things.

* Change to the library that contains the implementation of C++23 stacktrace in gcc14 vs 12/13.
