### PR TITLE
build: Update autobuild defaults for some dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
             pybind11_ver: v2.9.0
             setenvs: export FREETYPE_VERSION=VER-2-12-0
                             BUILD_PNG_VERSION=1.6.30
+                            WebP_BUILD_VERSION=1.5.0
           - desc: VP2022 clang13/C++17 py39 avx2 exr3.1 ocio2.3
             nametag: linux-vfx2022.clang13
             runner: ubuntu-latest
@@ -359,7 +360,7 @@ jobs:
             cxx_std: 17
             python_ver: "3.11"
             simd: "avx2,f16c"
-            fmt_ver: 11.1.4
+            fmt_ver: 11.2.0
             pybind11_ver: v2.13.6
             benchmark: 1
             setenvs: export PUGIXML_VERSION=v1.15
@@ -481,17 +482,17 @@ jobs:
             cc_compiler: gcc-13
             cxx_compiler: g++-13
             cxx_std: 20
-            fmt_ver: 11.2.0
+            fmt_ver: 12.0.0
             opencolorio_ver: v2.4.2
             openexr_ver: v3.4.0
-            pybind11_ver: v3.0.0
+            pybind11_ver: v3.0.1
             python_ver: "3.12"
             simd: avx2,f16c
-            setenvs: export LIBJPEGTURBO_VERSION=3.1.1
+            setenvs: export LIBJPEGTURBO_VERSION=3.1.2
                             LIBPNG_VERSION=v1.6.50
                             LIBRAW_VERSION=0.21.4
-                            LIBTIFF_VERSION=v4.7.0
-                            OPENJPEG_VERSION=v2.5.3
+                            LIBTIFF_VERSION=v4.7.1
+                            OPENJPEG_VERSION=v2.5.4
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
@@ -541,9 +542,9 @@ jobs:
             python_ver: "3.10"
             simd: avx2,f16c
             setenvs: export OpenImageIO_BUILD_LOCAL_DEPS=all
-                            LIBJPEGTURBO_VERSION=3.0.4
-                            LIBRAW_VERSION=0.21.3
-                            OPENJPEG_VERSION=v2.4.0
+                            OpenImageIO_DEPENDENCY_BUILD_VERBOSE=ON
+                            LIBRAW_VERSION=0.21.4
+                            OPENJPEG_VERSION=v2.5.4
                             PTEX_VERSION=v2.4.2
                             PUGIXML_VERSION=v1.14
                             WEBP_VERSION=v1.4.0
@@ -589,16 +590,16 @@ jobs:
             cc_compiler: gcc-14
             cxx_compiler: g++-14
             cxx_std: 20
-            fmt_ver: 11.2.0
+            fmt_ver: 12.0.0
             opencolorio_ver: v2.4.2
             openexr_ver: v3.4.0
-            pybind11_ver: v3.0.0
+            pybind11_ver: v3.0.1
             python_ver: "3.12"
-            setenvs: export LIBJPEGTURBO_VERSION=3.1.1
+            setenvs: export LIBJPEGTURBO_VERSION=3.1.2
                             LIBPNG_VERSION=v1.6.50
                             LIBRAW_VERSION=0.21.4
-                            LIBTIFF_VERSION=v4.7.0
-                            OPENJPEG_VERSION=v2.5.3
+                            LIBTIFF_VERSION=v4.7.1
+                            OPENJPEG_VERSION=v2.5.4
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
@@ -610,16 +611,16 @@ jobs:
             cc_compiler: clang-18
             cxx_compiler: clang++-18
             cxx_std: 20
-            fmt_ver: 11.2.0
+            fmt_ver: 12.0.0
             opencolorio_ver: v2.4.2
             openexr_ver: v3.4.0
-            pybind11_ver: v3.0.0
+            pybind11_ver: v3.0.1
             python_ver: "3.12"
-            setenvs: export LIBJPEGTURBO_VERSION=3.1.0
+            setenvs: export LIBJPEGTURBO_VERSION=3.1.2
                             LIBPNG_VERSION=v1.6.50
                             LIBRAW_VERSION=0.21.4
