### PR TITLE
build: fix openjph target use

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -278,7 +278,7 @@ macro (oiio_add_all_tests)
                     FOUNDVAR OPENJPEG_FOUND
                     IMAGEDIR oiio-images URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (htj2k
-                    FOUNDVAR OPENJPH_FOUND
+                    FOUNDVAR openjph_FOUND
                     IMAGEDIR oiio-images URL "Recent checkout of OpenImageIO-images")
     oiio_add_tests (jpeg2000-j2kp4files
                     FOUNDVAR OPENJPEG_FOUND

--- a/src/jpeg2000.imageio/CMakeLists.txt
+++ b/src/jpeg2000.imageio/CMakeLists.txt
@@ -8,10 +8,7 @@ if (OPENJPEG_FOUND)
     set(_jpeg2000_libs ${OPENJPEG_LIBRARIES})
     set(_jpeg2000_defs "USE_OPENJPEG")
 
-    if (OPENJPH_FOUND)
-        list(APPEND _jpeg2000_includes ${OPENJPH_INCLUDES})
-        list(APPEND _jpeg2000_lib_dirs ${OPENJPH_LIBRARY_DIRS})
-        list(APPEND _jpeg2000_libs ${OPENJPH_LIBRARIES})
+    if (openjph_FOUND)
         list(APPEND _jpeg2000_defs "USE_OPENJPH")
     endif()
 
@@ -19,6 +16,7 @@ if (OPENJPEG_FOUND)
         INCLUDE_DIRS ${_jpeg2000_includes}
         LINK_DIRECTORIES ${_jpeg2000_lib_dirs}
         LINK_LIBRARIES ${_jpeg2000_libs}
+                       $<TARGET_NAME_IF_EXISTS:openjph>
         DEFINITIONS ${_jpeg2000_defs}
     )
 else()


### PR DESCRIPTION
PR #4875, switched to using openjph's exported cmake config instead of
our own FindOpenJPH.cmake, and in the process also renamed OpenJPH ->
openjph to follow their convention.

But I botched it, still using the old OPENJPH_LIBRARIES (etc.)
variables instead of fully switching to the correct targets exported
from their config.

This PR minimally fixes that error, re-enabling use of openjph.

Fixes #4893 