### PR TITLE
test: Update ref output

### DIFF
--- a/testsuite/maketx/ref/out-alt.txt
+++ b/testsuite/maketx/ref/out-alt.txt
@@ -337,7 +337,6 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -366,7 +365,6 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:ColorSpace: "lin_rec709"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"


### PR DESCRIPTION
PRs #4840 and #4841 crossed in flight with their tests passing individually, but they needed one small adjustment to reference output in order to to account for their interaction in main.
