### PR TITLE
fix: FFmpeg sets zero oiio:BitsPerSample

### DIFF
--- a/testsuite/ffmpeg/ref/out-ffmpeg6.1.txt
+++ b/testsuite/ffmpeg/ref/out-ffmpeg6.1.txt
@@ -10,7 +10,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  1:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -22,7 +22,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  2:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -34,7 +34,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  3:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -46,7 +46,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  4:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -58,7 +58,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  5:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -70,7 +70,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  6:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -82,6 +82,6 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7

--- a/testsuite/ffmpeg/ref/out-ffmpeg8.0.txt
+++ b/testsuite/ffmpeg/ref/out-ffmpeg8.0.txt
@@ -10,7 +10,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  1:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -22,7 +22,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  2:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -34,7 +34,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  3:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -46,7 +46,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  4:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -58,7 +58,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  5:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -70,7 +70,7 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7
  subimage  6:  192 x  108, 3 channel, uint8 FFmpeg movie
@@ -82,6 +82,6 @@ ref/vp9_display_p3.mkv :  192 x  108, 3 channel, uint8 FFmpeg movie
     FramesPerSecond: 24/1 (24)
     SCENE: "Scene"
     ffmpeg:codec_name: "Google VP9"
-    oiio:BitsPerSample: 0
+    oiio:BitsPerSample: 8
     oiio:Movie: 1
     oiio:subimages: 7


### PR DESCRIPTION
## Description

Many codecs don't provide `bits_per_raw_sample`. The bit depth of the luma channel is the closest equivalent to a single bit depth then, while the chroma channels may be subsampled.

Tested on basically all the video files on my computer, they all give a non-zero bit depth that looks correct now.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
