### PR TITLE
Add type hints to Python docs

### DIFF
--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -72,7 +72,7 @@ described in detail in Section :ref:`sec-typedesc`, is replicated for Python.
     These names are also exported to the `OpenImageIO` namespace.
 
 
-.. py::method:: TypeDesc.TypeDesc(typename='unknown')
+.. py:method:: TypeDesc.TypeDesc(typename='unknown')
 
     Construct a `TypeDesc` object the easy way: from a string description.
     If the type name is omitted, it will default to`UNKNOWN`.
@@ -97,7 +97,7 @@ described in detail in Section :ref:`sec-typedesc`, is replicated for Python.
 
 
 
-.. py::method:: TypeDesc.TypeDesc(basetype=oiio.UNKNOWN, aggregate=oiio.SCALAR, vecsemantics=NOSEMANTICS, arraylen=0)
+.. py:method:: TypeDesc.TypeDesc(basetype=oiio.UNKNOWN, aggregate=oiio.SCALAR, vecsemantics=NOSEMANTICS, arraylen=0)
 
     Construct a `TypeDesc` object the hard way: from individual enum tokens
     describing the base type, aggregate class, semantic hints, and array length.
@@ -751,7 +751,7 @@ function that opens a file and prints all the relevant header information:
     from OpenImageIO import ImageInput
 
     # Print the contents of an ImageSpec
-    def print_imagespec (spec, subimage=0, mip=0) :
+    def print_imagespec (spec: ImageSpec, subimage: int=0, mip: int=0) :
         if spec.depth <= 1 :
             print ("  resolution %dx%d%+d%+d" % (spec.width, spec.height, spec.x, spec.y))
         else :
@@ -787,7 +787,7 @@ function that opens a file and prints all the relevant header information:
                 print (" ", i.name, "=", i.value)
 
 
-    def poor_mans_iinfo (filename) :
+    def poor_mans_iinfo (filename: str) :
         input = ImageInput.open (filename)
         if not input :
             print ('Could not open "' + filename + '"')
@@ -1243,7 +1243,7 @@ Example: Reading pixel values from a file to find min/max
     #!/usr/bin/env python 
     import OpenImageIO as oiio
     
-    def find_min_max (filename) :
+    def find_min_max (filename: str) :
         input = ImageInput.open (filename)
         if not input :
             print ('Could not open "' + filename + '"')
@@ -4041,8 +4041,8 @@ following boilerplate:
     # Create an ImageBuf holding a n image of constant color, given the
     # resolution, data format (defaulting to UINT8), fill value, and image
     # origin.
-    def make_constimage (xres, yres, chans=3, format=oiio.UINT8, value=(0,0,0),
-                         xoffset=0, yoffset=0) :
+    def make_constimage (xres: int, yres: int, chans: int=3, format: TypeDesc=oiio.UINT8, value: tuple[int, int, int]=(0,0,0),
+                         xoffset: int=0, yoffset: int=0) -> ImageBuf:
         spec = ImageSpec (xres,yres,chans,format)
         spec.x = xoffset
         spec.y = yoffset
@@ -4062,7 +4062,7 @@ what to do with it next.
 
     # Save an ImageBuf to a given file name, with optional forced image format
     # and error handling.
-    def write_image (image, filename, format=oiio.UNKNOWN) :
+    def write_image (image: ImageBuf, filename: str, format: TypeDesc=oiio.UNKNOWN) :
         if not image.has_error :
             image.write (filename, format)
         if image.has_error :

--- a/testsuite/docs-examples-python/src/docs-examples-imagebuf.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebuf.py
@@ -18,7 +18,7 @@
 import OpenImageIO as oiio
 import numpy as np
 
-def example1() :
+def example1() -> None:
     #
     # Example code fragment from the docs goes here.
     #

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -20,7 +20,7 @@ from OpenImageIO import *
 import numpy as np
 
 
-def example1():
+def example1() -> None:
     print("example1")
     #
     # Example code fragment from the docs goes here.
