### PR TITLE
cmake script to auto download and install the openjpeg dependency

### DIFF
--- a/src/cmake/build_OpenJPEG.cmake
+++ b/src/cmake/build_OpenJPEG.cmake
@@ -1,0 +1,32 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/Academ SoftwareFoundation/OpenImageIO
+
+set_cache (OpenJPEG_BUILD_VERSION 2.5.4 "OpenJPEG version for local builds")
+set (OpenJPEG_GIT_REPOSITORY "https://github.com/uclouvain/openjpeg.git")
+set (OpenJPEG_GIT_TAG "v${OpenJPEG_BUILD_VERSION}")
+set_cache (OpenJPEG_BUILD_SHARED_LIBS OFF #${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
+           DOC "Should a local OpenJPEG build, if necessary, build shared libraries" ADVANCED)
+
+string (MAKE_C_IDENTIFIER ${OpenJPEG_BUILD_VERSION} OpenJPEG_VERSION_IDENT)
+
+build_dependency_with_cmake(OpenJPEG
+    VERSION         ${OpenJPEG_BUILD_VERSION}
+    GIT_REPOSITORY  ${OpenJPEG_GIT_REPOSITORY}
+    GIT_TAG         ${OpenJPEG_GIT_TAG}
+    CMAKE_ARGS
+        -DBUILD_CODEC=OFF 
+
+
+    )
+# Set some things up that we'll need for a subsequent find_package to work
+set (OpenJPEG_ROOT ${OpenJPEG_LOCAL_INSTALL_DIR})
+
+
+# Signal to caller that we need to find again at the installed location
+set (OpenJPEG_REFIND TRUE)
+set (OpenJPEG_REFIND_ARGS CONFIG)
+
+if (OpenJPEG_BUILD_SHARED_LIBS)
+    install_local_dependency_libs (OpenJPEG OpenJPEG)
+endif ()


### PR DESCRIPTION
## Description

sub task of : https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4387
for sep 2025 dev days.

Adding a autobuild cmake file for openjpeg.

Matching the latest version like in the yet unmerged: 
https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4910

## Tests

I built it locally - I can see it's downloading the files from github and building them.
I can run the tests.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
