### PR TITLE
fix(api): Restore definition of OIIO_NAMESPACE_USING macro

### DIFF
--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -144,6 +144,7 @@ namespace OIIO = @PROJ_NAMESPACE@;
 // Macros to declare things in the current version's inline namespace.
 #define OIIO_NAMESPACE_BEGIN namespace @PROJ_NAMESPACE@ { inline namespace @PROJ_VERSION_NAMESPACE@ {
 #define OIIO_NAMESPACE_END } }
+#define OIIO_NAMESPACE_USING using namespace OIIO;
 #define OIIO_CURRENT_NAMESPACE @PROJ_NAMESPACE@::@PROJ_VERSION_NAMESPACE@
 
 #include <OpenImageIO/nsversions.h>


### PR DESCRIPTION
Version 3.1 removed this definition, thinking it was safe because we didn't use it anywhere, didn't document it, and what it expands to (`using namespace OIIO`) isn't any longer than the macro name, so is pointless to use.

But downstream projects did use it. Oops.