@@ -40,7 +40,7 @@ def example1():
 
 # Section: ImageBufAlgo common principles
 
-def example_output_error1():
+def example_output_error1() -> None:
     print("example_output_error1")
     fg = ImageBuf()
     bg = ImageBuf()
@@ -53,7 +53,7 @@ def example_output_error1():
     # END-imagebufalgo-output-error1
 
 
-def example_output_error2():
+def example_output_error2() -> None:
     print("example_output_error2")
     fg = ImageBuf()
     bg = ImageBuf()
@@ -69,7 +69,7 @@ def example_output_error2():
 
 # Section: Pattern Generation
 
-def example_zero():
+def example_zero() -> None:
     print("example_zero")
     A = ImageBuf("grid.exr")
     B = ImageBuf("grid.exr")
@@ -98,7 +98,7 @@ def example_zero():
     C.write("zero4.exr", "half")
 
 
-def example_fill():
+def example_fill() -> None:
     print("example_fill")
     # BEGIN-imagebufalgo-fill
     # Create a new 640x480 RGB image, with a top-to-bottom gradient
@@ -115,7 +115,7 @@ def example_fill():
     A.write("fill.exr", "half")
 
 
-def example_checker():
+def example_checker() -> None:
     print("example_checker")
     # BEGIN-imagebufalgo-checker
     # Create a new 640x480 RGB image, fill it with a two-toned gray
@@ -130,7 +130,7 @@ def example_checker():
     A.write("checker.exr", "half")
 
 
-def example_noise1():
+def example_noise1() -> None:
     print("example_noise1")
     # BEGIN-imagebufalgo-noise1
     # Create a new 256x256 field of grayscale white noise on [0,1)
@@ -156,7 +156,7 @@ def example_noise1():
     D.write("noise4.exr", "half")
 
 
-def example_noise2():
+def example_noise2() -> None:
     print("example_noise2")
     # BEGIN-imagebufalgo-noise2
     A = ImageBufAlgo.bluenoise_image()
@@ -165,7 +165,7 @@ def example_noise2():
     A.write("blue-noise.exr", "half")
 
 
-def example_point():
+def example_point() -> None:
     print("example_point")
     # BEGIN-imagebufalgo-point
     A = ImageBuf(ImageSpec(640, 480, 4, "float"))
@@ -176,7 +176,7 @@ def example_point():
     A.write("point.exr", "half")
 
 
-def example_lines():
+def example_lines() -> None:
     print("example_lines")
     # BEGIN-imagebufalgo-lines
     A = ImageBuf(ImageSpec(640, 480, 4, "float"))
@@ -188,7 +188,7 @@ def example_lines():
     A.write("lines.exr", "half")
 
 
-def example_box():
+def example_box() -> None:
     print("example_box")
     # BEGIN-imagebufalgo-box
     A = ImageBuf(ImageSpec(640, 480, 4, "float"))
@@ -201,7 +201,7 @@ def example_box():
     A.write("box.exr", "half")
 
 
-def example_text1():
+def example_text1() -> None:
     print("example_text1")
     ImgA = ImageBufAlgo.zero(ROI(0, 640, 0, 480, 0, 1, 0, 3))
     ImgB = ImageBufAlgo.zero(ROI(0, 640, 0, 480, 0, 1, 0, 3))
@@ -222,7 +222,7 @@ def example_text1():
     ImgB.write("text2.exr", "half")
 
 
-def example_text2():
+def example_text2() -> None:
     print("example_text2")
     # BEGIN-imagebufalgo-text2
     # Render text centered in the image, using text_size to find out
@@ -239,7 +239,7 @@ def example_text2():
 
 # Section: Image transformation and data movement
 
-def example_channels():
+def example_channels() -> None:
     print("example_channels")
     RGBA = ImageBuf("grid.exr")
     BRGA = ImageBuf()
@@ -270,7 +270,7 @@ def example_channels():
     BRGA.write("channels-brga.exr", "half")
 
 
-def example_channel_append():
+def example_channel_append() -> None:
     print("example_channel_append")
     Z = ImageBuf(ImageSpec(640, 480, 1, "float"))
 
