### PR TITLE
admin: Adjust license notices of A2-only source

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 #include <cstdio>


### PR DESCRIPTION
There are still a few historical authors who never signed on to the relicensing of OpenImageIO from BSD-3-Clause to Apache-2.0 two years ago, usually because we could find no current way to contact them.

The few (< 25) files that still had their extant code were therefore marked as using both licenses. They they almost always are down to just a few lines in the whole file that are still original to those authors (and therefore BSD), so every once in a while, natural code churn and rewrites of what they touched remove the very last of these lines from a file, leaving that file entirely Apache-2.0. I noticed that this was the case for these three files, and so removed the reference to BSD license, which no longer applies.
