### PR TITLE
build: fix build on NetBSD

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdio>
+#include <cstdarg>
 #include <map>
 #include <sstream>
 #include <string>

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -409,7 +409,7 @@ template<> struct BaseTypeFromC<uint64_t> { static constexpr TypeDesc::BASETYPE 
 template<> struct BaseTypeFromC<const uint64_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::UINT64; };
 template<> struct BaseTypeFromC<int64_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT64; };
 template<> struct BaseTypeFromC<const int64_t> { static constexpr TypeDesc::BASETYPE value = TypeDesc::INT64; };
-#if defined(__GNUC__) && __WORDSIZE == 64 && !(defined(__APPLE__) && defined(__MACH__))
+#if defined(__GNUC__) && __WORDSIZE == 64 && !(defined(__APPLE__) && defined(__MACH__)) || defined(__NetBSD__)
 // Some platforms consider int64_t and long long to be different types, even
 // though they are actually the same size.
 static_assert(!std::is_same_v<unsigned long long, uint64_t>);

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -21,8 +21,6 @@
 
 #include "imageio_pvt.h"
 
-using namespace std;
-
 OIIO_NAMESPACE_BEGIN
 
 
@@ -82,11 +80,11 @@ ImageBufAlgo::PixelStats::operator=(PixelStats&& other)
 inline void
 val(ImageBufAlgo::PixelStats& p, int c, float value)
 {
-    if (isnan(value)) {
+    if (std::isnan(value)) {
         ++p.nancount[c];
         return;
     }
-    if (isinf(value)) {
+    if (std::isinf(value)) {
         ++p.infcount[c];
         return;
     }
@@ -219,10 +217,10 @@ compare_value(ImageBuf::ConstIterator<BUFT, float>& a, int chan, VALT aval,
               bool& warned, float failthresh, float warnthresh,
               float failrelative, float warnrelative)
 {
-    if (!isfinite(aval) || !isfinite(bval)) {
-        if (isnan(aval) == isnan(bval) && isinf(aval) == isinf(bval))
+    if (!std::isfinite(aval) || !std::isfinite(bval)) {
+        if (std::isnan(aval) == std::isnan(bval) && std::isinf(aval) == std::isinf(bval))
             return;  // NaN may match NaN, Inf may match Inf
-        if (isfinite(result.maxerror)) {
+        if (std::isfinite(result.maxerror)) {
             // non-finite errors trump finite ones
             result.maxerror = std::numeric_limits<float>::infinity();
             result.maxx     = a.x();

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -218,7 +218,8 @@ compare_value(ImageBuf::ConstIterator<BUFT, float>& a, int chan, VALT aval,
               float failrelative, float warnrelative)
 {
     if (!std::isfinite(aval) || !std::isfinite(bval)) {
-        if (std::isnan(aval) == std::isnan(bval) && std::isinf(aval) == std::isinf(bval))
+        if (std::isnan(aval) == std::isnan(bval)
+            && std::isinf(aval) == std::isinf(bval))
             return;  // NaN may match NaN, Inf may match Inf
         if (std::isfinite(result.maxerror)) {
             // non-finite errors trump finite ones

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -21,6 +21,8 @@
 
 #include "imageio_pvt.h"
 
+using namespace std;
+
 OIIO_NAMESPACE_BEGIN
 
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -347,7 +347,7 @@ check_nan_block(const ImageBuf& src, ROI roi, int& found_nonfinite)
         for (int x = x0; x < x1; ++x) {
             src.getpixel(x, y, pel);
             for (int c = 0; c < spec.nchannels; ++c) {
-                if (!isfinite(pel[c])) {
+                if (!std::isfinite(pel[c])) {
                     spin_lock lock(maketx_mutex);
                     // if (found_nonfinite < 3)
                     //     std::cerr << "maketx ERROR: Found " << pel[c]

--- a/src/libOpenImageIO/printinfo.cpp
+++ b/src/libOpenImageIO/printinfo.cpp
@@ -78,9 +78,9 @@ stats_num(float val, int maxval, bool round)
     // Ensure uniform printing of NaN and Inf on all platforms
     using Strutil::fmt::format;
     std::string result;
-    if (isnan(val))
+    if (std::isnan(val))
         result = "nan";
-    else if (isinf(val))
+    else if (std::isinf(val))
         result = "inf";
     else if (maxval == 0) {
         result = format("{:f}", val);
@@ -245,7 +245,7 @@ print_deep_stats(std::ostream& out, string_view indent, const ImageBuf& input,
                 for (unsigned int s = 0; s < samples; ++s) {
                     for (int c = 0; c < nchannels; ++c) {
                         float d = input.deep_value(x, y, z, c, s);
-                        if (!isfinite(d)) {
+                        if (!std::isfinite(d)) {
                             if (nonfinites++ == 0) {
                                 nonfinite_pixel.setValue(x, y, z);
                                 nonfinite_pixel_samp = s;

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -268,9 +268,9 @@ vector_to_latlong(const Imath::V3f& R, bool y_is_up, float& s, float& t)
         t = 0.5f - atan2f(R.z, hypotf(R.x, R.y)) / (float)M_PI;
     }
     // learned from experience, beware NaNs
-    if (isnan(s))
+    if (std::isnan(s))
         s = 0.0f;
-    if (isnan(t))
+    if (std::isnan(t))
         t = 0.0f;
 }
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -550,7 +550,7 @@ test_half_convert_accuracy()
             && Imath::finitef(H[i])) {
             ++nwrong;
             Strutil::print("wrong {} 0b{}  h={}, f={} {}\n", i, bin16(i), H[i],
-                           F[i], isnan(f) ? "(nan)" : "");
+                           F[i], std::isnan(f) ? "(nan)" : "");
         }
     }
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -527,12 +527,12 @@ strcasecmp(const char* a, const char* b)
 #elif defined(_WIN32)
     return _stricmp_l(a, b, c_loc);
 #elif defined(__NetBSD__)
-    const unsigned char *us1 = (const unsigned char *)a,
-                    *us2 = (const unsigned char *)b;
+    const unsigned char *us1 = (const unsigned char*)a,
+                        *us2 = (const unsigned char*)b;
 
     while (tolower_l(*us1, c_loc) == tolower_l(*us2++, c_loc))
-            if (*us1++ == '\0')
-                    return (0);
+        if (*us1++ == '\0')
+            return (0);
     return (tolower_l(*us1, c_loc) - tolower_l(*--us2, c_loc));
 #else
 #    error("need equivalent of strcasecmp_l on this platform");
@@ -551,15 +551,15 @@ strncasecmp(const char* a, const char* b, size_t size)
     return _strnicmp_l(a, b, size, c_loc);
 #elif defined(__NetBSD__)
     if (size != 0) {
-            const unsigned char *us1 = (const unsigned char *)a,
-                            *us2 = (const unsigned char *)b;
+        const unsigned char *us1 = (const unsigned char*)a,
+                            *us2 = (const unsigned char*)b;
 
-            do {
-                    if (tolower_l(*us1, c_loc) != tolower_l(*us2++, c_loc))
-                            return (tolower_l(*us1, c_loc) - tolower_l(*--us2, c_loc));
-                    if (*us1++ == '\0')
-                            break;
-            } while (--size != 0);
+        do {
+            if (tolower_l(*us1, c_loc) != tolower_l(*us2++, c_loc))
+                return (tolower_l(*us1, c_loc) - tolower_l(*--us2, c_loc));
+            if (*us1++ == '\0')
+                break;
+        } while (--size != 0);
     }
     return (0);
 #else

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -67,7 +67,7 @@ static std::mutex output_mutex;
 // On systems that support it, get a location independent locale.
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) \
     || defined(__FreeBSD_kernel__) || defined(__OpenBSD__)           \
-    || defined(__GLIBC__)
+    || defined(__GLIBC__) || defined(__NetBSD__)
 static locale_t c_loc = newlocale(LC_ALL_MASK, "C", nullptr);
 #elif defined(_WIN32)
 static _locale_t c_loc = _create_locale(LC_ALL, "C");
@@ -526,6 +526,14 @@ strcasecmp(const char* a, const char* b)
     return strcasecmp_l(a, b, c_loc);
 #elif defined(_WIN32)
     return _stricmp_l(a, b, c_loc);
+#elif defined(__NetBSD__)
+    const unsigned char *us1 = (const unsigned char *)a,
+                    *us2 = (const unsigned char *)b;
+
+    while (tolower_l(*us1, c_loc) == tolower_l(*us2++, c_loc))
+            if (*us1++ == '\0')
+                    return (0);
+    return (tolower_l(*us1, c_loc) - tolower_l(*--us2, c_loc));
 #else
 #    error("need equivalent of strcasecmp_l on this platform");
 #endif
@@ -541,6 +549,19 @@ strncasecmp(const char* a, const char* b, size_t size)
     return strncasecmp_l(a, b, size, c_loc);
 #elif defined(_WIN32)
     return _strnicmp_l(a, b, size, c_loc);
+#elif defined(__NetBSD__)
+    if (size != 0) {
+            const unsigned char *us1 = (const unsigned char *)a,
+                            *us2 = (const unsigned char *)b;
+
+            do {
+                    if (tolower_l(*us1, c_loc) != tolower_l(*us2++, c_loc))
+                            return (tolower_l(*us1, c_loc) - tolower_l(*--us2, c_loc));
+                    if (*us1++ == '\0')
+                            break;
+            } while (--size != 0);
+    }
+    return (0);
 #else
 #    error("need equivalent of strncasecmp_l on this platform");
 #endif

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -58,9 +58,9 @@ print_nums(std::ostream& out, int n, const T* val, string_view sep = " ",
             if (i)
                 Strutil::print(out, "{}", sep);
             float v = float(val[i]);
-            if (isnan(v))
+            if (std::isnan(v))
                 Strutil::print(out, "nan");
-            else if (isinf(v))
+            else if (std::isinf(v))
                 Strutil::print(out, "inf");
             else
                 Strutil::print(out, "{:.9f}", v);

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1557,7 +1557,7 @@ do_tex_thread_workout(int iterations, int mythread)
     }
     // Force the compiler to not optimize away the "other work"
     for (int c = 0; c < nchannels; ++c)
-        OIIO_ASSERT(!isnan(result[c]));
+        OIIO_ASSERT(!std::isnan(result[c]));
 }
 
 


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

These patch fix the build on NetBSD 11.99.1. There were a couple problems:
- some missing `str*i*()` functions
- `isnan` etc. not being used from the proper `std::` namespace
- a missing header for `va_list`
- NetBSD also handles `long long` differently from `int64`
- 
<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