@@ -282,7 +282,7 @@ def example_channel_append():
     RGBAZ.write("channel-append.exr", "half")
 
 
-def example_copy():
+def example_copy() -> None:
     print("example_copy")
     # BEGIN-imagebufalgo-copy
     # Set B to be a copy of A, but converted to float
@@ -293,7 +293,7 @@ def example_copy():
     B.write("copy.exr", "half")
 
 
-def example_crop():
+def example_crop() -> None:
     print("example_crop")
     # BEGIN-imagebufalgo-crop
     # Set B to be a 200x100 region of A starting at (50,50), trimming
@@ -305,7 +305,7 @@ def example_crop():
     B.write("crop.exr", "half")
 
 
-def example_cut():
+def example_cut() -> None:
     print("example_cut")
     # BEGIN-imagebufalgo-cut
     # Set B to be a 200x100 region of A starting at (50,50), but
@@ -317,7 +317,7 @@ def example_cut():
     B.write("cut.exr", "half")
 
 
-def example_paste():
+def example_paste() -> None:
     print("example_paste")
     # BEGIN-imagebufalgo-paste
     # Paste Fg on top of Bg, offset by (100,100)
@@ -329,7 +329,7 @@ def example_paste():
     Bg.write("paste.exr", "half")
 
 
-def example_rotate_n():
+def example_rotate_n() -> None:
     print("example_rotate_n")
     # BEGIN-imagebufalgo-rotate-n
     A = ImageBuf("grid.exr")
@@ -343,7 +343,7 @@ def example_rotate_n():
     R270.write("rotate-270.exr", "half")
 
 
-def example_flip_flop_transpose():
+def example_flip_flop_transpose() -> None:
     print("example_flip_flop_transpose")
     # BEGIN-imagebufalgo-flip-flop-transpose
     A = ImageBuf("grid.exr")
@@ -357,7 +357,7 @@ def example_flip_flop_transpose():
     B3.write("transpose.exr", "half")
 
 
-def example_reorient():
+def example_reorient() -> None:
     print("example_reorient")
     tmp = ImageBuf("grid.exr")
     tmp.specmod().attribute("Orientation", 8)
@@ -371,7 +371,7 @@ def example_reorient():
     A.write("reorient.exr", "half")
 
 
-def example_circular_shift():
+def example_circular_shift() -> None:
     print("example_circular_shift")
     # BEGIN-imagebufalgo-cshift
     A = ImageBuf("grid.exr")
@@ -380,7 +380,7 @@ def example_circular_shift():
     B.write("cshift.exr", "half")
 
 
-def example_rotate():
+def example_rotate() -> None:
     print("example_rotate")
     # BEGIN-imagebufalgo-rotate-angle
     Src = ImageBuf("grid.exr")
@@ -389,7 +389,7 @@ def example_rotate():
     Dst.write("rotate-45.tif", "uint8")
 
 
-def example_resize():
+def example_resize() -> None:
     print("example_resize")
     # BEGIN-imagebufalgo-resize
     # Resize the image to 640x480, using the default filter
@@ -400,7 +400,7 @@ def example_resize():
     Dst.write("resize.tif", "uint8")
 
 
-def example_resample():
+def example_resample() -> None:
     print("example_resample")
 
     # BEGIN-imagebufalgo-resample
@@ -412,7 +412,7 @@ def example_resample():
     Dst.write("resample.exr", "half")
 
 
-def example_fit():
+def example_fit() -> None:
     print("example_fit")
     # BEGIN-imagebufalgo-fit
     # Resize to fit into a max of 640x480, preserving the aspect ratio
@@ -423,7 +423,7 @@ def example_fit():
     Dst.write("fit.tif", "uint8")
 
 
