### PR TITLE
Add zstd as a compression option for the OpenEXR plugin in OIIO

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1543,16 +1543,17 @@ The official OpenEXR site is http://www.openexr.com/.
    * - ``compression``
      - string
      - one of: ``"none"``, ``"rle"``, ``"zip"``, ``"zips"``, ``"piz"``,
-       ``"pxr24"``, ``"b44"``, ``"b44a"``, ``"dwaa"``, ``"dwab"`` or ``"htj2k"``.
+       ``"pxr24"``, ``"b44"``, ``"b44a"``, ``"dwaa"``, ``"dwab"``, ``"htj2k"`` or ``"zstd"``.
        (``"htj2k"`` is only supported with OpenEXR 3.4 or later.)
+       (``"zstd"`` is only supported with OpenEXR 3.5 or later.)
        If the writer receives a request for a compression type it does not
        recognize or is not supported by the version of OpenEXR on the
        system, it will use ``"zip"`` by default. For ``"dwaa"`` and
        ``"dwab"``, the dwaCompressionLevel may be optionally appended to the
        compression name after a colon, like this: ``"dwaa:200"``. (The
-       default DWA compression value is 45.) For ``"zip"`` and ``"zips"``
+       default DWA compression value is 45.) For ``"zip"``, ``"zips"`` and ``"zstd"``
        compression, a level from 1 to 9 may be appended (the default is
-       ``"zip:4"``), but note that this is only honored when building
+       ``"zip:4"`` and ``"zstd:5"``), but note that this is only honored when building
        against OpenEXR 3.1.3 or later.
    * - ``textureformat``
      - string

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -434,6 +434,9 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
 #ifdef IMF_HTJ2K_COMPRESSION
         case Imf::HTJ2K_COMPRESSION: comp = "htj2k"; break;
 #endif
+#ifdef IMF_ZSTD_COMPRESSION
+        case Imf::ZSTD_COMPRESSION: comp = "zstd"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -571,6 +571,9 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
 #ifdef IMF_HTJ2K_COMPRESSION
         case EXR_COMPRESSION_HTJ2K: comp = "htj2k"; break;
 #endif
+#ifdef IMF_ZSTD_COMPRESSION
+        case EXR_COMPRESSION_ZSTD: comp = "zstd"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -748,7 +748,7 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     // that 5 is a great tradeoff between size and speed, so that is our
     // default.
     if (Strutil::istarts_with(comp, "zstd")) {
-        header.zstdCompressionLevel() = (qual >= 1 && qual <= 22) ? qual : 5;
+        header.zstdCompressionLevel() = (qual >= 1 && qual <= 9) ? qual : 5;
     }
 #endif
     if (Strutil::istarts_with(comp, "dwa") && qual > 0) {

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -743,6 +743,14 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
         header.zipCompressionLevel() = (qual >= 1 && qual <= 9) ? qual : 4;
     }
 #endif
+#if OPENEXR_CODED_VERSION >= 30500
+    // OpenEXR 3.5.0 and later allow us to pick the level. We've found
+    // that 5 is a great tradeoff between size and speed, so that is our
+    // default.
+    if (Strutil::istarts_with(comp, "zstd")) {
+        header.zstdCompressionLevel() = (qual >= 1 && qual <= 22) ? qual : 5;
+    }
+#endif
     if (Strutil::istarts_with(comp, "dwa") && qual > 0) {
 #if OPENEXR_CODED_VERSION >= 30103
         // OpenEXR 3.1.3 and later have an API for setting the quality level
@@ -964,6 +972,10 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
 #ifdef IMF_HTJ2K_COMPRESSION
             else if (Strutil::iequals(str, "htj2k"))
                 header.compression() = Imf::HTJ2K_COMPRESSION;
+#endif
+#ifdef IMF_ZSTD_COMPRESSION
+            else if (Strutil::iequals(str, "zstd"))
+                header.compression() = Imf::ZSTD_COMPRESSION;
 #endif
         }
         return true;


### PR DESCRIPTION
## Description

After adding the new `zstd` compression codec to OpenEXR, here we enable it in the OIIO stack so it will be recognized by the library and binary tools, such as using oiiotool to directly change compression type into zstd.

add support `zstd` a new compression (AcademySoftwareFoundation/openexr#1604)

I'm also trying to study if more changes on the OIIO side is required to enabled the new `zstd` codec throughout the OIIO tool chain... suggestions welcome.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
