### PR TITLE
fix: sonar scan guard

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -177,7 +177,7 @@ jobs:
         if: inputs.coverage == '1'
         run: src/build-scripts/ci-coverage.bash
       - name: Sonar-scanner
-        if: inputs.sonar == 1
+        if: inputs.sonar == '1'
         env:
           GITHUB_TOKEN: ${{ secrets.PASSED_GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.PASSED_SONAR_TOKEN }}


### PR DESCRIPTION
We recreated the SonarCloud project to clear the 404s. This commit fixes the workflow condition by comparing to the string '1', so the Sonar scan step runs and uploads results.

## Description
Updates the GHA workflow guard so the Sonar scan actually executes:
- Change `if: inputs.sonar == 1` → `if: inputs.sonar == '1'` because `inputs.sonar` is a string (from `workflow_call` inputs).

## Tests
No unit tests added (CI-only change). Validation: run the “Analysis” workflow and confirm SonarCloud receives results.

## Checklist:
- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite.
- [ ] If I added or modified a C++ API call, I have also amended the corresponding Python bindings.
- [x] My code follows the prevailing code style of this project.
