### PR TITLE
ci: better spread of libpng versions we test against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
             opencolorio_ver: v2.3.0
             pybind11_ver: v2.9.0
             setenvs: export FREETYPE_VERSION=VER-2-12-0
+                            BUILD_PNG_VERSION=1.6.30
           - desc: VP2022 clang13/C++17 py39 avx2 exr3.1 ocio2.3
             nametag: linux-vfx2022.clang13
             runner: ubuntu-latest
@@ -75,6 +76,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 9.1.0
             setenvs: export FREETYPE_VERSION=VER-2-12-0
+                            BUILD_PNG_VERSION=1.6.30
           - desc: oldest gcc9.3/C++17 py3.9 exr3.1 ocio2.3
             # Oldest gcc and versions of the dependencies that we support.
             nametag: linux-oldest
@@ -92,6 +94,7 @@ jobs:
                              PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.1.0
                              PUGIXML_VERSION=v1.8
+                             BUILD_PNG_VERSION=1.6.0
             depcmds: sudo rm -rf /usr/local/include/OpenEXR
           - desc: oldest clang10/C++17 py3.9 exr3.1 ocio2.3
             # Oldest clang and versions of the dependencies that we support.
@@ -112,6 +115,7 @@ jobs:
                              PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.1.0
                              PUGIXML_VERSION=v1.8
+                             BUILD_PNG_VERSION=1.6.0
             depcmds: sudo rm -rf /usr/local/include/OpenEXR
           - desc: hobbled gcc9.3/C++17 py3.9 exr-3.1 no-sse
             # Use the oldest supported versions of required dependencies, and
@@ -137,6 +141,7 @@ jobs:
                              USE_OPENCV=0
                              FREETYPE_VERSION=VER-2-10-0
                              PUGIXML_VERSION=v1.8
+                             BUILD_PNG_VERSION=1.6.0
             depcmds: sudo rm -rf /usr/local/include/OpenEXR
 
     runs-on: ${{ matrix.runner }}
@@ -372,6 +377,7 @@ jobs:
             setenvs: export SANITIZE=address,undefined
                             OIIO_CMAKE_FLAGS="-DSANITIZE=address,undefined -DOIIO_HARDENING=3 -DUSE_PYTHON=0"
                             CTEST_EXCLUSIONS="broken|png-damaged"
+                            LIBPNG_VERSION=v1.6.50
 
           # Test ABI stability. `abi_check` is the version or commit that we
           # believe is the current standard against which we don't want to
@@ -425,6 +431,7 @@ jobs:
             python_ver: "3.12"
             simd: avx2,f16c
             setenvs: export LIBJPEGTURBO_VERSION=3.1.1
+                            LIBPNG_VERSION=v1.6.50
                             LIBRAW_VERSION=0.21.4
                             LIBTIFF_VERSION=v4.7.0
                             OPENJPEG_VERSION=v2.5.3
@@ -447,6 +454,7 @@ jobs:
             simd: avx2,f16c
             benchmark: 1
             setenvs: export LIBJPEGTURBO_VERSION=main
+                            LIBPNG_VERSION=master
                             LIBRAW_VERSION=master
                             LIBTIFF_VERSION=master
                             OPENJPEG_VERSION=master
@@ -523,6 +531,7 @@ jobs:
             pybind11_ver: v3.0.0
             python_ver: "3.12"
             setenvs: export LIBJPEGTURBO_VERSION=3.1.1
+                            LIBPNG_VERSION=v1.6.50
                             LIBRAW_VERSION=0.21.4
                             LIBTIFF_VERSION=v4.7.0
                             OPENJPEG_VERSION=v2.5.3
@@ -543,6 +552,7 @@ jobs:
             pybind11_ver: v3.0.0
             python_ver: "3.12"
             setenvs: export LIBJPEGTURBO_VERSION=3.1.0
+                            LIBPNG_VERSION=v1.6.50
                             LIBRAW_VERSION=0.21.4
                             LIBTIFF_VERSION=v4.7.0
                             OPENJPEG_VERSION=v2.5.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,7 @@ jobs:
             setenvs: export SANITIZE=address,undefined
                             OIIO_CMAKE_FLAGS="-DSANITIZE=address,undefined -DOIIO_HARDENING=3 -DUSE_PYTHON=0"
                             CTEST_EXCLUSIONS="broken|png-damaged"
-                            LIBPNG_VERSION=v1.6.50
+                            OpenImageIO_BUILD_LOCAL_DEPS=PNG
 
           # Test ABI stability. `abi_check` is the version or commit that we
           # believe is the current standard against which we don't want to

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of libpng to download if we don't have it yet
 LIBPNG_REPO=${LIBPNG_REPO:=https://github.com/pnggroup/libpng.git}
-LIBPNG_VERSION=${LIBPNG_VERSION:=v1.6.47}
+LIBPNG_VERSION=${LIBPNG_VERSION:=v1.6.50}
 
 # Where to put libpng repo source (default to the ext area)
 LIBPNG_SRC_DIR=${LIBPNG_SRC_DIR:=${PWD}/ext/libpng}

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -208,6 +208,10 @@ if [[ "$FREETYPE_VERSION" != "" ]] ; then
     source src/build-scripts/build_Freetype.bash
 fi
 
+if [[ "$LIBPNG_VERSION" != "" ]] ; then
+    source src/build-scripts/build_libpng.bash
+fi
+
 if [[ "$USE_ICC" != "" ]] ; then
     # We used gcc for the prior dependency builds, but use icc for OIIO itself
     echo "which icpc:" $(which icpc)

--- a/src/cmake/build_PNG.cmake
+++ b/src/cmake/build_PNG.cmake
@@ -6,7 +6,7 @@
 # PNG by hand!
 ######################################################################
 
-set_cache (PNG_BUILD_VERSION 1.6.47 "PNG version for local builds")
+set_cache (PNG_BUILD_VERSION 1.6.50 "PNG version for local builds")
 super_set (PNG_BUILD_GIT_REPOSITORY "https://github.com/pnggroup/libpng")
 super_set (PNG_BUILD_GIT_TAG "v${PNG_BUILD_VERSION}")
 super_set (PNG_BUILD_EXTRA_CMAKE_ARGS "")

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1771,6 +1771,11 @@ files use the file extension :file:`.png`.
    * - ``oiio:ColorSpace``
      - string
      - Color space (see Section :ref:`sec-metadata-color`).
+   * - ``CICP``
+     - int[4]
+     - CICP color space information (see Section :ref:`sec-metadata-color`).
+       Note that this attribute is only supported if OIIO was built against
+       libPNG 1.6.45 or newer.
    * - ``ICCProfile``
      - uint8[]
      - The ICC color profile. A variety of other ``ICCProfile:*`` attributes


### PR DESCRIPTION
* The "oldest" didn't really test against the oldest we claim to support.
* The "latest versions" didn't really test against the latest versions.
* The "bleeding edge" didn't really test against libpng master.
* The auto-build was unnecessarily a few releases behind.
* Documentation touch-ups
