### PR TITLE
feat(raw): add thumbnail support to the raw input plugin

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -1710,7 +1710,7 @@ void
 _errorfmt(const RawInput* input, int subimage, const char* format,
           const Args&... args)
 {
-    std::string fmt = "Failed to unpack thumbnail at index "
+    std::string fmt = "Failed to extract thumbnail at index "
                       + std::to_string(subimage) + ": " + format + ".";
     input->errorfmt(fmt.c_str(), args...);
 }
@@ -1764,7 +1764,8 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
     }
 
     if (image_type.empty()) {
-        _errorfmt(this, subimage, "unknown image type %i", mem_thumb->type);
+        _errorfmt(this, subimage, "unknown image type %i",
+                  static_cast<int>(mem_thumb->type));
         return false;
     }
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -1718,6 +1718,12 @@ _errorfmt(const RawInput* input, int subimage, const char* format,
 bool
 RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
 {
+    if (m_processor == nullptr) {
+        _errorfmt(this, subimage,
+                  "ImageInput hasn't been initialised properly");
+        return false;
+    }
+
 #if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
     if (subimage > 0) {
         // Older versions of Libraw supported a single thumbnail per image.
@@ -1726,7 +1732,7 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
     }
     int errcode = m_processor->unpack_thumb();
     if (errcode != 0) {
-        if (errcode != LIBRAW_REQUEST_FOR_NONEXISTENT_THUMBNAIL)
+        if (errcode != LIBRAW_REQUEST_FOR_NONEXISTENT_IMAGE)
             _errorfmt(this, subimage, "unpack_thumb error");
         return false;
     }
@@ -1764,7 +1770,7 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
     }
 
     if (image_type.empty()) {
-        _errorfmt(this, subimage, "unknown image type %i",
+        _errorfmt(this, subimage, "unknown image type {}",
                   static_cast<int>(mem_thumb->type));
         return false;
     }
@@ -1782,8 +1788,8 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
     } else {
         auto image_input = OIIO::ImageInput::create(image_type, false);
         if (image_input == nullptr) {
-            _errorfmt(this, subimage, "OIIO::ImageInput::create(\"%s\") error",
-                      image_type.c_str());
+            _errorfmt(this, subimage, "OIIO::ImageInput::create(\{}\") error",
+                      image_type);
             return false;
         }
 
@@ -1791,8 +1797,8 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
         bool result = image_input->valid_file(&proxy);
         if (!result) {
             _errorfmt(this, subimage,
-                      "the thumbnail is not a valid image of type \"%s\"",
-                      image_type.c_str());
+                      "the thumbnail is not a valid image of type \"{}\"",
+                      image_type);
             return false;
         }
 
@@ -1815,8 +1821,8 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
         if (!result) {
             _errorfmt(
                 this, subimage,
-                "failed to initialise an ImageInput object of type \"%s\" with the thumbnail data",
-                image_type.c_str());
+                "failed to initialise an ImageInput object of type \"{}\" with the thumbnail data",
+                image_type);
             return false;
         }
     }

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -10,7 +10,9 @@
 #include <OpenImageIO/half.h>
 
 #include <OpenImageIO/color.h>
+#include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
+#include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/strutil.h>
@@ -61,7 +63,7 @@ public:
     const char* format_name(void) const override { return "raw"; }
     int supports(string_view feature) const override
     {
-        return (feature == "exif"
+        return (feature == "exif" || feature == "thumbnail"
                 /* not yet? || feature == "iptc"*/);
     }
     bool open(const std::string& name, ImageSpec& newspec) override;
@@ -70,6 +72,7 @@ public:
     bool close() override;
     bool read_native_scanline(int subimage, int miplevel, int y, int z,
                               void* data) override;
+    bool get_thumbnail(ImageBuf& thumb, int subimage) override;
 
 private:
     bool m_process  = true;
@@ -1699,6 +1702,77 @@ RawInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
         };
         std::transform(dst, dst + length, dst, scale_func);
     }
+    return true;
+}
+
+bool
+RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
+{
+#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
+    if (subimage > 0)
+        return false;
+    int errcode = m_processor->unpack_thumb();
+#else
+    int errcode = m_processor->unpack_thumb_ex(subimage);
+#endif
+
+    if (errcode != 0)
+        return false;
+
+    libraw_processed_image_t* mem_thumb = m_processor->dcraw_make_mem_thumb(
+        &errcode);
+    if (mem_thumb == nullptr)
+        return false;
+
+    std::string image_type;
+    if (mem_thumb->type == LibRaw_image_formats::LIBRAW_IMAGE_JPEG)
+        image_type = "jpeg";
+    else if (mem_thumb->type == LibRaw_image_formats::LIBRAW_IMAGE_BITMAP)
+        image_type = "bmp";
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 22, 0)
+    else if (mem_thumb->type == LibRaw_image_formats::LIBRAW_IMAGE_JPEGXL)
+        image_type = "jpegxl";
+#endif
+
+    if (image_type.empty())
+        return false;
+
+    if (image_type == "bmp") {
+        size_t data_size = mem_thumb->width * mem_thumb->height
+                           * mem_thumb->colors;
+        if (data_size != mem_thumb->data_size)
+            return false;
+
+        ImageSpec image_spec(mem_thumb->width, mem_thumb->height,
+                             mem_thumb->colors, TypeDesc::UCHAR);
+        thumb.reset(image_spec);
+        thumb.set_pixels(thumb.roi_full(), TypeDesc::UCHAR, mem_thumb->data);
+    } else {
+        auto image_input = OIIO::ImageInput::create(image_type, false);
+        if (image_input == nullptr)
+            return false;
+
+        Filesystem::IOMemReader proxy(mem_thumb->data, mem_thumb->data_size);
+        bool result = image_input->valid_file(&proxy);
+        if (!result)
+            return false;
+
+        ImageSpec temp_spec, image_spec;
+        Filesystem::IOProxy* pp = &proxy;
+        temp_spec.attribute("oiio:ioproxy", TypeDesc::PTR, &pp);
+
+        result = image_input->open("", image_spec, temp_spec);
+        if (!result)
+            return false;
+
+        thumb.reset(image_spec);
+        result = image_input->read_image(0, 0, 0, image_spec.nchannels,
+                                         image_spec.format,
+                                         thumb.localpixels());
+        if (!result)
+            return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
This adds thumbnail support to the raw input plugin. 

Fixes #4107

This supports 3 of the 4 formats of thumbnails Libraw provides: BMP, JPEG, JPEGXL(untested). H265 is not supported, I don't know of any camera using it, and expect the code being significantly different from the other formats, given that the H265 is a movie container.

One thing I don't like about this implementation - I understand there is no way to query the number of thumbnails available in the file? We are expected to iterate, until `get_thumbnail()` returns false? If `get_thumbnail()` returns false not because there is no thumbnail for the requested index, but any other reason, we are not going to try reading past that index.

## Tests

I have tested manually with a bunch of raw images having either JPEG or BMP thumbnails. 

I have not tested the JPEGXL branch, as I'm not aware of any cameras using that for thumbnails. The code is identical to the JPEG branch though, so I'm not expecting any issues with that.

I couldn't see any unit tests around the thumbnail functionality at all. Should I add some? I assume we can't use `oiiotool` for this?

