### PR TITLE
ci: Fix testsuite/heif ref output

### DIFF
--- a/testsuite/heif/ref/out-libheif1.12-orient.txt
+++ b/testsuite/heif/ref/out-libheif1.12-orient.txt
@@ -60,10 +60,8 @@ cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
     channel list: R, G, B, A
     CICP: 9, 16, 9, 1
-    Software: "OpenImageIO 3.2.0.0dev : A50DC799B2B4CA667217608C0F82302455E5D32A"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
     oiio:ColorSpace: "srgb_rec709_scene"

--- a/testsuite/heif/ref/out-libheif1.4.txt
+++ b/testsuite/heif/ref/out-libheif1.4.txt
@@ -60,10 +60,8 @@ cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
     channel list: R, G, B, A
     CICP: 9, 16, 9, 1
-    Software: "OpenImageIO 3.2.0.0dev : A50DC799B2B4CA667217608C0F82302455E5D32A"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
     oiio:ColorSpace: "srgb_rec709_scene"

--- a/testsuite/heif/ref/out-libheif1.5.txt
+++ b/testsuite/heif/ref/out-libheif1.5.txt
@@ -60,10 +60,8 @@ cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
     channel list: R, G, B, A
     CICP: 9, 16, 9, 1
-    Software: "OpenImageIO 3.2.0.0dev : A50DC799B2B4CA667217608C0F82302455E5D32A"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
     oiio:ColorSpace: "srgb_rec709_scene"

--- a/testsuite/heif/ref/out-libheif1.9-alt2.txt
+++ b/testsuite/heif/ref/out-libheif1.9-alt2.txt
@@ -60,10 +60,8 @@ cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
     channel list: R, G, B, A
     CICP: 9, 16, 9, 1
-    Software: "OpenImageIO 3.2.0.0dev : A50DC799B2B4CA667217608C0F82302455E5D32A"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
     oiio:ColorSpace: "srgb_rec709_scene"

--- a/testsuite/heif/ref/out-libheif1.9-with-av1-alt2.txt
+++ b/testsuite/heif/ref/out-libheif1.9-with-av1-alt2.txt
@@ -60,10 +60,8 @@ cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
     channel list: R, G, B, A
     CICP: 9, 16, 9, 1
-    Software: "OpenImageIO 3.2.0.0dev : A50DC799B2B4CA667217608C0F82302455E5D32A"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
     oiio:ColorSpace: "srgb_rec709_scene"

--- a/testsuite/heif/ref/out-libheif1.9-with-av1.txt
+++ b/testsuite/heif/ref/out-libheif1.9-with-av1.txt
@@ -60,10 +60,8 @@ cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
     channel list: R, G, B, A
     CICP: 9, 16, 9, 1
-    Software: "OpenImageIO 3.2.0.0dev : A50DC799B2B4CA667217608C0F82302455E5D32A"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
     oiio:ColorSpace: "srgb_rec709_scene"

--- a/testsuite/heif/ref/out-libheif1.9.txt
+++ b/testsuite/heif/ref/out-libheif1.9.txt
@@ -60,10 +60,8 @@ cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
     channel list: R, G, B, A
     CICP: 9, 16, 9, 1
-    Software: "OpenImageIO 3.2.0.0dev : A50DC799B2B4CA667217608C0F82302455E5D32A"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
     oiio:ColorSpace: "srgb_rec709_scene"

--- a/testsuite/heif/run.py
+++ b/testsuite/heif/run.py
@@ -11,7 +11,7 @@ for f in files:
 
 command += oiiotool (os.path.join(imagedir, "test-10bit.avif") +
                      " -d uint10 --cicp \"9,16,9,1\" -o cicp_pq.avif" )
-command += info_command ("cicp_pq.avif")
+command += info_command ("cicp_pq.avif", safematch=True)
 
 files = [ "greyhounds-looking-for-a-table.heic", "sewing-threads.heic" ]
 for f in files:


### PR DESCRIPTION
PR #4880 checked in some output reference that contained version numbers, which passed in main but failed when backported to 3.1. This repairs it and makes the output suitable for any version that contains the patch.