-                            LIBTIFF_VERSION=v4.7.0
-                            OPENJPEG_VERSION=v2.5.3
+                            LIBTIFF_VERSION=v4.7.1
+                            OPENJPEG_VERSION=v2.5.4
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * libjpeg >= 8 (tested through jpeg9e), or libjpeg-turbo >= 2.1 (tested
    through 3.1)
  * zlib >= 1.2.7 (tested through 1.3.1)
- * [fmtlib](https://github.com/fmtlib/fmt) >= 7.0 (tested through 11.2 and master).
+ * [fmtlib](https://github.com/fmtlib/fmt) >= 7.0 (tested through 12.0 and master).
    If not found at build time, this will be automatically downloaded unless
    the build sets `-DBUILD_MISSING_FMT=OFF`.
  * [Robin-map](https://github.com/Tessil/robin-map) (unknown minimum, tested
@@ -51,7 +51,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for a wide variety of video formats:
      * ffmpeg >= 4.0 (tested through 8.0)
  * If you want support for jpeg 2000 images:
-     * OpenJpeg >= 2.0 (tested through 2.5.3; we recommend 2.4 or higher
+     * OpenJpeg >= 2.0 (tested through 2.5.4; we recommend 2.4 or higher
        for multithreading support)
  * If you want support for OpenVDB files:
      * OpenVDB >= 9.0 (tested through 12.1).
@@ -59,12 +59,12 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * TBB >= 2018 (tested through 2021 and OneTBB)
  * If you want support for converting to and from OpenCV data structures,
    or for capturing images from a camera:
-     * OpenCV 4.x (tested through 4.11)
+     * OpenCV 4.x (tested through 4.12)
  * If you want support for GIF images:
      * giflib >= 5.0 (tested through 5.2.2)
  * If you want support for HEIF/HEIC or AVIF images:
      * libheif >= 1.11 (1.16 required for correct orientation support,
-       tested through 1.19.8)
+       tested through 1.20.2)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.
  * If you want support for DICOM medical image files:
      * DCMTK >= 3.6.1 (tested through 3.6.9)
@@ -78,10 +78,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * libultrahdr >= 1.3 (tested through 1.4)
  * If you want support for JPEG XL images:
      * libjxl >= 0.10.1 (tested through 0.11.1)
- * If you want support for "Ultra HDR" inside JPEG images:
-     * libuhdr >= 1.3 (tested through 1.4)
  * If you want support for j2c files:
-     * OpenJPH >= 0.21 (tested through 0.22)
+     * OpenJPH >= 0.21.2 (tested through 0.23)
  * We use PugiXML for XML parsing. There is a version embedded in the OIIO
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distributions with policies against

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ SKBUILD_CMAKE_ARGS = "-DLINKSTATIC=1"
 # Suppress warnings that cause linux cibuildwheel build to fail
 CXXFLAGS = "-Wno-error=stringop-overflow -Wno-pragmas"
 SKBUILD_CMAKE_BUILD_TYPE = "MinSizeRel"
+# FIXME: Getting build problems when using WebP 1.6.0, so hold it back
+WebP_BUILD_VERSION = "1.5.0"
 
 [tool.cibuildwheel.windows.environment]
 SKBUILD_CMAKE_BUILD_TYPE = "MinSizeRel"

--- a/src/build-scripts/build_OpenJPEG.bash
+++ b/src/build-scripts/build_OpenJPEG.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of OpenJPEG to download if we don't have it yet
 OPENJPEG_REPO=${OPENJPEG_REPO:=https://github.com/uclouvain/openjpeg.git}
-OPENJPEG_VERSION=${OPENJPEG_VERSION:=v2.5.2}
+OPENJPEG_VERSION=${OPENJPEG_VERSION:=v2.5.4}
 
 # Where to put OpenJPEG repo source (default to the ext area)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of libjpeg-turbo to download if we don't have it yet
 LIBJPEGTURBO_REPO=${LIBJPEGTURBO_REPO:=https://github.com/libjpeg-turbo/libjpeg-turbo.git}
-LIBJPEGTURBO_VERSION=${LIBJPEGTURBO_VERSION:=3.0.4}
+LIBJPEGTURBO_VERSION=${LIBJPEGTURBO_VERSION:=3.1.2}
 
 # Where to put libjpeg-turbo repo source (default to the ext area)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/build-scripts/build_libraw.bash
+++ b/src/build-scripts/build_libraw.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Which LibRaw to retrieve, how to build it
 LIBRAW_REPO=${LIBRAW_REPO:=https://github.com/LibRaw/LibRaw.git}
-LIBRAW_VERSION=${LIBRAW_VERSION:=0.21.3}
+LIBRAW_VERSION=${LIBRAW_VERSION:=0.21.4}
 
 # Where to install the final results
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -13,7 +13,7 @@ LIBTIFF_REPO=${LIBTIFF_REPO:=https://gitlab.com/libtiff/libtiff.git}
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 LIBTIFF_BUILD_DIR=${LIBTIFF_BUILD_DIR:=${LOCAL_DEPS_DIR}/libtiff}
 LIBTIFF_INSTALL_DIR=${LIBTIFF_INSTALL_DIR:=${PWD}/ext/dist}
-LIBTIFF_VERSION=${LIBTIFF_VERSION:=v4.6.0}
+LIBTIFF_VERSION=${LIBTIFF_VERSION:=v4.7.1}
 LIBTIFF_BUILD_TYPE=${LIBTIFF_BUILD_TYPE:=Release}
 if [[ `uname` == "Linux" ]] ; then
     LIBTIFF_CXX_FLAGS=${LIBTIFF_CXX_FLAGS:="-O3 -Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings"}
@@ -42,6 +42,8 @@ if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
                -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
                -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \
                -DBUILD_SHARED_LIBS=${LIBTIFF_BUILD_SHARED_LIBS:-ON} \
+               -Dtiff-tools=${LIBTIFF_BUILD_TESTS:-OFF} \
+               -Dtiff-contrib=${LIBTIFF_BUILD_TESTS:-OFF} \
                -Dtiff-tests=${LIBTIFF_BUILD_TESTS:-OFF} \
                -Dtiff-docs=${LIBTIFF_BUILD_TESTS:-OFF} \
                -Dlibdeflate=ON \

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of pugixml to download if we don't have it yet
 PUGIXML_REPO=${PUGIXML_REPO:=https://github.com/zeux/pugixml.git}
-PUGIXML_VERSION=${PUGIXML_VERSION:=v1.11.4}
+PUGIXML_VERSION=${PUGIXML_VERSION:=v1.15}
 
 # Where to put pugixml repo source (default to the ext area)
 PUGIXML_SRC_DIR=${PUGIXML_SRC_DIR:=${PWD}/ext/pugixml}

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of pybind11 to download if we don't have it yet
 PYBIND11_REPO=${PYBIND11_REPO:=https://github.com/pybind/pybind11.git}
-PYBIND11_VERSION=${PYBIND11_VERSION:=v3.0.0}
+PYBIND11_VERSION=${PYBIND11_VERSION:=v3.0.1}
 
 # Where to put pybind11 repo source (default to the ext area)
 PYBIND11_SRC_DIR=${PYBIND11_SRC_DIR:=${PWD}/ext/pybind11}

--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of webp to download if we don't have it yet
 WEBP_REPO=${WEBP_REPO:=https://github.com/webmproject/libwebp.git}
-WEBP_VERSION=${WEBP_VERSION:=v1.4.0}
+WEBP_VERSION=${WEBP_VERSION:=v1.6.0}
 
 # Where to put webp repo source (default to the ext area)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -34,6 +34,10 @@ $OpenImageIO_ROOT/bin/oiiotool --unittest --list-formats --threads 0 \
 echo ; echo "Try unknown command:"
 $OpenImageIO_ROOT/bin/oiiotool -q --unknown || true
 
+if [[ `uname -s` == "Linux" ]] ; then
+    echo ; echo "ldd oiiotool:"
+    ldd $OpenImageIO_ROOT/bin/oiiotool
+fi
 
 #
 # Full test suite

--- a/src/cmake/build_TIFF.cmake
+++ b/src/cmake/build_TIFF.cmake
@@ -6,11 +6,11 @@
 # TIFF by hand!
 ######################################################################
 
-set_cache (TIFF_BUILD_VERSION 4.6.0 "TIFF version for local builds")
+set_cache (TIFF_BUILD_VERSION 4.7.1 "TIFF version for local builds")
 set (TIFF_GIT_REPOSITORY "https://gitlab.com/libtiff/libtiff.git")
-set (TIFF_GIT_TAG "v${TIFF_BUILD_VERSION}")
+set_cache (TIFF_GIT_TAG "v${TIFF_BUILD_VERSION}" "Git branch or tag")
 set_cache (TIFF_BUILD_SHARED_LIBS  ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
-           DOC "Should a local TIFF build, if necessary, build shared libraries" ADVANCED)
+           "Should a local TIFF build, if necessary, build shared libraries" ADVANCED)
 
 # We need libdeflate to build libtiff
 checked_find_package (libdeflate REQUIRED

--- a/src/cmake/build_WebP.cmake
+++ b/src/cmake/build_WebP.cmake
@@ -6,7 +6,7 @@
 # WebP by hand!
 ######################################################################
 
-set_cache (WebP_BUILD_VERSION 1.4.0 "WebP version for local builds")
+set_cache (WebP_BUILD_VERSION 1.6.0 "WebP version for local builds")
 set (WebP_GIT_REPOSITORY "https://github.com/webmproject/libwebp.git")
 set (WebP_GIT_TAG "v${WebP_BUILD_VERSION}")
 

--- a/src/cmake/build_libjpeg-turbo.cmake
+++ b/src/cmake/build_libjpeg-turbo.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/Academ SoftwareFoundation/OpenImageIO
 
-set_cache (libjpeg-turbo_BUILD_VERSION 3.0.4 "libjpeg-turbo version for local builds")
+set_cache (libjpeg-turbo_BUILD_VERSION 3.1.2 "libjpeg-turbo version for local builds")
 set (libjpeg-turbo_GIT_REPOSITORY "https://github.com/libjpeg-turbo/libjpeg-turbo")
 set (libjpeg-turbo_GIT_TAG "${libjpeg-turbo_BUILD_VERSION}")
 set_cache (libjpeg-turbo_BUILD_SHARED_LIBS OFF #${LOCAL_BUILD_SHARED_LIBS_DEFAULT}

--- a/src/cmake/build_pybind11.cmake
+++ b/src/cmake/build_pybind11.cmake
@@ -6,7 +6,7 @@
 # pybind11 by hand!
 ######################################################################
 
-set_cache (pybind11_BUILD_VERSION 3.0.0 "pybind11 version for local builds")
+set_cache (pybind11_BUILD_VERSION 3.0.1 "pybind11 version for local builds")
 set (pybind11_GIT_REPOSITORY "https://github.com/pybind/pybind11")
 set (pybind11_GIT_TAG "v${pybind11_BUILD_VERSION}")
 set_cache (pybind11_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}


### PR DESCRIPTION
Raise the version we "autobuild" for some packages:
* OpenJPEG 2.5.2 -> 2.5.4
* pybind11 3.0.0 -> 3.0.1
* libtiff 4.6.0 -> 4.7.1
* webp 1.4.0 -> 1.6.0
* libjpeg-turbo 3.0.4 -> 3.1.2

And some minor debugging and other aids along the way:

* After a build, on linux, do a `ldd` to verify what libraries are linked dynamically for the logs.
* Enhance build_dependency_with_cmake macro to allow optional commands: GIT_COMMIT, GIT_SHALLOW, QUIET