-def example_warp():
+def example_warp() -> None:
     print("example_warp")
     # BEGIN-imagebufalgo-warp
     M = (0.7071068,  0.7071068, 0,
@@ -434,7 +434,7 @@ def example_warp():
     # END-imagebufalgo-warp
     Dst.write("warp.exr", "half")
 
-def example_demosaic():
+def example_demosaic() -> None:
     print("example_demosaic")
     # BEGIN-imagebufalgo-demosaic
     Src = ImageBuf("bayer.png")
@@ -445,7 +445,7 @@ def example_demosaic():
     Dst.write("demosaic.png")
 
 # Section: Image Arithmetic
-def example_add():
+def example_add() -> None:
     print("example_add")
     # BEGIN-imagebufalgo-add
     # Add images A and B
@@ -459,7 +459,7 @@ def example_add():
     Sum.write("add.exr", "half")
     Sum_cspan.write("add_cspan.exr", "half")
 
-def example_sub():
+def example_sub() -> None:
     print("example_sub")
     # BEGIN-imagebufalgo-sub
     A = ImageBuf("A.exr")
@@ -468,7 +468,7 @@ def example_sub():
     # END-imagebufalgo-sub
     Diff.write("sub.exr", "half")
 
-def example_absdiff():
+def example_absdiff() -> None:
     print("example_absdiff")
     # BEGIN-imagebufalgo-absdiff
     A = ImageBuf("A.exr")
@@ -477,7 +477,7 @@ def example_absdiff():
     # END-imagebufalgo-absdiff
     Diff.write("absdiff.exr", "half")
 
-def example_abs():
+def example_abs() -> None:
     print("example_abs")
     # BEGIN-imagebufalgo-absolute
     A = ImageBuf("grid.exr")
@@ -485,7 +485,7 @@ def example_abs():
     # END-imagebufalgo-absolute
     Abs.write("abs.exr", "half")
 
-def example_scale():
+def example_scale() -> None:
     print("example_scale")
     # BEGIN-imagebufalgo-scale
     # Pixel-by-pixel multiplication of all channels of one image A by the single channel of the other image
@@ -495,7 +495,7 @@ def example_scale():
     #END-imagebufalgo-scale
     Product.write("scale.exr", "half")
 
-def example_mul():
+def example_mul() -> None:
     print("example_mul")
     # BEGIN-imagebufalgo-mul
     # Pixel-by-pixel, channel-by-channel multiplication of A and B
@@ -508,7 +508,7 @@ def example_mul():
     # END-imagebufalgo-mul
     Product.write("mul.exr", "half")
 
-def example_div():
+def example_div() -> None:
     print("example_div")
     # BEGIN-imagebufalgo-div
     # Pixel-by-pixel, channel-by-channel division of A by B
@@ -531,7 +531,7 @@ def example_div():
 
 # Section: Image enhancement / restoration
 
-def example_fixNonFinite():
+def example_fixNonFinite() -> None:
     print("example_fixNonFinite")
     # BEGIN-imagebufalgo-fixNonFinite
     Src = ImageBuf("with_nans.tif")
@@ -541,7 +541,7 @@ def example_fixNonFinite():
     # fixing the nans seems nondeterministic - so not writing out the image
     # Src.write("with_nans_fixed.tif")
 
-def example_fillholes_pushpull():
+def example_fillholes_pushpull() -> None:
     print("example_fillholes_pushpull")
     # BEGIN-imagebufalgo-fillholes_pushpull
     Src = ImageBuf("checker_with_alpha.exr")
@@ -550,7 +550,7 @@ def example_fillholes_pushpull():
     Filled.write("checker_with_alpha_filled.exr")
 
 
-def example_median_filter():
+def example_median_filter() -> None:
     print("example_median_filter")
     # BEGIN-imagebufalgo-median_filter
     Noisy = ImageBuf("tahoe.tif")
@@ -559,7 +559,7 @@ def example_median_filter():
     Clean.write("tahoe_median_filter.tif")
 
 
-def example_unsharp_mask():
+def example_unsharp_mask() -> None:
     print("example_unsharp_mask")
     # BEGIN-imagebufalgo-unsharp_mask
     Blurry = ImageBuf("tahoe.tif")
@@ -575,7 +575,7 @@ def example_unsharp_mask():
 
 # Section: Import / export
 
-def example_make_texture():
+def example_make_texture() -> None:
     print("example_make_texture")
     # BEGIN-imagebufalgo-make-texture
     Input = ImageBuf("grid.exr")

--- a/testsuite/docs-examples-python/src/docs-examples-imagecache.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagecache.py
@@ -18,7 +18,7 @@
 import OpenImageIO as oiio
 import numpy as np
 
-def example1() :
+def example1() -> None:
     #
     # Example code fragment from the docs goes here.
     #

--- a/testsuite/docs-examples-python/src/docs-examples-imageinput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageinput.py
@@ -18,7 +18,7 @@
 import OpenImageIO as oiio
 import numpy as np
 
-def example1() :
+def example1() -> None:
     #
     # Example code fragment from the docs goes here.
     #
@@ -37,7 +37,7 @@ def example1() :
 
 # BEGIN-imageinput-simple
 import OpenImageIO as oiio
-def simple_read():
+def simple_read() -> None:
     filename = "tahoe.tif"
 
     inp = oiio.ImageInput.open(filename)
@@ -51,7 +51,7 @@ def simple_read():
 # END-imageinput-simple
 
 
-def scanlines_read() :
+def scanlines_read() -> None:
     filename = "scanlines.tif"
 
     # BEGIN-imageinput-scanlines
@@ -66,7 +66,7 @@ def scanlines_read() :
     inp.close ()
     # END-imageinput-scanlines
 
-def tiles_read() :
+def tiles_read() -> None:
     filename = "tiled.tif"
 
      # BEGIN-imageinput-tiles
@@ -86,7 +86,7 @@ def tiles_read() :
     # END-imageinput-tiles
 
 
-def unassociated_alpha():
+def unassociated_alpha() -> None:
     filename = "unpremult.tif"
 
     # BEGIN-imageinput-unassociatedalpha
@@ -104,7 +104,7 @@ def unassociated_alpha():
         print("pixels holds associated alpha")
     # END-imageinput-unassociatedalpha
 
-def error_checking():
+def error_checking() -> None:
 # BEGIN-imageinput-errorchecking
     import OpenImageIO as oiio
     import numpy as np

--- a/testsuite/docs-examples-python/src/docs-examples-imageioapi.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageioapi.py
@@ -18,7 +18,7 @@
 import OpenImageIO as oiio
 import numpy as np
 
-def example1() :
+def example1() -> None:
     #
     # Example code fragment from the docs goes here.
     #

--- a/testsuite/docs-examples-python/src/docs-examples-imageoutput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageoutput.py
@@ -18,7 +18,7 @@
 import OpenImageIO as oiio
 import numpy as np
 
-def example1() :
+def example1() -> None:
     #
     # Example code fragment from the docs goes here.
     #
@@ -40,7 +40,7 @@ def example1() :
 import OpenImageIO as oiio
 import numpy as np
 
-def simple_write() :
+def simple_write() -> None:
     filename = "simple.tif"
     xres = 320
     yres = 240
@@ -56,7 +56,7 @@ def simple_write() :
 # END-imageoutput-simple
 
 
-def scanlines_write() :
+def scanlines_write() -> None:
     filename = "scanlines.tif"
     xres = 320
     yres = 240
@@ -77,7 +77,7 @@ def scanlines_write() :
         # END-imageoutput-scanlines
 
 
-def tiles_write() :
+def tiles_write() -> None:
     filename = "tiles.tif"
     xres = 320
     yres = 240

--- a/testsuite/docs-examples-python/src/docs-examples-texturesys.py
+++ b/testsuite/docs-examples-python/src/docs-examples-texturesys.py
@@ -18,7 +18,7 @@
 import OpenImageIO as oiio
 import numpy as np
 
-def example1() :
+def example1() -> None:
     #
     # Example code fragment from the docs goes here.
     #

--- a/testsuite/docs-examples-python/src/docs-examples-writingplugins.py
+++ b/testsuite/docs-examples-python/src/docs-examples-writingplugins.py
@@ -18,7 +18,7 @@
 import OpenImageIO as oiio
 import numpy as np
 
-def example1() :
+def example1() -> None:
     #
     # Example code fragment from the docs goes here.
     #

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -48,7 +48,7 @@ tmpdir = os.path.abspath (tmpdir)
 redirect = " >> out.txt "
 wrapper_cmd = ""
 
-def make_relpath (path, start=os.curdir):
+def make_relpath (path: str, start: str=os.curdir) -> str:
     "Wrapper around os.path.relpath which always uses '/' as the separator."
     p = os.path.relpath (path, start)
     return p if platform.system() != 'Windows' else p.replace ('\\', '/')
@@ -82,7 +82,7 @@ if str(mytest).endswith('.batch') :
 test_source_dir = os.getenv('OIIO_TESTSUITE_SRC',
                             os.path.join(OIIO_TESTSUITE_ROOT, mytest))
 
-def oiio_app (app):
+def oiio_app (app: str) -> str:
     if (platform.system () != 'Windows' or options.devenv_config == ""):
         cmd = os.path.join(OIIO_BUILD_ROOT, "bin", app) + " "
     else:
@@ -145,7 +145,7 @@ if platform.system() == 'Windows' :
     # if not os.path.exists("../common") :
     #     shutil.copytree ("../../testsuite/common", "..")
 else :
-    def newsymlink(src, dst):
+    def newsymlink(src: str, dst: str):
         print("newsymlink", src, dst)
         # os.path.exists returns False for broken symlinks, so remove if thats the case
         if os.path.islink(dst):
@@ -176,7 +176,7 @@ else :
 # a non-zero value and writes the differences to "diff_file".
 # Based on the command-line interface to difflib example from the Python
 # documentation
-def text_diff (fromfile, tofile, diff_file=None):
+def text_diff (fromfile: str, tofile: str, diff_file: str=None) -> int:
     import time
     try:
         fromdate = time.ctime (os.stat (fromfile).st_mtime)
@@ -208,7 +208,7 @@ def text_diff (fromfile, tofile, diff_file=None):
     return 1
 
 
-def run_app(app, silent=False, concat=True):
+def run_app(app: str, silent: bool=False, concat: bool=True) -> str:
     command = app
     if not silent:
         command += redirect
@@ -220,9 +220,9 @@ def run_app(app, silent=False, concat=True):
 # Construct a command that will print info for an image, appending output to
 # the file "out.txt".  If 'safematch' is nonzero, it will exclude printing
 # of fields that tend to change from run to run or release to release.
-def info_command (file, extraargs="", safematch=False, hash=True,
-                  verbose=True, silent=False, concat=True, failureok=False,
-                  info_program="oiiotool") :
+def info_command (file: str, extraargs: str="", safematch: bool=False, hash: bool=True,
+                  verbose: bool=True, silent: bool=False, concat: bool=True, failureok: bool=False,
+                  info_program: str="oiiotool") -> str:
     args = ""
     if info_program == "oiiotool" :
         args += " --info"
@@ -247,7 +247,7 @@ def info_command (file, extraargs="", safematch=False, hash=True,
 # the file "out.txt".  We allow a small number of pixels to have up to
 # 1 LSB (8 bit) error, it's very hard to make different platforms and
 # compilers always match to every last floating point bit.
-def diff_command (fileA, fileB, extraargs="", silent=False, concat=True) :
+def diff_command (fileA: str, fileB: str, extraargs: str="", silent: bool=False, concat: bool=True) -> str :
     command = (oiio_app("idiff") + "-a"
                + " -fail " + str(failthresh)
                + " -failpercent " + str(failpercent)
@@ -266,9 +266,9 @@ def diff_command (fileA, fileB, extraargs="", silent=False, concat=True) :
 
 # Construct a command that will create a texture, appending console
 # output to the file "out.txt".
-def maketx_command (infile, outfile, extraargs="",
-                    showinfo=False, showinfo_extra="",
-                    silent=False, concat=True) :
+def maketx_command (infile: str, outfile: str, extraargs: str="",
+                    showinfo: bool=False, showinfo_extra: str="",
+                    silent: str=False, concat: str=True) -> str :
     command = (oiio_app("maketx")
                + " " + make_relpath(infile,tmpdir)
                + " " + extraargs
@@ -289,9 +289,9 @@ def maketx_command (infile, outfile, extraargs="",
 # correctly).  If testwrite is nonzero, also iconvert the file to make a
 # copy (tests writing that format), and then idiff to make sure it
 # matches the original.
-def rw_command (dir, filename, testwrite=True, use_oiiotool=False, extraargs="",
-                preargs="", idiffextraargs="", output_filename="",
-                safematch=False, printinfo=True) :
+def rw_command (dir: str, filename: str, testwrite: bool=True, use_oiiotool: bool=False, extraargs: str="",
+                preargs: str="", idiffextraargs: str="", output_filename: str="",
+                safematch: bool=False, printinfo: bool=True) -> str:
     fn = make_relpath (dir + "/" + filename, tmpdir)
     if printinfo :
         cmd = info_command (fn, safematch=safematch)
@@ -317,7 +317,7 @@ def rw_command (dir, filename, testwrite=True, use_oiiotool=False, extraargs="",
 
 
 # Construct a command that will testtex
-def testtex_command (file, extraargs="", silent=False, concat=True) :
+def testtex_command (file: str, extraargs: str="", silent: bool=False, concat: bool=True) -> str:
     cmd = oiio_app("testtex") + " " + file + " " + extraargs + " "
     if not silent :
         cmd += redirect
@@ -327,7 +327,7 @@ def testtex_command (file, extraargs="", silent=False, concat=True) :
 
 
 # Construct a command that will run iconvert and append its output to out.txt
-def iconvert (args, silent=False, concat=True, failureok=False) :
+def iconvert (args: str, silent: bool=False, concat: bool=True, failureok: bool=False) -> str:
     cmd = (oiio_app("iconvert") + " " + args)
     if not silent :
         cmd += redirect
@@ -339,7 +339,7 @@ def iconvert (args, silent=False, concat=True, failureok=False) :
 
 
 # Construct a command that will run oiiotool and append its output to out.txt
-def oiiotool (args, silent=False, concat=True, failureok=False) :
+def oiiotool (args: str, silent: bool=False, concat: bool=True, failureok: bool=False) -> str:
     cmd = (oiio_app("oiiotool") + " " + args)
     if not silent :
         cmd += redirect
@@ -356,7 +356,7 @@ def oiiotool (args, silent=False, concat=True, failureok=False) :
 # the identical name, and if that fails, it will look for alternatives of
 # the form "basename-*.ext" (or ANY match in the ref directory, if anymatch
 # is True).
-def checkref (name, refdirlist) :
+def checkref (name: str, refdirlist: list[str]) -> tuple[bool, str]:
     # Break the output into prefix+extension
     (prefix, extension) = os.path.splitext(name)
     ok = 0
@@ -398,7 +398,7 @@ def checkref (name, refdirlist) :
 # in 'ref/'.  If all outputs match their reference copies, return 0
 # to pass.  If any outputs do not match their references return 1 to
 # fail.
-def runtest (command, outputs, failureok=0) :
+def runtest (command: str, outputs: list[str], failureok: int=0) -> int :
     err = 0
 #    print ("working dir = " + tmpdir)
     os.chdir (srcdir)


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->
Closes #4752

Add Python type hints into documentation, in places where example code defines a function. That ended up being just `src/doc/pythonbindings.rst`. I also updated `testsuite/runtest.py` and the functions in `testsuite/docs-examples-python/src/docs-examples-*.py`.

While I was in `pythonbindings.rst`, I noticed a couple places with `py::method` (note the double colon). These lines didn't render in the docs, so I removed the extra colon to match other usage.


## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

I locally built the docs to make sure html looks good. I ran the tests with `ctest` and the tests ran, so I'm taking that as a sign that `runtest.py` still works.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
