### PR TITLE
fix(oiiotool): Use normalized path when creating wildcard path pattern

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -911,7 +911,7 @@ Filesystem::parse_pattern(const char* pattern_, int framepadding_override,
 
     // std::cout << "Format: '" << fmt << "'\n";
 
-    normalized_pattern = prefix + fmt + suffix;
+    normalized_pattern = Filesystem::generic_filepath(prefix + fmt + suffix);
     framespec          = thesequence;
 
     return true;


### PR DESCRIPTION
## Description

On Windows, using a wildcard input path containing `\` back slashes would lead to failures because it would be compared with file paths containing `/` forward slashes. Use the existing `Filesystem::generic_filepath` API which calls `path::generic_string` which normalizes the directory separator to the form that should match.

An example of the existing failure:
```
.\oiiotool.exe -v t:\render\foo_#.png --resize 160x90 -o t:\smaller_#.png

oiiotool WARNING : No frame number or views matched the wildcards
oiiotool ERROR: read : File does not exist: "t:\render\foo_#.png"
Full command line was:
> oiiotool.exe -v t:\\render\\foo_#.png --resize 160x90 -o t:\\smaller_#.png
```
Workaround - without this PR you would have to use an input path containing `/`:
```
.\oiiotool.exe -v t:/render/foo_#.png --resize 160x90 -o t:\smaller_#.png
Reading t:/render/foo_0001.png
Writing t:\smaller_0001.png
Reading t:/render/foo_0002.png
Writing t:\smaller_0002.png
```

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
