### PR TITLE
ci: Add more exceptions to when we test docs building

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ on:
       - '**.cmake'
       - '**/CMakeLists.txt'
       - '**/run.py'
+      - 'src/build-scripts/**'
+      - './*.md'
   pull_request:
     paths-ignore:
       - '**/ci.yml'
@@ -29,6 +31,8 @@ on:
       - '**.cmake'
       - '**/CMakeLists.txt'
       - '**/run.py'
+      - 'src/build-scripts/**'
+      - './*.md'
   schedule:
     # Full nightly build
     - cron: "0 8 * * *"


### PR DESCRIPTION
These additional things need not trigger a CI test build of the online documentation:

* Build scripts
* Markdown docs that aren't part of the documentation we're generating (like the main README.md, INSTALL.md, etc.)

Doing so just makes CI take longer and wastes resources.
