### PR TITLE
Update fmt version to 12.0.0

### DIFF
--- a/src/cmake/build_fmt.cmake
+++ b/src/cmake/build_fmt.cmake
@@ -6,7 +6,7 @@
 # fmt by hand!
 ######################################################################
 
-set_cache (fmt_BUILD_VERSION 10.2.1 "fmt version for local builds")
+set_cache (fmt_BUILD_VERSION 12.0.0 "fmt version for local builds")
 set (fmt_GIT_REPOSITORY "https://github.com/fmtlib/fmt")
 set (fmt_GIT_TAG "${fmt_BUILD_VERSION}")
 # Note: fmt doesn't put "v" in front of version for its git tags


### PR DESCRIPTION
Upgrading fmt dependency to 12.0.0.

Current fmt version is not compatible with Clang 21.1.2 (Maybe older too)