### PR TITLE
feat: Support display color space interop IDs in I/O

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -35,6 +35,7 @@ public:
                               void* data) override;
 
 private:
+    std::string m_image_state_default;  // Default image state for color space
     int64_t m_padded_scanline_size;
     int m_pad_size;
     bmp_pvt::BmpFileHeader m_bmp_header;
@@ -153,6 +154,9 @@ BmpInput::open(const std::string& name, ImageSpec& newspec,
     // this behavior off.
     bool monodetect = config["bmp:monochrome_detect"].get<int>(1);
 
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
+
     ioproxy_retrieve_from_config(config);
     if (!ioproxy_use_or_open(name))
         return false;
@@ -265,7 +269,8 @@ BmpInput::open(const std::string& name, ImageSpec& newspec,
     // display, so assume it's sRGB. This is not really correct -- see the
     // comments below.
     const bool erase_other_attributes = false;
-    pvt::set_colorspace_srgb(m_spec, erase_other_attributes);
+    pvt::set_colorspace_srgb(m_spec, m_image_state_default,
+                             erase_other_attributes);
 #if 0
     if (m_dib_header.size >= WINDOWS_V4
         && m_dib_header.cs_type == CSType::CalibratedRGB) {

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -8,6 +8,8 @@
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
 
+#include "imageio_pvt.h"
+
 #include "bmp_pvt.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -262,7 +264,8 @@ BmpInput::open(const std::string& name, ImageSpec& newspec,
     // Default presumption is that a BMP file is meant to look reasonable on a
     // display, so assume it's sRGB. This is not really correct -- see the
     // comments below.
-    m_spec.attribute("oiio:ColorSpace", "srgb_rec709_scene");
+    const bool erase_other_attributes = false;
+    pvt::set_colorspace_srgb(m_spec, erase_other_attributes);
 #if 0
     if (m_dib_header.size >= WINDOWS_V4
         && m_dib_header.cs_type == CSType::CalibratedRGB) {

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -182,13 +182,14 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
         // either grayscale or printing density
         if (!std::isinf(m_cin.header.Gamma()) && m_cin.header.Gamma() != 0.0f)
             // actual gamma value is read later on
-            set_colorspace_rec709_gamma(m_spec, float(m_cin.header.Gamma()));
+            pvt::set_colorspace_rec709_gamma(m_spec,
+                                             float(m_cin.header.Gamma()));
         break;
     }
 
     // gamma exponent
     if (!std::isinf(m_cin.header.Gamma()) && m_cin.header.Gamma() != 0.0f)
-        set_colorspace_rec709_gamma(m_spec, float(m_cin.header.Gamma()));
+        pvt::set_colorspace_rec709_gamma(m_spec, float(m_cin.header.Gamma()));
 #endif
 
     // general metadata

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -61,8 +61,9 @@ public:
                           void* data) override;
 
 private:
-    std::string m_filename;            ///< Stash the filename
-    std::vector<unsigned char> m_buf;  ///< Buffer the image pixels
+    std::string m_filename;             ///< Stash the filename
+    std::string m_image_state_default;  ///< Default image state for color space
+    std::vector<unsigned char> m_buf;   ///< Buffer the image pixels
     int m_subimage;
     int m_miplevel;
     int m_nchans;               ///< Number of colour channels in image
@@ -412,6 +413,8 @@ DDSInput::open(const std::string& name, ImageSpec& newspec,
                const ImageSpec& config)
 {
     ioproxy_retrieve_from_config(config);
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
     return open(name, newspec);
 }
 
@@ -845,7 +848,7 @@ DDSInput::seek_subimage(int subimage, int miplevel)
     }
 
     if (is_srgb) {
-        pvt::set_colorspace_srgb(m_spec);
+        pvt::set_colorspace_srgb(m_spec, m_image_state_default);
     } else if (!is_srgb
                && (basetype == TypeDesc::HALF || basetype == TypeDesc::FLOAT)) {
         // linear color space for HDR-ish images

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -87,6 +87,11 @@ options are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for BMP output**
 
@@ -211,6 +216,11 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.    
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 Additionally, an integer ``dds:bc5normal`` global attribute is supported
 to control behaviour of images compressed in BC5/ATI2 compression format.
@@ -294,6 +304,11 @@ options are supported:
    * - ``oiio:subimages``
      - int
      - The number of "image elements" (subimages) in the file.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 
 **Configuration settings for DPX output**
@@ -618,6 +633,11 @@ options are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for GIF output**
 
@@ -727,6 +747,11 @@ options are supported:
        orientation of the image). If this hint is set to 0, the pixels will be
        left in their orientation as stored in the file, and the "Orientation"
        metadata will reflect that.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for HDR output**
 
@@ -807,6 +832,12 @@ attributes are supported:
        having Orientation 1). If zero, then libheif will not reorient the
        image and the Orientation metadata will be set to reflect the camera
        orientation.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
+
 
 **Configuration settings for HEIF output**
 
@@ -871,6 +902,11 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.    
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for ICO output**
 
@@ -947,6 +983,11 @@ options are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for IFF output**
 
@@ -1063,6 +1104,11 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for JPEG output**
 
@@ -1195,6 +1241,11 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
   
 If OpenJPH is installed, the reader will attempt to read the file first with 
 the OpenJPH library, and if that fails, it will fall back to the OpenJPEG library.
@@ -1302,6 +1353,11 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
        
 **Configuration settings for JPEG XL output**
 
@@ -1837,6 +1893,11 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
    * - ``png:linear_premult``
      - int
      - If nonzero, will convert  or gamma-encoded values to linear color
@@ -2317,6 +2378,11 @@ options are supported:
        initialization. This populates the image attributes which depend on the
        pixel values.
        (Default: 0)
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 |
 
@@ -2424,6 +2490,11 @@ options are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for RLA output**
 
@@ -2674,6 +2745,11 @@ attributes are supported:
        cause the reader to leave alpha unassociated (versus the default of
        premultiplying color channels by alpha if the alpha channel is
        unassociated).
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for Targa output**
 
@@ -2842,6 +2918,11 @@ options are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for TIFF output**
 
@@ -3152,6 +3233,11 @@ attributes are supported:
      - If nonzero, will leave alpha unassociated (versus the default of
        premultiplying color channels by alpha if the alpha channel is
        unassociated).
+   * - ``oiio:ImageStateDefault``
+     - string
+     - If ``scene`` or ``display``, prefer to assign the image a scene or
+       display referred ``oiio:ColorSpace``. The default is ``display``,
+       while ``scene`` is more common for textures.
 
 **Configuration settings for WebP output**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -60,7 +60,8 @@ tiles.
      - Version of the BMP file format
    * - ``oiio:ColorSpace``
      - string
-     - currently, it is always ``"sRGB"`` (we presume all BMP files are sRGB)
+     - currently, it is always ``"srgb_rec709_display"`` or
+       ``"srgb_rec709_scene"`` (we presume all BMP files are sRGB)
 
 **Configuration settings for BMP input**
 

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -2849,12 +2849,14 @@ Color space conversion
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.jpg");
-          ImageBuf Dst = ImageBufAlgo::colorconvert (Src, "sRGB", "acescg", true);
+          ImageBuf Dst = ImageBufAlgo::colorconvert (Src, "srgb_rec709_scene",
+                                                     "acescg", true);
 
        .. code-tab:: py
 
           Src = ImageBuf("tahoe.jpg")
-          Dst = ImageBufAlgo.colorconvert (Src, "sRGB", "acescg", True)
+          Dst = ImageBufAlgo.colorconvert (Src, "srgb_rec709_scene", "acescg",
+                                           True)
 
        .. code-tab:: bash oiiotool
 
@@ -2950,14 +2952,15 @@ Color space conversion
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.exr");
-          ImageBuf Dst = ImageBufAlgo::ociodisplay (Src, "sRGB", "Film", "lnf",
-                                                    "", true, "SHOT", "pe0012");
+          ImageBuf Dst = ImageBufAlgo::ociodisplay (Src, "srgb_rec709_scene",
+                                                    "Film", "lnf", "", true,
+                                                    "SHOT", "pe0012");
 
        .. code-tab:: py
 
           Src = ImageBuf("tahoe.jpg")
-          Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "Film", "lnf",
-                                          "", True, "SHOT", "pe0012")
+          Dst = ImageBufAlgo.ociodisplay (Src, "srgb_rec709_scene", "Film",
+                                          "lnf", "", True, "SHOT", "pe0012")
 
        .. code-tab:: bash oiiotool
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3610,7 +3610,8 @@ Color manipulation
     .. code-block:: python
 
         Src = ImageBuf ("tahoe.jpg")
-        Dst = ImageBufAlgo.colorconvert (Src, "sRGB", "scene_linear")
+        Dst = ImageBufAlgo.colorconvert (Src, "srgb_rec709_scene",
+                                         "scene_linear")
 
 
 
@@ -3660,7 +3661,7 @@ Color manipulation
     .. code-block:: python
 
         Src = ImageBuf ("tahoe.exr")
-        Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "Film", "lnf",
+        Dst = ImageBufAlgo.ociodisplay (Src, "srgb_rec709_scene", "Film", "lnf",
                                   context_key="SHOT", context_value="pe0012")
 
 

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -149,9 +149,11 @@ Color information
     - `"lin_ap1_scene"`, `"ACEScg"` :  ACEScg color space encoding.
     - `"lin_ap0_scene"` :  ACES2065-1, the recommended ACES space for
       interchange and archiving.
-    - `"srgb_rec709_scene"` : Using standard (piecewise) sRGB response and
+    - `"srgb_rec709_display"` : Using standard (piecewise) sRGB response and
       primaries. The token `"sRGB"` is treated as a synonym.
-    - `"g22_rec709_scene"` : Rec709/sRGB primaries, but using a response curve
+    - `"srgb_rec709_scene"` : Same response and primaries as
+      `"srgb_rec709_display"` but for scene referred images.
+    - `"g22_rec709_display"` : Rec709/sRGB primaries, but using a response curve
       corresponding to gamma 2.2.
 
     Additionally, `"scene_linear"` is a role that is appropriate for color

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -150,7 +150,8 @@ Color information
     - `"lin_ap0_scene"` :  ACES2065-1, the recommended ACES space for
       interchange and archiving.
     - `"srgb_rec709_display"` : Using standard (piecewise) sRGB response and
-      primaries. The token `"sRGB"` is treated as a synonym.
+      primaries. The token `"sRGB"` is treated as a synonym, but it is
+      recommended to use the more specific interop ID.
     - `"srgb_rec709_scene"` : Same response and primaries as
       `"srgb_rec709_display"` but for scene referred images.
     - `"g22_rec709_display"` : Rec709/sRGB primaries, but using a response curve

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -29,6 +29,8 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/typedesc.h>
 
+#include "imageio_pvt.h"
+
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
@@ -314,7 +316,7 @@ DPXInput::seek_subimage(int subimage, int miplevel)
     switch (m_dpx.header.Transfer(subimage)) {
     case dpx::kLinear: m_spec.set_colorspace("lin_rec709_scene"); break;
     case dpx::kLogarithmic: m_spec.set_colorspace("KodakLog"); break;
-    case dpx::kITUR709: m_spec.set_colorspace("srgb_rec709_scene"); break;
+    case dpx::kITUR709: pvt::set_colorspace_srgb(m_spec); break;
     case dpx::kUserDefined:
         if (!std::isnan(m_dpx.header.Gamma()) && m_dpx.header.Gamma() != 0) {
             set_colorspace_rec709_gamma(m_spec, float(m_dpx.header.Gamma()));

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -91,6 +91,8 @@ public:
     }
     bool valid_file(const std::string& name) const override;
     bool open(const std::string& name, ImageSpec& spec) override;
+    bool open(const std::string& name, ImageSpec& spec,
+              const ImageSpec& config) override;
     bool close(void) override;
     int current_subimage(void) const override
     {
@@ -133,6 +135,7 @@ private:
     bool m_codec_cap_delay;
     bool m_read_frame;
     int64_t m_start_time;
+    std::string m_image_state_default;
 
     // init to initialize state
     void init(void)
@@ -212,6 +215,14 @@ FFmpegInput::valid_file(const std::string& name) const
 }
 
 
+bool
+FFmpegInput::open(const std::string& name, ImageSpec& spec,
+                  const ImageSpec& config)
+{
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
+    return open(name, spec);
+}
 
 bool
 FFmpegInput::open(const std::string& name, ImageSpec& spec)
@@ -550,7 +561,7 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
         = { m_codec_context->color_primaries, m_codec_context->color_trc,
             m_codec_context->colorspace,
             m_codec_context->color_range == AVCOL_RANGE_MPEG ? 0 : 1 };
-    pvt::set_colorspace_cicp(m_spec, cicp);
+    pvt::set_colorspace_cicp(m_spec, cicp, m_image_state_default);
 
     m_nsubimages = m_frames;
     spec         = m_spec;

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -71,6 +71,7 @@ receive_frame(AVCodecContext* avctx, AVFrame* picture, AVPacket* avpkt)
 
 
 
+#include "imageio_pvt.h"
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/imageio.h>
 #include <iostream>
@@ -549,11 +550,7 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
         = { m_codec_context->color_primaries, m_codec_context->color_trc,
             m_codec_context->colorspace,
             m_codec_context->color_range == AVCOL_RANGE_MPEG ? 0 : 1 };
-    m_spec.attribute("CICP", TypeDesc(TypeDesc::INT, 4), cicp);
-    const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
-    string_view interop_id = colorconfig.get_color_interop_id(cicp);
-    if (!interop_id.empty())
-        m_spec.attribute("oiio:ColorSpace", interop_id);
+    pvt::set_colorspace_cicp(m_spec, cicp);
 
     m_nsubimages = m_frames;
     spec         = m_spec;

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -65,10 +65,11 @@ public:
     }
 
 private:
-    std::string m_filename;          ///< Stash the filename
-    GifFileType* m_gif_file;         ///< GIFLIB handle
-    int m_transparent_color;         ///< Transparent color index
-    int m_subimage;                  ///< Current subimage index
+    std::string m_filename;             ///< Stash the filename
+    std::string m_image_state_default;  ///< Default image state for color space
+    GifFileType* m_gif_file;            ///< GIFLIB handle
+    int m_transparent_color;            ///< Transparent color index
+    int m_subimage;                     ///< Current subimage index
     int m_disposal_method;           ///< Disposal method of current subimage.
                                      ///  Indicates what to do with canvas
                                      ///  before drawing the _next_ subimage.
@@ -173,6 +174,8 @@ bool
 GIFInput::open(const std::string& name, ImageSpec& newspec,
                const ImageSpec& config)
 {
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
     // Check 'config' for any special requests
     ioproxy_retrieve_from_config(config);
     ioseek(0);
@@ -261,7 +264,7 @@ GIFInput::read_subimage_metadata(ImageSpec& newspec)
     newspec.nchannels = 4;
     newspec.default_channel_names();
     newspec.alpha_channel = 4;
-    pvt::set_colorspace_srgb(newspec);
+    pvt::set_colorspace_srgb(newspec, m_image_state_default);
 
     m_previous_disposal_method = m_disposal_method;
     m_disposal_method          = DISPOSAL_UNSPECIFIED;

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -12,6 +12,8 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/thread.h>
 
+#include "imageio_pvt.h"
+
 // GIFLIB:
 // http://giflib.sourceforge.net/
 // Format description:
@@ -259,7 +261,7 @@ GIFInput::read_subimage_metadata(ImageSpec& newspec)
     newspec.nchannels = 4;
     newspec.default_channel_names();
     newspec.alpha_channel = 4;
-    newspec.set_colorspace("srgb_rec709_scene");
+    pvt::set_colorspace_srgb(newspec);
 
     m_previous_disposal_method = m_disposal_method;
     m_disposal_method          = DISPOSAL_UNSPECIFIED;

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -68,6 +68,7 @@ private:
     bool m_keep_unassociated_alpha = false;
     bool m_do_associate            = false;
     bool m_reorient                = true;
+    std::string m_image_state_default;
     std::unique_ptr<heif::Context> m_ctx;
     heif_item_id m_primary_id;             // id of primary image
     std::vector<heif_item_id> m_item_ids;  // ids of all other images
@@ -149,7 +150,9 @@ HeifInput::open(const std::string& name, ImageSpec& newspec,
 
     m_keep_unassociated_alpha
         = (config.get_int_attribute("oiio:UnassociatedAlpha") != 0);
-    m_reorient = config.get_int_attribute("oiio:reorient", 1);
+    m_reorient            = config.get_int_attribute("oiio:reorient", 1);
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
 
     try {
         m_ctx->read_from_file(name);
@@ -275,7 +278,7 @@ HeifInput::seek_subimage(int subimage, int miplevel)
     if (m_bitdepth > 8) {
         m_spec.attribute("oiio:BitsPerSample", m_bitdepth);
     }
-    pvt::set_colorspace_srgb(m_spec);
+    pvt::set_colorspace_srgb(m_spec, m_image_state_default);
 
 #if LIBHEIF_HAVE_VERSION(1, 9, 0)
     // Read CICP. Have to use the C API to get it from the image handle,
@@ -301,7 +304,7 @@ HeifInput::seek_subimage(int subimage, int miplevel)
                                       int(nclx->transfer_characteristics),
                                       int(nclx->matrix_coefficients),
                                       int(nclx->full_range_flag ? 1 : 0) };
-                pvt::set_colorspace_cicp(m_spec, cicp);
+                pvt::set_colorspace_cicp(m_spec, cicp, m_image_state_default);
             }
             heif_nclx_color_profile_free(nclx);
         }

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -10,6 +10,8 @@
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/tiffutils.h>
 
+#include "imageio_pvt.h"
+
 #include <libheif/heif_cxx.h>
 
 #define MAKE_LIBHEIF_VERSION(a, b, c, d) \
@@ -250,12 +252,7 @@ HeifOutput::close()
         std::unique_ptr<heif_color_profile_nclx,
                         void (*)(heif_color_profile_nclx*)>
             nclx(heif_nclx_color_profile_alloc(), heif_nclx_color_profile_free);
-        const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
-        const ParamValue* p    = m_spec.find_attribute("CICP",
-                                                       TypeDesc(TypeDesc::INT, 4));
-        string_view colorspace = m_spec.get_string_attribute("oiio:ColorSpace");
-        cspan<int> cicp        = (p) ? p->as_cspan<int>()
-                                     : colorconfig.get_cicp(colorspace);
+        cspan<int> cicp = pvt::get_colorspace_cicp(m_spec);
         if (!cicp.empty()) {
             nclx->color_primaries          = heif_color_primaries(cicp[0]);
             nclx->transfer_characteristics = heif_transfer_characteristics(

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -43,13 +43,14 @@ public:
                               void* data) override;
 
 private:
-    std::string m_filename;            ///< Stash the filename
-    ico_header m_ico;                  ///< ICO header
-    std::vector<unsigned char> m_buf;  ///< Buffer the image pixels
-    int m_subimage;                    ///< What subimage are we looking at?
-    int m_bpp;                         ///< Bits per pixel
-    int m_offset;                      ///< Offset to image data
-    int m_subimage_size;               ///< Length (in bytes) of image data
+    std::string m_filename;             ///< Stash the filename
+    std::string m_image_state_default;  ///< Default image state for color space
+    ico_header m_ico;                   ///< ICO header
+    std::vector<unsigned char> m_buf;   ///< Buffer the image pixels
+    int m_subimage;                     ///< What subimage are we looking at?
+    int m_bpp;                          ///< Bits per pixel
+    int m_offset;                       ///< Offset to image data
+    int m_subimage_size;                ///< Length (in bytes) of image data
     int m_palette_size;  ///< Number of colours in palette (0 means 256)
 
     png_structp m_png;     ///< PNG read structure pointer
@@ -142,6 +143,9 @@ ICOInput::open(const std::string& name, ImageSpec& newspec,
         return false;
     }
 
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
+
     // default to subimage #0, according to convention
     bool ok = seek_subimage(0, 0);
     if (ok)
@@ -231,7 +235,7 @@ ICOInput::seek_subimage(int subimage, int miplevel)
         png_set_sig_bytes(m_png, 8);  // already read 8 bytes
 
         PNG_pvt::read_info(m_png, m_info, m_bpp, m_color_type, m_interlace_type,
-                           m_bg, m_spec, true);
+                           m_bg, m_spec, true, m_image_state_default);
 
         m_spec.attribute("oiio:BitsPerSample", m_bpp / m_spec.nchannels);
 

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -226,7 +226,7 @@ adjust_spec(ImageInput* in, ImageOutput* out, const ImageSpec& inspec,
     if (gammaval != 1.0f)
         outspec.attribute("oiio:Gamma", gammaval);
     if (sRGB) {
-        pvt::set_colorspace_srgb(outspec);
+        pvt::set_colorspace_srgb(outspec, string_view());
         if (!strcmp(in->format_name(), "jpeg")
             || outspec.find_attribute("Exif:ColorSpace"))
             outspec.attribute("Exif:ColorSpace", 1);

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -18,6 +18,8 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
 
+#include "imageio_pvt.h"
+
 
 using namespace OIIO;
 
@@ -224,7 +226,7 @@ adjust_spec(ImageInput* in, ImageOutput* out, const ImageSpec& inspec,
     if (gammaval != 1.0f)
         outspec.attribute("oiio:Gamma", gammaval);
     if (sRGB) {
-        outspec.set_colorspace("srgb_rec709_scene");
+        pvt::set_colorspace_srgb(outspec);
         if (!strcmp(in->format_name(), "jpeg")
             || outspec.find_attribute("Exif:ColorSpace"))
             outspec.attribute("Exif:ColorSpace", 1);

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -415,14 +415,14 @@ public:
     string_view get_color_interop_id(string_view colorspace) const;
 
     /// Find color interop ID corresponding to the CICP code.
-    /// If prefer_image_state is set to "scene", prefer returning a scene
+    /// If image_state_default is set to "scene", prefer returning a scene
     /// referred interop ID over a display referred interop ID if both exist.
     /// Returns empty string if not found.
     ///
     /// @version 3.1
     string_view
     get_color_interop_id(const int cicp[4],
-                         string_view prefer_image_state = "display") const;
+                         string_view image_state_default = "display") const;
 
     /// Return a filename or other identifier for the config we're using.
     std::string configname() const;

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -415,10 +415,14 @@ public:
     string_view get_color_interop_id(string_view colorspace) const;
 
     /// Find color interop ID corresponding to the CICP code.
+    /// If prefer_image_state is set to "scene", prefer returning a scene
+    /// referred interop ID over a display referred interop ID if both exist.
     /// Returns empty string if not found.
     ///
     /// @version 3.1
-    string_view get_color_interop_id(const int cicp[4]) const;
+    string_view
+    get_color_interop_id(const int cicp[4],
+                         string_view prefer_image_state = "display") const;
 
     /// Return a filename or other identifier for the config we're using.
     std::string configname() const;

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -215,6 +215,11 @@ public:
     /// - `string colorconfig` :
     ///           Name of the OCIO config to use. Default: "" (meaning to use
     ///           the default color config).
+    /// - `string image_state_default` :
+    ///           Preferred "display" or "scene" image state when automatically
+    ///           determining the color space of an image file. Default: "display"
+    ///           (matching default image input behavior, however "scene" may
+    ///           be a better choice for textures).
     ///
     /// - `string options`
     ///           This catch-all is simply a comma-separated list of

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3853,7 +3853,7 @@ OIIO_API std::string geterror(bool clear = true);
 ///    For more information, please see OpenImageIO's documentation on the
 ///    built-in PNG format support.
 ///
-/// - `string color:prefer_image_state` ("display")
+/// - `string color:image_state_default` ("display")
 ///
 ///    When the color space of an image file is ambiguous and can be
 ///    interpreted as either a display referred or scene referred, by default

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -4198,7 +4198,6 @@ OIIO_API void set_colorspace(ImageSpec& spec, string_view name);
 /// @version 3.0
 OIIO_API void set_colorspace_rec709_gamma(ImageSpec& spec, float gamma);
 
-
 /// Are the two named color spaces equivalent, based on the default color
 /// config in effect?
 ///

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3843,6 +3843,17 @@ OIIO_API std::string geterror(bool clear = true);
 ///    For more information, please see OpenImageIO's documentation on the
 ///    built-in PNG format support.
 ///
+/// - `string color:prefer_image_state` ("display")
+///
+///    When the color space of an image file is ambiguous and can be
+///    interpreted as either a display referred or scene referred, by default
+///    the `oiio:ColorSpace` attribute will be set to a display color space
+///    like `srgb_rec709_display`.
+///
+///    By setting the preferred image state to "scene", the corresponding
+///    scene referred color space like `srgb_rec709_scene` will be chosen
+///    instead. For textures in particular this can be a better default guess.
+///
 /// - `int limits:channels` (1024)
 ///
 ///    When nonzero, the maximum number of color channels in an image. Image

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -912,10 +912,10 @@ public:
     /// 1. Assigning to the delegate adds a metadata attribute:
     ///
     ///        ImageSpec spec;
-    ///        spec["foo"] = 42;                   // int
-    ///        spec["pi"] = float(M_PI);           // float
-    ///        spec["oiio:ColorSpace"] = "sRGB";   // string
-    ///        spec["cameratoworld"] = Imath::Matrix44(...);  // matrix
+    ///        spec["foo"] = 42;                                  // int
+    ///        spec["pi"] = float(M_PI);                          // float
+    ///        spec["oiio:ColorSpace"] = "srgb_rec709_display";   // string
+    ///        spec["cameratoworld"] = Imath::Matrix44(...);      // matrix
     ///
     ///    Be very careful, the attribute's type will be implied by the C++
     ///    type of what you assign.

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -130,10 +130,32 @@ check_texture_metadata_sanity(ImageSpec& spec);
 /// Set oiio:ColorSpace to the default sRGB colorspace, which may be display
 /// or scene referred depending on configuration.
 ///
+/// If image_state_default is "scene" or "display", a colorspace with that
+/// image state will be preferred over otherwise equivalent color spaces.
+///
 /// If erase_other_attributes is true, other potentially conflicting attributes
 /// are erased.
 OIIO_API void
-set_colorspace_srgb(ImageSpec& spec, bool erase_other_attributes = true);
+set_colorspace_srgb(ImageSpec& spec,
+                    string_view image_state_default = "display",
+                    bool erase_other_attributes     = true);
+
+/// Set oiio:ColorSpace in the spec's metadata based on the gamma value.
+///
+/// If image_state_default is "scene" or "display" a colrospace with that
+/// image state will be prefered over otherwise equivalent color spaces.
+OIIO_API void
+set_colorspace_rec709_gamma(ImageSpec& spec, float gamma,
+                            string_view image_state_default = "display");
+
+// Set CICP attribute in the spec's metadata, and set oiio:ColorSpace
+// along with it if there is a corresponding known colorspace.
+//
+/// If image_state_default is "scene" or "display" a colrospace with that
+/// image state will be prefered over otherwise equivalent color spaces.
+OIIO_API void
+set_colorspace_cicp(ImageSpec& spec, const int cicp[4],
+                    string_view image_state_default = "display");
 
 /// Returns true if for the purpose of interop, the spec's metadata
 /// specifies a color space that should be encoded as sRGB.
@@ -153,11 +175,6 @@ get_colorspace_rec709_gamma(const ImageSpec& spec);
 // Returns an empty vector if not found.
 OIIO_API std::vector<uint8_t>
 get_colorspace_icc_profile(const ImageSpec& spec, bool from_colorspace = true);
-
-// Set CICP attribute in the spec's metadata, and set oiio:ColorSpace
-// along with it if there is a corresponding known colorspace.
-OIIO_API void
-set_colorspace_cicp(ImageSpec& spec, const int cicp[4]);
 
 // Returns CICP from the spec's metadata, either from a CICP attribute
 // or from the colorspace if from_colorspace is true.

--- a/src/include/imageio_pvt.h
+++ b/src/include/imageio_pvt.h
@@ -127,6 +127,44 @@ parallel_convert_from_float(const float* src, void* dst, size_t nvals,
 OIIO_API bool
 check_texture_metadata_sanity(ImageSpec& spec);
 
+/// Set oiio:ColorSpace to the default sRGB colorspace, which may be display
+/// or scene referred depending on configuration.
+///
+/// If erase_other_attributes is true, other potentially conflicting attributes
+/// are erased.
+OIIO_API void
+set_colorspace_srgb(ImageSpec& spec, bool erase_other_attributes = true);
+
+/// Returns true if for the purpose of interop, the spec's metadata
+/// specifies a color space that should be encoded as sRGB.
+///
+/// If default_to_srgb is true, the colorspace will be assumed to
+/// be sRGB if no colorspace was specified in the spec.
+OIIO_API bool
+is_colorspace_srgb(const ImageSpec& spec, bool default_to_srgb = true);
+
+/// If the spec's metadata specifies a color space with Rec709 primaries and
+/// gamma transfer function, return the gamma value. If not, return zero.
+OIIO_API float
+get_colorspace_rec709_gamma(const ImageSpec& spec);
+
+// Returns ICC profile from the spec's metadata, either from an ICCProfile
+// attribute or from the colorspace if from_colorspace is true.
+// Returns an empty vector if not found.
+OIIO_API std::vector<uint8_t>
+get_colorspace_icc_profile(const ImageSpec& spec, bool from_colorspace = true);
+
+// Set CICP attribute in the spec's metadata, and set oiio:ColorSpace
+// along with it if there is a corresponding known colorspace.
+OIIO_API void
+set_colorspace_cicp(ImageSpec& spec, const int cicp[4]);
+
+// Returns CICP from the spec's metadata, either from a CICP attribute
+// or from the colorspace if from_colorspace is true.
+// Returns an empty span if not found.
+OIIO_API cspan<int>
+get_colorspace_cicp(const ImageSpec& spec, bool from_colorspace = true);
+
 /// Get the timing report from log_time entries.
 OIIO_API std::string
 timing_report();

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -44,20 +44,9 @@
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/timer.h>
 
+#include "imageio_pvt.h"
 
 #include "ivutils.h"
-
-
-namespace {
-
-inline bool
-IsSpecSrgb(const ImageSpec& spec)
-{
-    return equivalent_colorspace(spec.get_string_attribute("oiio:ColorSpace"),
-                                 "srgb_rec709_scene");
-}
-
-}  // namespace
 
 
 // clang-format off
@@ -1242,7 +1231,8 @@ ImageViewer::loadCurrentImage(int subimage, int miplevel)
                 //std::cerr << "Loading HALF-FLOAT as FLOAT\n";
                 read_format = TypeDesc::FLOAT;
             }
-            if (IsSpecSrgb(image_spec) && !glwin->is_srgb_capable()) {
+            if (pvt::is_colorspace_srgb(image_spec)
+                && !glwin->is_srgb_capable()) {
                 // If the image is in sRGB, but OpenGL can't load sRGB textures then
                 // we'll need to do the transformation on the CPU after loading the
                 // image. We (so far) can only do this with UINT8 images, so make
@@ -1257,7 +1247,8 @@ ImageViewer::loadCurrentImage(int subimage, int miplevel)
             read_format      = TypeDesc::UINT8;
             allow_transforms = true;
 
-            if (IsSpecSrgb(image_spec) && !glwin->is_srgb_capable())
+            if (pvt::is_colorspace_srgb(image_spec)
+                && !glwin->is_srgb_capable())
                 srgb_transform = true;
         }
 
@@ -1443,7 +1434,7 @@ ImageViewer::exposureMinusOneTenthStop()
     img->exposure(img->exposure() - 0.1);
     if (!glwin->is_glsl_capable()) {
         bool srgb_transform = (!glwin->is_srgb_capable()
-                               && IsSpecSrgb(img->spec()));
+                               && pvt::is_colorspace_srgb(img->spec()));
         img->pixel_transform(srgb_transform, (int)current_color_mode(),
                              current_channel());
         displayCurrentImage();
@@ -1462,7 +1453,7 @@ ImageViewer::exposureMinusOneHalfStop()
     img->exposure(img->exposure() - 0.5);
     if (!glwin->is_glsl_capable()) {
         bool srgb_transform = (!glwin->is_srgb_capable()
-                               && IsSpecSrgb(img->spec()));
+                               && pvt::is_colorspace_srgb(img->spec()));
         img->pixel_transform(srgb_transform, (int)current_color_mode(),
                              current_channel());
         displayCurrentImage();
@@ -1481,7 +1472,7 @@ ImageViewer::exposurePlusOneTenthStop()
     img->exposure(img->exposure() + 0.1);
     if (!glwin->is_glsl_capable()) {
         bool srgb_transform = (!glwin->is_srgb_capable()
-                               && IsSpecSrgb(img->spec()));
+                               && pvt::is_colorspace_srgb(img->spec()));
         img->pixel_transform(srgb_transform, (int)current_color_mode(),
                              current_channel());
         displayCurrentImage();
@@ -1500,7 +1491,7 @@ ImageViewer::exposurePlusOneHalfStop()
     img->exposure(img->exposure() + 0.5);
     if (!glwin->is_glsl_capable()) {
         bool srgb_transform = (!glwin->is_srgb_capable()
-                               && IsSpecSrgb(img->spec()));
+                               && pvt::is_colorspace_srgb(img->spec()));
         img->pixel_transform(srgb_transform, (int)current_color_mode(),
                              current_channel());
         displayCurrentImage();
@@ -1520,7 +1511,7 @@ ImageViewer::gammaMinus()
     img->gamma(img->gamma() - 0.05);
     if (!glwin->is_glsl_capable()) {
         bool srgb_transform = (!glwin->is_srgb_capable()
-                               && IsSpecSrgb(img->spec()));
+                               && pvt::is_colorspace_srgb(img->spec()));
         img->pixel_transform(srgb_transform, (int)current_color_mode(),
                              current_channel());
         displayCurrentImage();
@@ -1539,7 +1530,7 @@ ImageViewer::gammaPlus()
     img->gamma(img->gamma() + 0.05);
     if (!glwin->is_glsl_capable()) {
         bool srgb_transform = (!glwin->is_srgb_capable()
-                               && IsSpecSrgb(img->spec()));
+                               && pvt::is_colorspace_srgb(img->spec()));
         img->pixel_transform(srgb_transform, (int)current_color_mode(),
                              current_channel());
         displayCurrentImage();
@@ -1572,7 +1563,7 @@ ImageViewer::viewChannel(int c, COLOR_MODE colormode)
             IvImage* img = cur();
             if (img) {
                 bool srgb_transform = (!glwin->is_srgb_capable()
-                                       && IsSpecSrgb(img->spec()));
+                                       && pvt::is_colorspace_srgb(img->spec()));
                 img->pixel_transform(srgb_transform, (int)colormode, c);
             }
         } else {

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -18,6 +18,7 @@
 #    include <QPen>
 #endif
 
+#include "imageio_pvt.h"
 #include "ivutils.h"
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/timer.h>
@@ -2198,9 +2199,7 @@ IvGL::typespec_to_opengl(const ImageSpec& spec, int nchannels, GLenum& gltype,
         break;
     }
 
-    bool issrgb
-        = equivalent_colorspace(spec.get_string_attribute("oiio:ColorSpace"),
-                                "srgb_rec709_scene");
+    bool issrgb = pvt::is_colorspace_srgb(spec);
 
     glinternalformat = nchannels;
     if (nchannels == 1) {

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -93,11 +93,12 @@ public:
 
 private:
     std::string m_filename;
-    int m_next_scanline;   // Which scanline is the next to read?
-    bool m_raw;            // Read raw coefficients, not scanlines
-    bool m_cmyk;           // The input file is cmyk
-    bool m_fatalerr;       // JPEG reader hit a fatal error
-    bool m_decomp_create;  // Have we created the decompressor?
+    std::string m_image_state_default;  // Default image state for color space
+    int m_next_scanline;                // Which scanline is the next to read?
+    bool m_raw;                         // Read raw coefficients, not scanlines
+    bool m_cmyk;                        // The input file is cmyk
+    bool m_fatalerr;                    // JPEG reader hit a fatal error
+    bool m_decomp_create;               // Have we created the decompressor?
     struct jpeg_decompress_struct m_cinfo;
     my_error_mgr m_jerr;
     jvirt_barray_ptr* m_coeffs;

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -157,8 +157,10 @@ bool
 JpgInput::open(const std::string& name, ImageSpec& newspec,
                const ImageSpec& config)
 {
-    auto p = config.find_attribute("_jpeg:raw", TypeInt);
-    m_raw  = p && *(int*)p->data();
+    auto p                = config.find_attribute("_jpeg:raw", TypeInt);
+    m_raw                 = p && *(int*)p->data();
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
     ioproxy_retrieve_from_config(config);
     m_config.reset(new ImageSpec(config));  // save config spec
     return open(name, newspec);
@@ -260,7 +262,7 @@ JpgInput::open(const std::string& name, ImageSpec& newspec)
         return false;
 
     // Assume JPEG is in sRGB unless the Exif or XMP tags say otherwise.
-    pvt::set_colorspace_srgb(m_spec);
+    pvt::set_colorspace_srgb(m_spec, m_image_state_default);
 
     if (m_cinfo.jpeg_color_space == JCS_CMYK)
         m_spec.attribute("jpeg:ColorSpace", "CMYK");

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -12,6 +12,8 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/tiffutils.h>
 
+#include "imageio_pvt.h"
+
 #include "jpeg_pvt.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -258,7 +260,7 @@ JpgInput::open(const std::string& name, ImageSpec& newspec)
         return false;
 
     // Assume JPEG is in sRGB unless the Exif or XMP tags say otherwise.
-    m_spec.set_colorspace("srgb_rec709_scene");
+    pvt::set_colorspace_srgb(m_spec);
 
     if (m_cinfo.jpeg_color_space == JCS_CMYK)
         m_spec.attribute("jpeg:ColorSpace", "CMYK");

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -109,7 +109,8 @@ private:
     opj_image_t* m_image;
     opj_codec_t* m_codec;
     opj_stream_t* m_stream;
-    bool m_keep_unassociated_alpha;  // Do not convert unassociated alpha
+    bool m_keep_unassociated_alpha;     // Do not convert unassociated alpha
+    std::string m_image_state_default;  // Default image state for color space
 
     void init(void);
 
@@ -371,7 +372,7 @@ Jpeg2000Input::ojph_read_header()
     m_spec = ImageSpec(w, h, ch, dtype);
     m_spec.default_channel_names();
     m_spec.attribute("oiio:BitsPerSample", siz.get_bit_depth(0));
-    pvt::set_colorspace_srgb(m_spec);
+    pvt::set_colorspace_srgb(m_spec, m_image_state_default);
 
     return true;
 }
@@ -619,7 +620,7 @@ Jpeg2000Input::open(const std::string& name, ImageSpec& p_spec)
     m_spec.full_height = m_image->y1;
 
     m_spec.attribute("oiio:BitsPerSample", maxPrecision);
-    pvt::set_colorspace_srgb(m_spec);
+    pvt::set_colorspace_srgb(m_spec, m_image_state_default);
 
     if (m_image->icc_profile_len && m_image->icc_profile_buf) {
         m_spec.attribute("ICCProfile",
@@ -650,6 +651,8 @@ Jpeg2000Input::open(const std::string& name, ImageSpec& newspec,
     // Check 'config' for any special requests
     if (config.get_int_attribute("oiio:UnassociatedAlpha", 0) == 1)
         m_keep_unassociated_alpha = true;
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
     ioproxy_retrieve_from_config(config);
     return open(name, newspec);
 }

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -15,6 +15,8 @@
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/tiffutils.h>
 
+#include "imageio_pvt.h"
+
 #ifdef USE_OPENJPH
 #    include <openjph/ojph_codestream.h>
 #    include <openjph/ojph_file.h>
@@ -369,7 +371,7 @@ Jpeg2000Input::ojph_read_header()
     m_spec = ImageSpec(w, h, ch, dtype);
     m_spec.default_channel_names();
     m_spec.attribute("oiio:BitsPerSample", siz.get_bit_depth(0));
-    m_spec.set_colorspace("srgb_rec709_scene");
+    pvt::set_colorspace_srgb(m_spec);
 
     return true;
 }
@@ -617,7 +619,7 @@ Jpeg2000Input::open(const std::string& name, ImageSpec& p_spec)
     m_spec.full_height = m_image->y1;
 
     m_spec.attribute("oiio:BitsPerSample", maxPrecision);
-    m_spec.set_colorspace("srgb_rec709_scene");
+    pvt::set_colorspace_srgb(m_spec);
 
     if (m_image->icc_profile_len && m_image->icc_profile_buf) {
         m_spec.attribute("ICCProfile",

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -481,10 +481,10 @@ Jpeg2000Output::create_jpeg2000_image()
     // someboody comes along that desperately needs JPEG2000 and ICC
     // profiles, maybe they will be motivated enough to track down the
     // problem.
-    const ParamValue *icc = m_spec.find_attribute ("ICCProfile");
-    if (icc && icc->type().basetype == TypeDesc::UINT8 && icc->type().arraylen > 0) {
-        m_image->icc_profile_len = icc->type().arraylen;
-        m_image->icc_profile_buf = (unsigned char *) icc->data();
+    std::vector<uint8_t> icc_profile = get_colorspace_icc_profile(m_spec);
+    if (icc_profile.size()) {
+        m_image->icc_profile_len = icc_profile.size();
+        m_image->icc_profile_buf = (unsigned char *) icc_profile.data();
     }
 #endif
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -2100,7 +2100,8 @@ struct ColorInteropID {
 // Mapping between color interop ID and CICP, based on Color Interop Forum
 // recommendations.
 constexpr ColorInteropID color_interop_ids[] = {
-    // Display referred interop IDs.
+    // Display referred interop IDs first so they are the default in automatic.
+    // conversion from CICP to interop ID.
     { "srgb_rec709_display", CICPPrimaries::Rec709, CICPTransfer::sRGB,
       CICPMatrix::BT709 },
     // Not all software interprets this CICP the same, see the
@@ -2137,9 +2138,9 @@ constexpr ColorInteropID color_interop_ids[] = {
     { "ocio:lin_ciexyzd65_display", CICPPrimaries::XYZD65, CICPTransfer::Linear,
       CICPMatrix::Unspecified },
 
-    // Scene referred interop IDs first so they are the default in automatic
-    // conversion from CICP to interop ID. Some are not display color spaces
-    // at all, but can be represented by CICP anyway.
+    // Scene referred interop IDs. These have CICPs even if it can be argued
+    // those are only meant for display color spaces. It still improves interop
+    // with other software that does not care about the distinction.
     { "lin_ap1_scene" },
     { "lin_ap0_scene" },
     { "lin_rec709_scene", CICPPrimaries::Rec709, CICPTransfer::Linear,
@@ -2199,7 +2200,7 @@ string_view
 ColorConfig::get_color_interop_id(const int cicp[4],
                                   const string_view prefer_image_state) const
 {
-    string_view other_interop_id;
+    string_view other_interop_id = "";
     for (const ColorInteropID& interop : color_interop_ids) {
         if (interop.has_cicp && interop.cicp[0] == cicp[0]
             && interop.cicp[1] == cicp[1]) {

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -483,7 +483,7 @@ ColorConfig::Impl::inventory()
     add("lin_rec709", 0, linflags);
     add("srgb_rec709_display", 1, CSInfo::is_srgb_display);
     add("srgb_rec709_scene", 1, CSInfo::is_srgb_scene);
-    add("sRGB", 1, CSInfo::is_srgb_display);
+    add("sRGB", 1, CSInfo::is_srgb_scene);
     add("Rec709", 2, CSInfo::is_Rec709);
 
     for (auto&& cs : colorspaces)
@@ -600,14 +600,14 @@ ColorConfig::Impl::classify_by_name(CSInfo& cs)
     //
     if (Strutil::iequals(cs.name, "srgb_rec709_display")
         || Strutil::iequals(cs.name, "srgb_display")
-        || Strutil::iequals(cs.name, "sRGB - Display")
-        || Strutil::iequals(cs.name, "sRGB")) {
+        || Strutil::iequals(cs.name, "sRGB - Display")) {
         cs.setflag(CSInfo::is_srgb_display, srgb_display_alias);
     } else if (Strutil::iequals(cs.name, "srgb_rec709_scene")
                || Strutil::iequals(cs.name, "srgb_tx")
                || Strutil::iequals(cs.name, "srgb_texture")
                || Strutil::iequals(cs.name, "srgb texture")
-               || Strutil::iequals(cs.name, "sRGB - Texture")) {
+               || Strutil::iequals(cs.name, "sRGB - Texture")
+               || Strutil::iequals(cs.name, "sRGB")) {
         cs.setflag(CSInfo::is_srgb_scene, srgb_scene_alias);
     } else if (Strutil::iequals(cs.name, "lin_rec709_scene")
                || Strutil::iequals(cs.name, "lin_rec709")
@@ -1386,12 +1386,12 @@ ColorConfig::Impl::resolve(string_view name) const
     // Maybe it's an informal alias of common names?
     spin_rw_write_lock lock(m_mutex);
     if ((Strutil::iequals(name, "sRGB")
-         || Strutil::iequals(name, "srgb_rec709_display"))
-        && !srgb_display_alias.empty())
-        return srgb_display_alias;
-    if (Strutil::iequals(name, "srgb_rec709_scene")
+         || Strutil::iequals(name, "srgb_rec709_scene"))
         && !srgb_scene_alias.empty())
         return srgb_scene_alias;
+    if (Strutil::iequals(name, "srgb_rec709_display")
+        && !srgb_display_alias.empty())
+        return srgb_display_alias;
     if ((Strutil::iequals(name, "lin_srgb")
          || Strutil::iequals(name, "lin_rec709")
          || Strutil::iequals(name, "lin_rec709_scene")

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -18,6 +18,8 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/tiffutils.h>
 
+#include "imageio_pvt.h"
+
 #include "exif.h"
 
 OIIO_NAMESPACE_BEGIN
@@ -1255,7 +1257,7 @@ decode_exif(cspan<uint8_t> exif, ImageSpec& spec)
         // Exif spec says that anything other than 0xffff==uncalibrated
         // should be interpreted to be sRGB.
         if (cs != 0xffff)
-            spec.set_colorspace("srgb_rec709_scene");
+            OIIO::pvt::set_colorspace_srgb(spec);
     }
 
     // Look for a maker note offset, now that we have seen all the metadata

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -53,7 +53,7 @@ int png_linear_premult(0);
 int tiff_half(0);
 int tiff_multithread(1);
 int dds_bc5normal(0);
-ustring color_prefer_image_state("display");
+ustring color_image_state_default("display");
 int limit_channels(1024);
 int limit_imagesize_MB(std::min(32 * 1024,
                                 int(Sysutil::physical_memory() >> 20)));
@@ -407,10 +407,6 @@ attribute(string_view name, TypeDesc type, const void* val)
         dds_bc5normal = *(const int*)val;
         return true;
     }
-    if (name == "color:prefer_image_state" && type == TypeString) {
-        color_prefer_image_state = ustring(*(const char**)val);
-        return true;
-    }
     if (name == "limits:channels" && type == TypeInt) {
         limit_channels = *(const int*)val;
         return true;
@@ -615,10 +611,6 @@ getattribute(string_view name, TypeDesc type, void* val)
     }
     if (name == "dds:bc5normal" && type == TypeInt) {
         *(int*)val = dds_bc5normal;
-        return true;
-    }
-    if (name == "color:prefer_image_state" && type == TypeString) {
-        *(ustring*)val = color_prefer_image_state;
         return true;
     }
     if (name == "oiio:print_uncaught_errors" && type == TypeInt) {

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -53,6 +53,7 @@ int png_linear_premult(0);
 int tiff_half(0);
 int tiff_multithread(1);
 int dds_bc5normal(0);
+ustring color_prefer_image_state("display");
 int limit_channels(1024);
 int limit_imagesize_MB(std::min(32 * 1024,
                                 int(Sysutil::physical_memory() >> 20)));
@@ -406,6 +407,10 @@ attribute(string_view name, TypeDesc type, const void* val)
         dds_bc5normal = *(const int*)val;
         return true;
     }
+    if (name == "color:prefer_image_state" && type == TypeString) {
+        color_prefer_image_state = ustring(*(const char**)val);
+        return true;
+    }
     if (name == "limits:channels" && type == TypeInt) {
         limit_channels = *(const int*)val;
         return true;
@@ -610,6 +615,10 @@ getattribute(string_view name, TypeDesc type, void* val)
     }
     if (name == "dds:bc5normal" && type == TypeInt) {
         *(int*)val = dds_bc5normal;
+        return true;
+    }
+    if (name == "color:prefer_image_state" && type == TypeString) {
+        *(ustring*)val = color_prefer_image_state;
         return true;
     }
     if (name == "oiio:print_uncaught_errors" && type == TypeInt) {

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -758,6 +758,8 @@ ImageCacheFile::open(ImageCachePerThreadInfo* thread_info)
         configspec = *m_configspec;
     if (imagecache().unassociatedalpha())
         configspec.attribute("oiio:UnassociatedAlpha", 1);
+    configspec.attribute("oiio:ImageStateDefault",
+                         imagecache().image_state_default());
 
     if (m_inputcreator)
         inp.reset(m_inputcreator());
@@ -1987,6 +1989,7 @@ ImageCacheImpl::init()
     m_latlong_y_up_default = true;
     m_Mw2c.makeIdentity();
     m_colorspace              = ustring("scene_linear");
+    m_image_state_default     = ustring("display");
     m_mem_used                = 0;
     m_statslevel              = 0;
     m_max_errors_per_file     = 100;
@@ -2597,6 +2600,12 @@ ImageCacheImpl::attribute(string_view name, TypeDesc type, const void* val)
             m_colorspace  = uval;
             do_invalidate = true;
         }
+    } else if (name == "image_state_default" && type == TypeDesc::STRING) {
+        ustring uval(*(const char**)val);
+        if (uval != m_image_state_default) {
+            m_image_state_default = uval;
+            do_invalidate         = true;
+        }
     } else if (name == "max_mip_res" && type == TypeInt) {
         m_max_mip_res = *(const int*)val;
         do_invalidate = true;
@@ -2745,6 +2754,10 @@ ImageCacheImpl::getattribute(string_view name, TypeDesc type, void* val) const
     }
     if (name == "colorspace" && type == TypeDesc::STRING) {
         *(const char**)val = m_colorspace.c_str();
+        return true;
+    }
+    if (name == "image_state_default" && type == TypeDesc::STRING) {
+        *(const char**)val = m_image_state_default.c_str();
         return true;
     }
     if (name == "all_filenames" && type.basetype == TypeDesc::STRING

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -1280,6 +1280,10 @@ public:
     int max_mip_res() const noexcept { return m_max_mip_res; }
 
     ustring colorspace() const noexcept { return m_colorspace; }
+    ustring image_state_default() const noexcept
+    {
+        return m_image_state_default;
+    }
 
     size_t heapsize() const;
     size_t footprint(ImageCacheFootprint& output) const;
@@ -1339,12 +1343,13 @@ private:
     bool m_trust_file_extensions = false;  ///< Assume file extensions don't lie?
     bool m_max_open_files_strict = false;  ///< Be strict about open files limit?
     int m_failure_retries;                 ///< Times to re-try disk failures
-    int m_max_mip_res = 1 << 30;  ///< Don't use MIP levels higher than this
-    Imath::M44f m_Mw2c;           ///< world-to-"common" matrix
-    Imath::M44f m_Mc2w;           ///< common-to-world matrix
-    ustring m_substitute_image;   ///< Substitute this image for all others
-    ustring m_colorspace;         ///< Working color space
-    ustring m_colorconfigname;    ///< Filename of color config to use
+    int m_max_mip_res = 1 << 30;    ///< Don't use MIP levels higher than this
+    Imath::M44f m_Mw2c;             ///< world-to-"common" matrix
+    Imath::M44f m_Mc2w;             ///< common-to-world matrix
+    ustring m_substitute_image;     ///< Substitute this image for all others
+    ustring m_colorspace;           ///< Working color space
+    ustring m_colorconfigname;      ///< Filename of color config to use
+    ustring m_image_state_default;  ///< Default image state for file color spaces
 
     mutable FilenameMap m_files;    ///< Map file names to ImageCacheFile's
     ustring m_file_sweep_name;      ///< Sweeper for "clock" paging algorithm

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5789,7 +5789,7 @@ output_file(Oiiotool& ot, cspan<const char*> argv)
                 || Strutil::iends_with(filename, ".jpeg")
                 || Strutil::iends_with(filename, ".gif")
                 || Strutil::iends_with(filename, ".webp")))
-            outcolorspace = string_view("srgb_rec709_scene");
+            outcolorspace = string_view("srgb_rec709_display");
         if (outcolorspace.empty()
             && (Strutil::iends_with(filename, ".ppm")
                 || Strutil::iends_with(filename, ".pnm")))

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -18,6 +18,7 @@
 #include <OpenImageIO/tiffutils.h>
 #include <OpenImageIO/typedesc.h>
 
+#include "imageio_pvt.h"
 
 #define OIIO_LIBPNG_VERSION                                    \
     (PNG_LIBPNG_VER_MAJOR * 10000 + PNG_LIBPNG_VER_MINOR * 100 \
@@ -40,7 +41,6 @@ http://lists.openimageio.org/pipermail/oiio-dev-openimageio.org/2009-April/00065
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 #define ICC_PROFILE_ATTR "ICCProfile"
-#define CICP_ATTR "CICP"
 
 namespace PNG_pvt {
 
@@ -224,7 +224,8 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
     int srgb_intent;
     double gamma = 0.0;
     if (png_get_sRGB(sp, ip, &srgb_intent)) {
-        spec.attribute("oiio:ColorSpace", "srgb_rec709_scene");
+        const bool erase_other_attributes = false;
+        pvt::set_colorspace_srgb(spec, erase_other_attributes);
     } else if (png_get_gAMA(sp, ip, &gamma) && gamma > 0.0) {
         // Round gamma to the nearest hundredth to prevent stupid
         // precision choices and make it easier for apps to make
@@ -235,7 +236,8 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
         set_colorspace_rec709_gamma(spec, g);
     } else {
         // If there's no info at all, assume sRGB.
-        spec.attribute("oiio:ColorSpace", "srgb_rec709_scene");
+        const bool erase_other_attributes = false;
+        pvt::set_colorspace_srgb(spec, erase_other_attributes);
     }
 
     if (png_get_valid(sp, ip, PNG_INFO_iCCP)) {
@@ -331,11 +333,7 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
         png_byte pri = 0, trc = 0, mtx = 0, vfr = 0;
         if (png_get_cICP(sp, ip, &pri, &trc, &mtx, &vfr)) {
             const int cicp[4] = { pri, trc, mtx, vfr };
-            spec.attribute(CICP_ATTR, TypeDesc(TypeDesc::INT, 4), cicp);
-            const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
-            string_view interop_id = colorconfig.get_color_interop_id(cicp);
-            if (!interop_id.empty())
-                spec.attribute("oiio:ColorSpace", interop_id);
+            pvt::set_colorspace_cicp(spec, cicp);
         }
     }
 #endif
@@ -609,78 +607,34 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
     convert_alpha = spec.alpha_channel != -1
                     && !spec.get_int_attribute("oiio:UnassociatedAlpha", 0);
 
-    string_view colorspace = spec.get_string_attribute("oiio:ColorSpace",
-                                                       "srgb_rec709_scene");
-    const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
     OIIO_MAYBE_UNUSED bool wrote_colorspace = false;
     srgb                                    = false;
-    if (colorconfig.equivalent(colorspace, "srgb_rec709_scene")) {
-        srgb  = true;
+    if (pvt::is_colorspace_srgb(spec)) {
         gamma = 1.0f;
-    } else if (colorconfig.equivalent(colorspace, "g22_rec709_scene")) {
-        gamma = 2.2f;
-    } else if (colorconfig.equivalent(colorspace, "g24_rec709_scene")) {
-        gamma = 2.4f;
-    } else if (colorconfig.equivalent(colorspace, "g18_rec709_scene")) {
-        gamma = 1.8f;
-    } else {
-        gamma = spec.get_float_attribute("oiio:Gamma", 1.0f);
-        // obsolete "oiio:Gamma" attrib for back compatibility
-    }
-
-    if (colorconfig.equivalent(colorspace, "scene_linear")
-        || colorconfig.equivalent(colorspace, "lin_rec709_scene")) {
-        if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
-            return "Could not set PNG gAMA chunk";
-        png_set_gAMA(sp, ip, 1.0);
-        srgb             = false;
-        wrote_colorspace = true;
-    } else if (Strutil::istarts_with(colorspace, "Gamma")) {
-        // Back compatible, this is DEPRECATED(3.1)
-        Strutil::parse_word(colorspace);
-        float g = Strutil::from_string<float>(colorspace);
-        if (g >= 0.01f && g <= 10.0f /* sanity check */)
-            gamma = g;
-        if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
-            return "Could not set PNG gAMA chunk";
-        png_set_gAMA(sp, ip, 1.0f / gamma);
-        srgb             = false;
-        wrote_colorspace = true;
-    } else if (colorconfig.equivalent(colorspace, "g22_rec709_scene")) {
-        gamma = 2.2f;
-        if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
-            return "Could not set PNG gAMA chunk";
-        png_set_gAMA(sp, ip, 1.0f / gamma);
-        srgb             = false;
-        wrote_colorspace = true;
-    } else if (colorconfig.equivalent(colorspace, "g18_rec709_scene")) {
-        gamma = 1.8f;
-        if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
-            return "Could not set PNG gAMA chunk";
-        png_set_gAMA(sp, ip, 1.0f / gamma);
-        srgb             = false;
-        wrote_colorspace = true;
-    } else if (colorconfig.equivalent(colorspace, "srgb_rec709_scene")) {
+        srgb  = true;
         if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
             return "Could not set PNG gAMA and cHRM chunk";
         png_set_sRGB_gAMA_and_cHRM(sp, ip, PNG_sRGB_INTENT_ABSOLUTE);
-        srgb             = true;
         wrote_colorspace = true;
+    } else {
+        gamma = pvt::get_colorspace_rec709_gamma(spec);
+        if (gamma != 0.0f) {
+            if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
+                return "Could not set PNG gAMA chunk";
+            png_set_gAMA(sp, ip, 1.0 / gamma);
+            srgb             = false;
+            wrote_colorspace = true;
+        }
     }
 
     // Write ICC profile, if we have anything
-    const ParamValue* icc_profile_parameter = spec.find_attribute(
-        ICC_PROFILE_ATTR);
-    if (icc_profile_parameter != nullptr) {
-        unsigned int length = icc_profile_parameter->type().size();
+    std::vector<uint8_t> icc_profile = pvt::get_colorspace_icc_profile(spec);
+    if (icc_profile.size()) {
         if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
             return "Could not set PNG iCCP chunk";
-        unsigned char* icc_profile
-            = (unsigned char*)icc_profile_parameter->data();
-        if (icc_profile && length) {
-            png_set_iCCP(sp, ip, "Embedded Profile", 0, icc_profile, length);
-            wrote_colorspace = true;
-        }
+        png_set_iCCP(sp, ip, "Embedded Profile", 0, icc_profile.data(),
+                     icc_profile.size());
+        wrote_colorspace = true;
     }
 
     if (false && !spec.find_attribute("DateTime")) {
@@ -738,11 +692,7 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
 #ifdef PNG_cICP_SUPPORTED
     // Only automatically determine CICP from oiio::ColorSpace if we didn't
     // write colorspace metadata yet.
-    const ParamValue* p = spec.find_attribute(CICP_ATTR,
-                                              TypeDesc(TypeDesc::INT, 4));
-    cspan<int> cicp     = (p) ? p->as_cspan<int>()
-                          : (!wrote_colorspace) ? colorconfig.get_cicp(colorspace)
-                                                : cspan<int>();
+    cspan<int> cicp = pvt::get_colorspace_cicp(spec, !wrote_colorspace);
     if (!cicp.empty()) {
         png_byte vals[4];
         for (int i = 0; i < 4; ++i)

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -51,9 +51,10 @@ private:
     int m_subimage;                    ///< What subimage are we looking at?
     Imath::Color3f m_bg;               ///< Background color
     int m_next_scanline;
-    bool m_keep_unassociated_alpha;  ///< Do not convert unassociated alpha
-    bool m_linear_premult;           ///< Do premult for sRGB images in linear
-    bool m_srgb   = false;           ///< It's an sRGB image (not gamma)
+    bool m_keep_unassociated_alpha;     ///< Do not convert unassociated alpha
+    std::string m_image_state_default;  ///< Default image state for color space
+    bool m_linear_premult;  ///< Do premult for sRGB images in linear
+    bool m_srgb   = false;  ///< It's an sRGB image (not gamma)
     bool m_err    = false;
     float m_gamma = 1.0f;
     std::unique_ptr<ImageSpec> m_config;  // Saved copy of configuration spec
@@ -170,7 +171,8 @@ PNGInput::open(const std::string& name, ImageSpec& newspec)
 
     bool ok = PNG_pvt::read_info(m_png, m_info, m_bit_depth, m_color_type,
                                  m_interlace_type, m_bg, m_spec,
-                                 m_keep_unassociated_alpha);
+                                 m_keep_unassociated_alpha,
+                                 m_image_state_default);
     if (!ok || m_err
         || !check_open(m_spec, { 0, 1 << 20, 0, 1 << 20, 0, 1, 0, 4 })) {
         close();
@@ -203,6 +205,8 @@ PNGInput::open(const std::string& name, ImageSpec& newspec,
     // Check 'config' for any special requests
     if (config.get_int_attribute("oiio:UnassociatedAlpha", 0) == 1)
         m_keep_unassociated_alpha = true;
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
     m_linear_premult = config.get_int_attribute("png:linear_premult",
                                                 OIIO::get_int_attribute(
                                                     "png:linear_premult"));

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -177,22 +177,15 @@ PNGInput::open(const std::string& name, ImageSpec& newspec)
         return false;
     }
 
-    string_view colorspace = m_spec.get_string_attribute("oiio:ColorSpace",
-                                                         "srgb_rec709_scene");
-    const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
-    m_srgb = false;
-    if (colorconfig.equivalent(colorspace, "srgb_rec709_scene")) {
+    if (pvt::is_colorspace_srgb(m_spec)) {
         m_srgb  = true;
         m_gamma = 1.0f;
-    } else if (colorconfig.equivalent(colorspace, "g22_rec709_scene")) {
-        m_gamma = 2.2f;
-    } else if (colorconfig.equivalent(colorspace, "g24_rec709_scene")) {
-        m_gamma = 2.4f;
-    } else if (colorconfig.equivalent(colorspace, "g18_rec709_scene")) {
-        m_gamma = 1.8f;
     } else {
-        m_gamma = m_spec.get_float_attribute("oiio:Gamma", 1.0f);
-        // obsolete "oiio:Gamma" attrib for back compatibility
+        m_srgb  = false;
+        m_gamma = pvt::get_colorspace_rec709_gamma(m_spec);
+        if (m_gamma == 0.0f) {
+            m_gamma = 1.0f;
+        }
     }
 
     newspec         = spec();

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -645,7 +645,9 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         return false;
     }
     if (cs.empty()) {
-        pvt::set_colorspace_srgb(m_spec);
+        string_view image_state_default = m_config.get_string_attribute(
+            "oiio:ImageStateDefault");
+        pvt::set_colorspace_srgb(m_spec, image_state_default);
     } else {
         m_spec.set_colorspace(cs);
     }

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -578,8 +578,7 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
     } else if (cs.empty() || colorconfig.equivalent(cs, "srgb_rec709_display")
-               || colorconfig.equivalent(cs, "srgb_rec709_scene")
-               || Strutil::iequals(cs, "sRGB") /* Necessary? */) {
+               || colorconfig.equivalent(cs, "srgb_rec709_scene")) {
         // Request explicit sRGB, including usual sRGB response
         m_processor->imgdata.params.output_color = 1;
         m_processor->imgdata.params.gamm[0]      = 1.0 / 2.4;
@@ -589,7 +588,7 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
                || Strutil::iequals(cs, "lin_srgb")
                || Strutil::iequals(cs, "lin_rec709")
                || Strutil::iequals(cs, "linear") /* DEPRECATED */) {
-        // Request "sRGB" primaries, linear response
+        // Request sRGB primaries, linear response
         m_processor->imgdata.params.output_color = 1;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -19,6 +19,8 @@
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/tiffutils.h>
 
+#include "imageio_pvt.h"
+
 #if OIIO_GNUC_VERSION || OIIO_CLANG_VERSION
 // fix warnings in libraw headers: use of auto_ptr
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -569,14 +571,13 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
     // request for "sRGB-linear" will give you sRGB primaries with a linear
     // response.
     const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
-    std::string cs = config.get_string_attribute("raw:ColorSpace",
-                                                 "srgb_rec709_scene");
+    std::string cs = config.get_string_attribute("raw:ColorSpace");
     if (Strutil::iequals(cs, "raw")) {
         // Values straight from the chip
         m_processor->imgdata.params.output_color = 0;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
-    } else if (colorconfig.equivalent(cs, "srgb_rec709_scene")
+    } else if (cs.empty() || colorconfig.equivalent(cs, "srgb_rec709_scene")
                || Strutil::iequals(cs, "sRGB") /* Necessary? */) {
         // Request explicit sRGB, including usual sRGB response
         m_processor->imgdata.params.output_color = 1;
@@ -643,7 +644,11 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         errorfmt("raw:ColorSpace set to unknown value \"{}\"", cs);
         return false;
     }
-    m_spec.set_colorspace(cs);
+    if (cs.empty()) {
+        pvt::set_colorspace_srgb(m_spec);
+    } else {
+        m_spec.set_colorspace(cs);
+    }
 
     // Exposure adjustment
     float exposure = config.get_float_attribute("raw:Exposure", -1.0f);

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -577,7 +577,8 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         m_processor->imgdata.params.output_color = 0;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
-    } else if (cs.empty() || colorconfig.equivalent(cs, "srgb_rec709_scene")
+    } else if (cs.empty() || colorconfig.equivalent(cs, "srgb_rec709_display")
+               || colorconfig.equivalent(cs, "srgb_rec709_scene")
                || Strutil::iequals(cs, "sRGB") /* Necessary? */) {
         // Request explicit sRGB, including usual sRGB response
         m_processor->imgdata.params.output_color = 1;

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -524,7 +524,7 @@ TGAInput::get_thumbnail(ImageBuf& thumb, int subimage)
         // the thumbnail is in the same format as the main image but
         // uncompressed.
         ImageSpec thumbspec(res[0], res[1], m_spec.nchannels, TypeUInt8);
-        thumbspec.set_colorspace("srgb_rec709_scene");
+        pvt::set_colorspace_srgb(thumbspec);
         thumb.reset(thumbspec);
         int bytespp    = (m_tga.bpp == 15) ? 2 : (m_tga.bpp / 8);
         int palbytespp = (m_tga.cmap_size == 15) ? 2 : (m_tga.cmap_size / 8);

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -186,10 +186,11 @@ private:
     bool m_convert_alpha;            ///< Do we need to associate alpha?
     bool m_separate;                 ///< Separate planarconfig?
     bool m_testopenconfig;           ///< Debug aid to test open-with-config
-    bool m_use_rgba_interface;       ///< Sometimes we punt
-    bool m_is_byte_swapped;          ///< Is the file opposite our endian?
-    int m_rowsperstrip;              ///< For scanline imgs, rows per strip
-    unsigned short m_planarconfig;   ///< Planar config of the file
+    std::string m_image_state_default;  ///< Default image state for color space
+    bool m_use_rgba_interface;          ///< Sometimes we punt
+    bool m_is_byte_swapped;             ///< Is the file opposite our endian?
+    int m_rowsperstrip;                 ///< For scanline imgs, rows per strip
+    unsigned short m_planarconfig;      ///< Planar config of the file
     unsigned short m_bitspersample;  ///< Of the *file*, not the client's view
     unsigned short m_photometric;    ///< Of the *file*, not the client's view
     unsigned short m_compression;    ///< TIFF compression tag
@@ -773,6 +774,8 @@ TIFFInput::open(const std::string& name, ImageSpec& newspec,
     // OIIO components.
     if (config.get_int_attribute("oiio:DebugOpenConfig!", 0))
         m_testopenconfig = true;
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
     return open(name, newspec);
 }
 
@@ -1317,7 +1320,8 @@ TIFFInput::readspec(bool read_meta)
                 // NOTE: We do not erase other attributes as we want to
                 // preserve TIFF attributes.
                 const bool erase_other_attributes = false;
-                pvt::set_colorspace_srgb(m_spec, erase_other_attributes);
+                pvt::set_colorspace_srgb(m_spec, m_image_state_default,
+                                         erase_other_attributes);
             }
         }
         // TIFFReadEXIFDirectory seems to do something to the internal state

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1313,11 +1313,12 @@ TIFFInput::readspec(bool read_meta)
             }
             // Exif spec says that anything other than 0xffff==uncalibrated
             // should be interpreted to be sRGB.
-            if (m_spec.get_int_attribute("Exif:ColorSpace") != 0xffff)
-                m_spec.attribute("oiio:ColorSpace", "srgb_rec709_scene");
-            // NOTE: We must set "oiio:ColorSpace" explicitly, not call
-            // set_colorspace, or it will erase several other TIFF attribs we
-            // need to preserve.
+            if (m_spec.get_int_attribute("Exif:ColorSpace") != 0xffff) {
+                // NOTE: We do not erase other attributes as we want to
+                // preserve TIFF attributes.
+                const bool erase_other_attributes = false;
+                pvt::set_colorspace_srgb(m_spec, erase_other_attributes);
+            }
         }
         // TIFFReadEXIFDirectory seems to do something to the internal state
         // that requires a TIFFSetDirectory to set things straight again.

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -49,6 +49,7 @@ private:
     int m_subimage      = -1;                // Subimage we're pointed to
     int m_subimage_read = -1;                // Subimage stored in decoded_image
     bool m_keep_unassociated_alpha = false;  // Do not convert unassociated alpha
+    std::string m_image_state_default;  // Default image state for color space
 
     void init(void)
     {
@@ -164,7 +165,8 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
 
     m_spec = ImageSpec(w, h, (m_demux_flags & ALPHA_FLAG) ? 4 : 3, TypeUInt8);
     m_scanline_size = m_spec.scanline_bytes();
-    pvt::set_colorspace_srgb(m_spec);  // webp is always sRGB
+    pvt::set_colorspace_srgb(m_spec,
+                             m_image_state_default);  // webp is always sRGB
     if (m_demux_flags & ANIMATION_FLAG) {
         m_spec.attribute("oiio:Movie", 1);
         m_frame_count       = (int)WebPDemuxGetI(m_demux, WEBP_FF_FRAME_COUNT);
@@ -218,6 +220,9 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
 
     if (config.get_int_attribute("oiio:UnassociatedAlpha", 0) == 1)
         m_keep_unassociated_alpha = true;
+
+    m_image_state_default = config.get_string_attribute(
+        "oiio:ImageStateDefault");
 
     seek_subimage(0, 0);
     spec = m_spec;

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -7,6 +7,8 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/tiffutils.h>
 
+#include "imageio_pvt.h"
+
 #include <webp/decode.h>
 #include <webp/demux.h>
 
@@ -162,7 +164,7 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
 
     m_spec = ImageSpec(w, h, (m_demux_flags & ALPHA_FLAG) ? 4 : 3, TypeUInt8);
     m_scanline_size = m_spec.scanline_bytes();
-    m_spec.set_colorspace("srgb_rec709_scene");  // webp is always sRGB
+    pvt::set_colorspace_srgb(m_spec);  // webp is always sRGB
     if (m_demux_flags & ANIMATION_FLAG) {
         m_spec.attribute("oiio:Movie", 1);
         m_frame_count       = (int)WebPDemuxGetI(m_demux, WEBP_FF_FRAME_COUNT);

--- a/testsuite/bmp/ref/out.txt
+++ b/testsuite/bmp/ref/out.txt
@@ -4,7 +4,7 @@ Reading ../oiio-images/bmpsuite/g01bg.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g01bg.bmp" and "g01bg.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g01bw.bmp
@@ -13,7 +13,7 @@ Reading ../oiio-images/bmpsuite/g01bw.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g01bw.bmp" and "g01bw.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g01p1.bmp
@@ -22,7 +22,7 @@ Reading ../oiio-images/bmpsuite/g01p1.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g01p1.bmp" and "g01p1.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g01wb.bmp
@@ -31,7 +31,7 @@ Reading ../oiio-images/bmpsuite/g01wb.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g01wb.bmp" and "g01wb.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g04.bmp
@@ -40,7 +40,7 @@ Reading ../oiio-images/bmpsuite/g04.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 4
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g04.bmp" and "g04.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g04p4.bmp
@@ -49,7 +49,7 @@ Reading ../oiio-images/bmpsuite/g04p4.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 4
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g04p4.bmp" and "g04p4.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g04rle.bmp
@@ -59,7 +59,7 @@ Reading ../oiio-images/bmpsuite/g04rle.bmp
     compression: "rle4"
     bmp:bitsperpixel: 4
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g04rle.bmp" and "g04rle.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08.bmp
@@ -68,7 +68,7 @@ Reading ../oiio-images/bmpsuite/g08.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08.bmp" and "g08.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08os2.bmp
@@ -77,7 +77,7 @@ Reading ../oiio-images/bmpsuite/g08os2.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 1
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08os2.bmp" and "g08os2.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08p64.bmp
@@ -86,7 +86,7 @@ Reading ../oiio-images/bmpsuite/g08p64.bmp
     channel list: Y
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08p64.bmp" and "g08p64.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08p256.bmp
@@ -95,7 +95,7 @@ Reading ../oiio-images/bmpsuite/g08p256.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08p256.bmp" and "g08p256.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08pi64.bmp
@@ -104,7 +104,7 @@ Reading ../oiio-images/bmpsuite/g08pi64.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08pi64.bmp" and "g08pi64.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08pi256.bmp
@@ -113,7 +113,7 @@ Reading ../oiio-images/bmpsuite/g08pi256.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08pi256.bmp" and "g08pi256.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08res11.bmp
@@ -125,7 +125,7 @@ Reading ../oiio-images/bmpsuite/g08res11.bmp
     YResolution: 3937
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08res11.bmp" and "g08res11.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08res21.bmp
@@ -137,7 +137,7 @@ Reading ../oiio-images/bmpsuite/g08res21.bmp
     YResolution: 3937
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08res21.bmp" and "g08res21.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08res22.bmp
@@ -149,7 +149,7 @@ Reading ../oiio-images/bmpsuite/g08res22.bmp
     YResolution: 7874
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08res22.bmp" and "g08res22.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08s0.bmp
@@ -158,7 +158,7 @@ Reading ../oiio-images/bmpsuite/g08s0.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08s0.bmp" and "g08s0.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08w124.bmp
@@ -167,7 +167,7 @@ Reading ../oiio-images/bmpsuite/g08w124.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08w124.bmp" and "g08w124.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08w125.bmp
@@ -176,7 +176,7 @@ Reading ../oiio-images/bmpsuite/g08w125.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08w125.bmp" and "g08w125.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08w126.bmp
@@ -185,7 +185,7 @@ Reading ../oiio-images/bmpsuite/g08w126.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08w126.bmp" and "g08w126.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08rle.bmp
@@ -195,7 +195,7 @@ Reading ../oiio-images/bmpsuite/g08rle.bmp
     compression: "rle8"
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08rle.bmp" and "g08rle.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08offs.bmp
@@ -204,7 +204,7 @@ Reading ../oiio-images/bmpsuite/g08offs.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g08offs.bmp" and "g08offs.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g24.bmp
@@ -212,7 +212,7 @@ Reading ../oiio-images/bmpsuite/g24.bmp
     SHA-1: B1FB63649469F31D02D7AD065D3128EE04CC662E
     channel list: R, G, B
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g24.bmp" and "g24.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g32bf.bmp
@@ -220,7 +220,7 @@ Reading ../oiio-images/bmpsuite/g32bf.bmp
     SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
     channel list: R, G, B, A
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g32bf.bmp" and "g32bf.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g32def.bmp
@@ -228,7 +228,7 @@ Reading ../oiio-images/bmpsuite/g32def.bmp
     SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
     channel list: R, G, B, A
     bmp:version: 3
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g32def.bmp" and "g32def.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g16bf555.bmp
@@ -238,7 +238,7 @@ Reading ../oiio-images/bmpsuite/g16bf555.bmp
     bmp:bitsperpixel: 16
     bmp:version: 3
     oiio:BitsPerSample: 5
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g16bf555.bmp" and "g16bf555.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g16bf565.bmp
@@ -248,7 +248,7 @@ Reading ../oiio-images/bmpsuite/g16bf565.bmp
     bmp:bitsperpixel: 16
     bmp:version: 3
     oiio:BitsPerSample: 5
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g16bf565.bmp" and "g16bf565.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g16def555.bmp
@@ -258,7 +258,7 @@ Reading ../oiio-images/bmpsuite/g16def555.bmp
     bmp:bitsperpixel: 16
     bmp:version: 3
     oiio:BitsPerSample: 5
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmpsuite/g16def555.bmp" and "g16def555.bmp"
 PASS
 Reading src/g01bg2-v5.bmp
@@ -269,7 +269,7 @@ src/g01bg2-v5.bmp    :  127 x   64, 3 channel, uint8 bmp
     XResolution: 2835
     YResolution: 2835
     bmp:version: 5
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "src/g01bg2-v5.bmp" and "g01bg2-v5.bmp"
 PASS
 Reading src/PRINTER.BMP
@@ -278,7 +278,7 @@ src/PRINTER.BMP      :  160 x  120, 3 channel, uint8 bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 1
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "src/PRINTER.BMP" and "PRINTER.BMP"
 PASS
 Reading ../oiio-images/bmp/gracehopper.bmp
@@ -288,7 +288,7 @@ Reading ../oiio-images/bmp/gracehopper.bmp
     ResolutionUnit: "m"
     XResolution: 2835
     YResolution: 2835
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/bmp/gracehopper.bmp" and "gracehopper.bmp"
 PASS
 oiiotool ERROR: read : "src/decodecolormap-corrupt.bmp": Possible corrupted header, invalid palette size

--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -184,49 +184,49 @@ Reading ../oiio-images/dds/dds_dxgi_bc1_srgb.dds
     channel list: R, G, B, A
     compression: "DXT1"
     textureformat: "Plain Texture"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/dds/dds_dxgi_bc2_srgb.dds
 ../oiio-images/dds/dds_dxgi_bc2_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: D99494018941ADCA11EAE469D8C6E598DA37A8BF
     channel list: R, G, B, A
     compression: "DXT3"
     textureformat: "Plain Texture"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/dds/dds_dxgi_bc3_srgb.dds
 ../oiio-images/dds/dds_dxgi_bc3_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 75F9FCD1920A00966F2FE13DF40F4FB0A6CD8DED
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/dds/dds_dxgi_bc7_srgb.dds
 ../oiio-images/dds/dds_dxgi_bc7_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 91DBAC0E5ED54D5BBEECA4C48AB704FA9F7FE317
     channel list: R, G, B, A
     compression: "BC7"
     textureformat: "Plain Texture"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/dds/dds_dxgi_rgba8_srgb.dds
 ../oiio-images/dds/dds_dxgi_rgba8_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 61986C7E2D4F402B4A268AE5187AAFAF1647C0E6
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/dds/dds_dxgi_bgra8_srgb.dds
 ../oiio-images/dds/dds_dxgi_bgra8_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 61986C7E2D4F402B4A268AE5187AAFAF1647C0E6
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/dds/dds_dxgi_bgrx8_srgb.dds
 ../oiio-images/dds/dds_dxgi_bgrx8_srgb.dds :   16 x    8, 3 channel, uint8 dds
     SHA-1: 6BF57CCCCF14021926285CE97D25AEC150324476
     channel list: R, G, B
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/dds/dds_dxgi_rgb10a2.dds
 ../oiio-images/dds/dds_dxgi_rgb10a2.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: F38B31F89991752DAB792DC9FF29F7F7DE0E7911

--- a/testsuite/gif/ref/out.txt
+++ b/testsuite/gif/ref/out.txt
@@ -6,21 +6,21 @@ Reading ../oiio-images/gif/gif_animation.gif
     channel list: R, G, B, A
     FramesPerSecond: 100/123 (0.813008)
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:Movie: 1
  subimage  1:   30 x   30, 4 channel, uint8 gif
     SHA-1: D69F1E35C727EEC9E3DF750374E41D42192DFFBE
     channel list: R, G, B, A
     FramesPerSecond: 100/123 (0.813008)
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:Movie: 1
  subimage  2:   30 x   30, 4 channel, uint8 gif
     SHA-1: 3897B49CE5378D3C65590497269B1BB3F9D7630F
     channel list: R, G, B, A
     FramesPerSecond: 100/123 (0.813008)
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:Movie: 1
 Reading ../oiio-images/gif/gif_oiio_logo_with_alpha.gif
 ../oiio-images/gif/gif_oiio_logo_with_alpha.gif :  135 x  135, 4 channel, uint8 gif
@@ -28,37 +28,37 @@ Reading ../oiio-images/gif/gif_oiio_logo_with_alpha.gif
     channel list: R, G, B, A
     ImageDescription: "oiio logo with alpha"
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/gif/gif_tahoe.gif
 ../oiio-images/gif/gif_tahoe.gif : 2048 x 1536, 4 channel, uint8 gif
     SHA-1: 4E76899178CDAA94690E52CD18E07B810E40A273
     channel list: R, G, B, A
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/gif/gif_tahoe_interlaced.gif
 ../oiio-images/gif/gif_tahoe_interlaced.gif : 2048 x 1536, 4 channel, uint8 gif
     SHA-1: 4E76899178CDAA94690E52CD18E07B810E40A273
     channel list: R, G, B, A
     gif:Interlacing: 1
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/gif/gif_bluedot.gif
 ../oiio-images/gif/gif_bluedot.gif :    1 x    1, 4 channel, uint8 gif
     SHA-1: EE0202803A0133BDA7BC40AC63091DCC58A4225B
     channel list: R, G, B, A
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/gif/gif_diagonal_interlaced.gif
 ../oiio-images/gif/gif_diagonal_interlaced.gif :  200 x  200, 4 channel, uint8 gif
     SHA-1: CE1C613BB8B7EE80673B640CA3E392345C8C9FF4
     channel list: R, G, B, A
     gif:Interlacing: 1
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/gif/gif_triangle_interlaced.gif
 ../oiio-images/gif/gif_triangle_interlaced.gif :  200 x  200, 4 channel, uint8 gif
     SHA-1: 44F8A0F4F39AB3ED532268B9EB45E09548925345
     channel list: R, G, B, A
     gif:Interlacing: 1
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/gif/gif_test_disposal_method.gif
 ../oiio-images/gif/gif_test_disposal_method.gif :   50 x   50, 4 channel, uint8 gif
     4 subimages: 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8]
@@ -66,29 +66,29 @@ Reading ../oiio-images/gif/gif_test_disposal_method.gif
     SHA-1: 30839F361083DA6893F6A29B4F4628DCFBF9F1B5
     channel list: R, G, B, A
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
  subimage  1:   50 x   50, 4 channel, uint8 gif
     SHA-1: 214A1EE026296A399D8A530C44275FC5BDFBA3BA
     channel list: R, G, B, A
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
  subimage  2:   50 x   50, 4 channel, uint8 gif
     SHA-1: 298C45330E7FAF68A6922C521EA766CA1594B1A4
     channel list: R, G, B, A
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
  subimage  3:   50 x   50, 4 channel, uint8 gif
     SHA-1: 6D46A3F714B4BD68D289B9A945FF2716F1EB3A64
     channel list: R, G, B, A
     gif:Interlacing: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/gif/gif_test_loop_count.gif
 ../oiio-images/gif/gif_test_loop_count.gif :   20 x   20, 4 channel, uint8 gif
     SHA-1: C4AA837A5833B05CFCA50BD090D42AEB033069E1
     channel list: R, G, B, A
     gif:Interlacing: 0
     gif:LoopCount: 12345
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:LoopCount: 12345
 Reading tahoe-tiny.gif
 tahoe-tiny.gif       :  128 x   96, 4 channel, uint8 gif
@@ -97,6 +97,6 @@ tahoe-tiny.gif       :  128 x   96, 4 channel, uint8 gif
     FramesPerSecond: 100/100 (1)
     gif:Interlacing: 0
     gif:LoopCount: 0
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:LoopCount: 0
     oiio:Movie: 1

--- a/testsuite/gpsread/ref/out-alt.txt
+++ b/testsuite/gpsread/ref/out-alt.txt
@@ -29,7 +29,7 @@ Reading ../oiio-images/tahoe-gps.jpg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading tahoe-gps.jpg
 tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
@@ -58,4 +58,4 @@ tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/gpsread/ref/out-jpeg9d.txt
+++ b/testsuite/gpsread/ref/out-jpeg9d.txt
@@ -29,7 +29,7 @@ Reading ../oiio-images/tahoe-gps.jpg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading tahoe-gps.jpg
 tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: A74C7DF2B01825DCB6881407AE77C11DC56AB741
@@ -58,4 +58,4 @@ tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/gpsread/ref/out.txt
+++ b/testsuite/gpsread/ref/out.txt
@@ -29,7 +29,7 @@ Reading ../oiio-images/tahoe-gps.jpg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading tahoe-gps.jpg
 tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
@@ -58,4 +58,4 @@ tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/heif/ref/out-libheif1.12-orient.txt
+++ b/testsuite/heif/ref/out-libheif1.12-orient.txt
@@ -38,12 +38,12 @@ ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
     Exif:SubsecTimeDigitized: "006"
     Exif:SubsecTimeOriginal: "006"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/Chimera-AV1-8bit-162.avif
 ref/Chimera-AV1-8bit-162.avif :  480 x  270, 3 channel, uint8 heif
     SHA-1: F8FDAF1BD56A21E3AF99CF8EE7FA45434D2826C7
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/test-10bit.avif
 ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     SHA-1: A217653C4E10FEBF080E26F9FC78F572184B1FDA
@@ -54,7 +54,7 @@ ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading cicp_pq.avif
 cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
@@ -132,7 +132,7 @@ Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
     GPS:LongitudeRef: "E"
     GPS:Speed: 0.171966
     GPS:SpeedRef: "K" (km/hour)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:OriginalOrientation: 8
 Reading ../oiio-images/heif/sewing-threads.heic
 ../oiio-images/heif/sewing-threads.heic : 4000 x 3000, 3 channel, uint8 heif
@@ -181,4 +181,4 @@ Reading ../oiio-images/heif/sewing-threads.heic
     GPS:LatitudeRef: "N"
     GPS:Longitude: 1, 49, 34.0187
     GPS:LongitudeRef: "E"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/heif/ref/out-libheif1.4.txt
+++ b/testsuite/heif/ref/out-libheif1.4.txt
@@ -38,12 +38,12 @@ ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
     Exif:SubsecTimeDigitized: "006"
     Exif:SubsecTimeOriginal: "006"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/Chimera-AV1-8bit-162.avif
 ref/Chimera-AV1-8bit-162.avif :  480 x  270, 3 channel, uint8 heif
     SHA-1: F8FDAF1BD56A21E3AF99CF8EE7FA45434D2826C7
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/test-10bit.avif
 ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     SHA-1: A217653C4E10FEBF080E26F9FC78F572184B1FDA
@@ -54,7 +54,7 @@ ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading cicp_pq.avif
 cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
@@ -132,7 +132,7 @@ Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
     GPS:LongitudeRef: "E"
     GPS:Speed: 0.171966
     GPS:SpeedRef: "K" (km/hour)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:OriginalOrientation: 6
 Reading ../oiio-images/heif/sewing-threads.heic
 ../oiio-images/heif/sewing-threads.heic : 4000 x 3000, 3 channel, uint8 heif
@@ -181,4 +181,4 @@ Reading ../oiio-images/heif/sewing-threads.heic
     GPS:LatitudeRef: "N"
     GPS:Longitude: 1, 49, 34.0187
     GPS:LongitudeRef: "E"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/heif/ref/out-libheif1.5.txt
+++ b/testsuite/heif/ref/out-libheif1.5.txt
@@ -38,12 +38,12 @@ ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
     Exif:SubsecTimeDigitized: "006"
     Exif:SubsecTimeOriginal: "006"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/Chimera-AV1-8bit-162.avif
 ref/Chimera-AV1-8bit-162.avif :  480 x  270, 3 channel, uint8 heif
     SHA-1: F8FDAF1BD56A21E3AF99CF8EE7FA45434D2826C7
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/test-10bit.avif
 ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     SHA-1: A217653C4E10FEBF080E26F9FC78F572184B1FDA
@@ -54,7 +54,7 @@ ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading cicp_pq.avif
 cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
@@ -132,7 +132,7 @@ Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
     GPS:LongitudeRef: "E"
     GPS:Speed: 0.171966
     GPS:SpeedRef: "K" (km/hour)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:OriginalOrientation: 6
 Reading ../oiio-images/heif/sewing-threads.heic
 ../oiio-images/heif/sewing-threads.heic : 4000 x 3000, 3 channel, uint8 heif
@@ -181,4 +181,4 @@ Reading ../oiio-images/heif/sewing-threads.heic
     GPS:LatitudeRef: "N"
     GPS:Longitude: 1, 49, 34.0187
     GPS:LongitudeRef: "E"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/heif/ref/out-libheif1.9-alt2.txt
+++ b/testsuite/heif/ref/out-libheif1.9-alt2.txt
@@ -38,7 +38,7 @@ ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
     Exif:SubsecTimeDigitized: "006"
     Exif:SubsecTimeOriginal: "006"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
 ../oiio-images/heif/greyhounds-looking-for-a-table.heic : 3024 x 4032, 3 channel, uint8 heif
     SHA-1: 8064B23A1A995B0D6525AFB5248EEC6C730BBB6C
@@ -96,7 +96,7 @@ Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
     GPS:LongitudeRef: "E"
     GPS:Speed: 0.171966
     GPS:SpeedRef: "K" (km/hour)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:OriginalOrientation: 6
 Reading ../oiio-images/heif/sewing-threads.heic
 ../oiio-images/heif/sewing-threads.heic : 4000 x 3000, 3 channel, uint8 heif
@@ -145,4 +145,4 @@ Reading ../oiio-images/heif/sewing-threads.heic
     GPS:LatitudeRef: "N"
     GPS:Longitude: 1, 49, 34.0187
     GPS:LongitudeRef: "E"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/heif/ref/out-libheif1.9-with-av1-alt2.txt
+++ b/testsuite/heif/ref/out-libheif1.9-with-av1-alt2.txt
@@ -38,12 +38,12 @@ ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
     Exif:SubsecTimeDigitized: "006"
     Exif:SubsecTimeOriginal: "006"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/Chimera-AV1-8bit-162.avif
 ref/Chimera-AV1-8bit-162.avif :  480 x  270, 3 channel, uint8 heif
     SHA-1: F8FDAF1BD56A21E3AF99CF8EE7FA45434D2826C7
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/test-10bit.avif
 ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     SHA-1: A217653C4E10FEBF080E26F9FC78F572184B1FDA
@@ -54,7 +54,7 @@ ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading cicp_pq.avif
 cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
@@ -132,7 +132,7 @@ Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
     GPS:LongitudeRef: "E"
     GPS:Speed: 0.171966
     GPS:SpeedRef: "K" (km/hour)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:OriginalOrientation: 6
 Reading ../oiio-images/heif/sewing-threads.heic
 ../oiio-images/heif/sewing-threads.heic : 4000 x 3000, 3 channel, uint8 heif
@@ -181,4 +181,4 @@ Reading ../oiio-images/heif/sewing-threads.heic
     GPS:LatitudeRef: "N"
     GPS:Longitude: 1, 49, 34.0187
     GPS:LongitudeRef: "E"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/heif/ref/out-libheif1.9-with-av1.txt
+++ b/testsuite/heif/ref/out-libheif1.9-with-av1.txt
@@ -38,12 +38,12 @@ ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
     Exif:SubsecTimeDigitized: "006"
     Exif:SubsecTimeOriginal: "006"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/Chimera-AV1-8bit-162.avif
 ref/Chimera-AV1-8bit-162.avif :  480 x  270, 3 channel, uint8 heif
     SHA-1: F8FDAF1BD56A21E3AF99CF8EE7FA45434D2826C7
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ref/test-10bit.avif
 ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     SHA-1: A217653C4E10FEBF080E26F9FC78F572184B1FDA
@@ -54,7 +54,7 @@ ref/test-10bit.avif  :   16 x   16, 4 channel, uint10 heif
     Exif:ImageHistory: "oiiotool --pattern fill:topleft=1,0,0,1:topright=0,1,0,1:bottomleft=0,0,1,1:bottomright=1,1,1,1 16x16 4 -d uint16 -o test16.png"
     heif:UnassociatedAlpha: 1
     oiio:BitsPerSample: 10
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading cicp_pq.avif
 cicp_pq.avif         :   16 x   16, 4 channel, uint10 heif
     SHA-1: 0F3CAB52D479BC23E9C981DBADDFEF1F792E5540
@@ -132,7 +132,7 @@ Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
     GPS:LongitudeRef: "E"
     GPS:Speed: 0.171966
     GPS:SpeedRef: "K" (km/hour)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:OriginalOrientation: 6
 Reading ../oiio-images/heif/sewing-threads.heic
 ../oiio-images/heif/sewing-threads.heic : 4000 x 3000, 3 channel, uint8 heif
@@ -181,4 +181,4 @@ Reading ../oiio-images/heif/sewing-threads.heic
     GPS:LatitudeRef: "N"
     GPS:Longitude: 1, 49, 34.0187
     GPS:LongitudeRef: "E"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/heif/ref/out-libheif1.9.txt
+++ b/testsuite/heif/ref/out-libheif1.9.txt
@@ -38,7 +38,7 @@ ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
     Exif:SubsecTimeDigitized: "006"
     Exif:SubsecTimeOriginal: "006"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
 ../oiio-images/heif/greyhounds-looking-for-a-table.heic : 3024 x 4032, 3 channel, uint8 heif
     SHA-1: 8211F56BBABDC7615CCAF67CBF49741D1A292D2E
@@ -96,7 +96,7 @@ Reading ../oiio-images/heif/greyhounds-looking-for-a-table.heic
     GPS:LongitudeRef: "E"
     GPS:Speed: 0.171966
     GPS:SpeedRef: "K" (km/hour)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:OriginalOrientation: 6
 Reading ../oiio-images/heif/sewing-threads.heic
 ../oiio-images/heif/sewing-threads.heic : 4000 x 3000, 3 channel, uint8 heif
@@ -145,4 +145,4 @@ Reading ../oiio-images/heif/sewing-threads.heic
     GPS:LatitudeRef: "N"
     GPS:Longitude: 1, 49, 34.0187
     GPS:LongitudeRef: "E"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/ico/ref/out.txt
+++ b/testsuite/ico/ref/out.txt
@@ -29,7 +29,7 @@ Reading ../oiio-images/ico/oiio.ico
     SHA-1: F44C9B94AB7D612F62A4DC29FD9C56FD173F2614
     channel list: R, G, B, A
     oiio:BitsPerSample: 2
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:UnassociatedAlpha: 1
  subimage  7:   48 x   48, 4 channel, uint8 ico
     SHA-1: 127700A3DACBF25FCD800642D78F8EE91EDE24B9

--- a/testsuite/jpeg-corrupt/ref/out-alt.txt
+++ b/testsuite/jpeg-corrupt/ref/out-alt.txt
@@ -7,7 +7,7 @@ src/corrupt-exif.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/corrupt-exif-1626.jpg
 src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     SHA-1: 6CBB7DB602A67DB300AB28842F20F6DCA02B82B1
@@ -17,6 +17,6 @@ src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 corrupt-icc-4551.jpg
 DCT coefficient (lossy) or spatial difference (lossless) out of range

--- a/testsuite/jpeg-corrupt/ref/out-alt2.txt
+++ b/testsuite/jpeg-corrupt/ref/out-alt2.txt
@@ -7,7 +7,7 @@ src/corrupt-exif.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/corrupt-exif-1626.jpg
 src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     SHA-1: FB711E5A0E4440C6B7C7A94835C44706569FFB78
@@ -17,7 +17,7 @@ src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 corrupt-icc-4551.jpg
 DCT coefficient (lossy) or spatial difference (lossless) out of range
 Reading src/corrupt-icc-4552.jpg
@@ -43,4 +43,4 @@ src/corrupt-icc-4552.jpg : 1500 x 1000, 3 channel, uint8 jpeg
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Unknown"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/jpeg-corrupt/ref/out-alt3.txt
+++ b/testsuite/jpeg-corrupt/ref/out-alt3.txt
@@ -7,7 +7,7 @@ src/corrupt-exif.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/corrupt-exif-1626.jpg
 src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     SHA-1: 6CBB7DB602A67DB300AB28842F20F6DCA02B82B1
@@ -17,7 +17,7 @@ src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 corrupt-icc-4551.jpg
 Reading src/corrupt-icc-4552.jpg
 src/corrupt-icc-4552.jpg : 1500 x 1000, 3 channel, uint8 jpeg
@@ -42,4 +42,4 @@ src/corrupt-icc-4552.jpg : 1500 x 1000, 3 channel, uint8 jpeg
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Unknown"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/jpeg-corrupt/ref/out-alt4.txt
+++ b/testsuite/jpeg-corrupt/ref/out-alt4.txt
@@ -7,7 +7,7 @@ src/corrupt-exif.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/corrupt-exif-1626.jpg
 src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     SHA-1: FB711E5A0E4440C6B7C7A94835C44706569FFB78
@@ -17,7 +17,7 @@ src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 corrupt-icc-4551.jpg
 DCT coefficient out of range
 Reading src/corrupt-icc-4552.jpg
@@ -43,4 +43,4 @@ src/corrupt-icc-4552.jpg : 1500 x 1000, 3 channel, uint8 jpeg
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Unknown"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/jpeg-corrupt/ref/out.txt
+++ b/testsuite/jpeg-corrupt/ref/out.txt
@@ -7,7 +7,7 @@ src/corrupt-exif.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/corrupt-exif-1626.jpg
 src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     SHA-1: 6CBB7DB602A67DB300AB28842F20F6DCA02B82B1
@@ -17,7 +17,7 @@ src/corrupt-exif-1626.jpg :  256 x  256, 3 channel, uint8 jpeg
     XResolution: 300
     YResolution: 300
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 corrupt-icc-4551.jpg
 DCT coefficient (lossy) or spatial difference (lossless) out of range
 Reading src/corrupt-icc-4552.jpg
@@ -43,4 +43,4 @@ src/corrupt-icc-4552.jpg : 1500 x 1000, 3 channel, uint8 jpeg
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Unknown"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/jpeg-metadata/ref/out.txt
+++ b/testsuite/jpeg-metadata/ref/out.txt
@@ -10,7 +10,7 @@ src/blender-render.jpg :  640 x  480, 3 channel, uint8 jpeg
     Blender:Scene: "Scene"
     Blender:Time: "00:00:00:01"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "src/blender-render.jpg" and "no-attribs.jpg"
 PASS
 Reading no-attribs.jpg
@@ -21,7 +21,7 @@ no-attribs.jpg       :  640 x  480, 3 channel, uint8 jpeg
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/blender-render.jpg
 src/blender-render.jpg :  640 x  480, 3 channel, uint8 jpeg
     SHA-1: A60D05FC42FDEE2FC8907531E3641C17D7C1E3AB
@@ -34,7 +34,7 @@ src/blender-render.jpg :  640 x  480, 3 channel, uint8 jpeg
     Blender:Scene: "Scene"
     Blender:Time: "00:00:00:01"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "src/blender-render.jpg" and "with-attribs.jpg"
 PASS
 Reading with-attribs.jpg
@@ -52,7 +52,7 @@ with-attribs.jpg     :  640 x  480, 3 channel, uint8 jpeg
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/blender-render.jpg
 src/blender-render.jpg :  640 x  480, 3 channel, uint8 jpeg
     SHA-1: A60D05FC42FDEE2FC8907531E3641C17D7C1E3AB
@@ -65,7 +65,7 @@ src/blender-render.jpg :  640 x  480, 3 channel, uint8 jpeg
     Blender:Scene: "Scene"
     Blender:Time: "00:00:00:01"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "src/blender-render.jpg" and "with-attribs-and-desc.jpg"
 PASS
 Reading with-attribs-and-desc.jpg
@@ -84,7 +84,7 @@ with-attribs-and-desc.jpg :  640 x  480, 3 channel, uint8 jpeg
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading src/blender-render.jpg
 src/blender-render.jpg :  640 x  480, 3 channel, uint8 jpeg
     SHA-1: A60D05FC42FDEE2FC8907531E3641C17D7C1E3AB
@@ -97,7 +97,7 @@ src/blender-render.jpg :  640 x  480, 3 channel, uint8 jpeg
     Blender:Scene: "Scene"
     Blender:Time: "00:00:00:01"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "src/blender-render.jpg" and "with-colon-desc.jpg"
 PASS
 Reading with-colon-desc.jpg
@@ -109,4 +109,4 @@ with-colon-desc.jpg  :  640 x  480, 3 channel, uint8 jpeg
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/jpeg/ref/out.txt
+++ b/testsuite/jpeg/ref/out.txt
@@ -4,6 +4,6 @@ src/YCbCrK.jpg       :   52 x   52, 3 channel, uint8 jpeg
     channel list: R, G, B
     jpeg:ColorSpace: "YCbCrK"
     jpeg:subsampling: "4:4:4"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "rgb-from-YCbCrK.tif" and "ref/rgb-from-YCbCrK.tif"
 PASS

--- a/testsuite/jpeg2000-j2kp4files/ref/out-alt.txt
+++ b/testsuite/jpeg2000-j2kp4files/ref/out-alt.txt
@@ -3,7 +3,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file1.jp2
     SHA-1: 746B1B44D0E5EE3999B1350B2A4245D679A617F7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file1.jp2" and "file1.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file2.jp2
@@ -11,7 +11,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file2.jp2
     SHA-1: FB4746F0C4909CE8FED60C0179B70B2EEA0C0BA9
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file2.jp2" and "file2.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file3.jp2
@@ -19,7 +19,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file3.jp2
     SHA-1: B8A8FBF015263C072B051839F6BE645E7F27C671
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file3.jp2" and "file3.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file4.jp2
@@ -27,7 +27,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file4.jp2
     SHA-1: A45171430806BA3E74705675C855A781FC04BE44
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file4.jp2" and "file4.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
@@ -52,7 +52,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
     ICCProfile:profile_version: "2.2.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file6.jp2
@@ -60,7 +60,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file6.jp2
     SHA-1: 3A29DFAD0AA3F910AA2D37007989A4CC6E7BDE2A
     channel list: Y
     oiio:BitsPerSample: 12
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file6.jp2" and "file6.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
@@ -87,7 +87,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 16
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
@@ -112,7 +112,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
     ICCProfile:profile_version: "2.2.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file9.jp2
@@ -120,6 +120,6 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file9.jp2
     SHA-1: 501807547A6F9B8FA61EF7A4FD9AB7B369E7800C
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file9.jp2" and "file9.jp2"
 PASS

--- a/testsuite/jpeg2000-j2kp4files/ref/out-spinux.txt
+++ b/testsuite/jpeg2000-j2kp4files/ref/out-spinux.txt
@@ -3,7 +3,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file1.jp2
     SHA-1: 746B1B44D0E5EE3999B1350B2A4245D679A617F7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file1.jp2" and "file1.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file2.jp2
@@ -11,7 +11,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file2.jp2
     SHA-1: FB4746F0C4909CE8FED60C0179B70B2EEA0C0BA9
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file2.jp2" and "file2.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file3.jp2
@@ -19,7 +19,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file3.jp2
     SHA-1: B8A8FBF015263C072B051839F6BE645E7F27C671
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file3.jp2" and "file3.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file4.jp2
@@ -27,7 +27,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file4.jp2
     SHA-1: A45171430806BA3E74705675C855A781FC04BE44
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file4.jp2" and "file4.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
@@ -52,7 +52,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
     ICCProfile:profile_version: "2.2.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file6.jp2
@@ -60,7 +60,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file6.jp2
     SHA-1: 3A29DFAD0AA3F910AA2D37007989A4CC6E7BDE2A
     channel list: Y
     oiio:BitsPerSample: 12
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file6.jp2" and "file6.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
@@ -87,7 +87,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 16
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
@@ -112,7 +112,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
     ICCProfile:profile_version: "2.2.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file9.jp2
@@ -120,6 +120,6 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file9.jp2
     SHA-1: 9784D248E95A47CDB3D0B260C7FBFFE2A4A2D492
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file9.jp2" and "file9.jp2"
 PASS

--- a/testsuite/jpeg2000-j2kp4files/ref/out.txt
+++ b/testsuite/jpeg2000-j2kp4files/ref/out.txt
@@ -3,7 +3,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file1.jp2
     SHA-1: 746B1B44D0E5EE3999B1350B2A4245D679A617F7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file1.jp2" and "file1.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file2.jp2
@@ -11,7 +11,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file2.jp2
     SHA-1: 668A651D2B8C3B99CCCC560F993F5BBD33F2B3E7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file2.jp2" and "file2.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file3.jp2
@@ -19,7 +19,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file3.jp2
     SHA-1: B8A8FBF015263C072B051839F6BE645E7F27C671
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file3.jp2" and "file3.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file4.jp2
@@ -27,7 +27,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file4.jp2
     SHA-1: A45171430806BA3E74705675C855A781FC04BE44
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file4.jp2" and "file4.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
@@ -52,7 +52,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
     ICCProfile:profile_version: "2.2.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file6.jp2
@@ -60,7 +60,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file6.jp2
     SHA-1: 3A29DFAD0AA3F910AA2D37007989A4CC6E7BDE2A
     channel list: Y
     oiio:BitsPerSample: 12
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file6.jp2" and "file6.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
@@ -87,7 +87,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 16
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
@@ -112,7 +112,7 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
     ICCProfile:profile_version: "2.2.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../j2kp4files_v1_5/testfiles_jp2/file9.jp2
@@ -120,6 +120,6 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file9.jp2
     SHA-1: 501807547A6F9B8FA61EF7A4FD9AB7B369E7800C
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file9.jp2" and "file9.jp2"
 PASS

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -15,7 +15,7 @@ nomakegps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading nomake.jpg
 nomake.jpg           : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: A74C7DF2B01825DCB6881407AE77C11DC56AB741
@@ -43,7 +43,7 @@ nomake.jpg           : 2048 x 1536, 3 channel, uint8 jpeg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading nogps.jpg
 nogps.jpg            : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: A74C7DF2B01825DCB6881407AE77C11DC56AB741
@@ -62,13 +62,13 @@ nogps.jpg            : 2048 x 1536, 3 channel, uint8 jpeg
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading noattribs.jpg
 noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: A74C7DF2B01825DCB6881407AE77C11DC56AB741
     channel list: R, G, B
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 initial keywords=
 after adding, keywords=foo; bar
 after clearing, keywords=
@@ -156,7 +156,7 @@ tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading tahoe-icc.webp
 tahoe-icc.webp       :  128 x   96, 3 channel, uint8 webp
     SHA-1: 407D97F3D62F90C7F9A78AF85989ED3C06C59523
@@ -178,4 +178,4 @@ tahoe-icc.webp       :  128 x   96, 3 channel, uint8 webp
     ICCProfile:profile_size: 560
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -15,7 +15,7 @@ nomakegps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading nomake.jpg
 nomake.jpg           : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
@@ -43,7 +43,7 @@ nomake.jpg           : 2048 x 1536, 3 channel, uint8 jpeg
     GPS:TimeStamp: 17, 56, 33
     GPS:VersionID: 2, 2, 0, 0
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading nogps.jpg
 nogps.jpg            : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
@@ -62,13 +62,13 @@ nogps.jpg            : 2048 x 1536, 3 channel, uint8 jpeg
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 1
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading noattribs.jpg
 noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
     channel list: R, G, B
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 initial keywords=
 after adding, keywords=foo; bar
 after clearing, keywords=
@@ -156,7 +156,7 @@ tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
     jpeg:subsampling: "4:2:0"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading tahoe-icc.webp
 tahoe-icc.webp       :  128 x   96, 3 channel, uint8 webp
     SHA-1: 407D97F3D62F90C7F9A78AF85989ED3C06C59523
@@ -178,4 +178,4 @@ tahoe-icc.webp       :  128 x   96, 3 channel, uint8 webp
     ICCProfile:profile_size: 560
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"

--- a/testsuite/png/ref/out-libpng15.txt
+++ b/testsuite/png/ref/out-libpng15.txt
@@ -106,18 +106,18 @@ Reading g22_rec709_display.png
 g22_rec709_display.png :   64 x   64, 3 channel, uint8 png
     SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
     channel list: R, G, B
-    oiio:ColorSpace: "g22_rec709_display"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading g22_rec709_scene.png
 g22_rec709_scene.png :   64 x   64, 3 channel, uint8 png
     SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
     channel list: R, G, B
-    oiio:ColorSpace: "g22_rec709_scene"
+    oiio:ColorSpace: "g22_rec709_display"
     oiio:Gamma: 2.2
 Reading test16.png
 test16.png           :   16 x   16, 4 channel, uint16 png
     SHA-1: 6BDC50A9C1C3E9735D95A08B410FF893AA767415
     channel list: R, G, B, A
-    oiio:ColorSpace: "srgb_rec709_display"
+    oiio:ColorSpace: "srgb_rec709_scene"
 Reading test16.png
 test16.png           :   16 x   16, 4 channel, uint16 png
     SHA-1: 6BDC50A9C1C3E9735D95A08B410FF893AA767415

--- a/testsuite/png/ref/out-libpng15.txt
+++ b/testsuite/png/ref/out-libpng15.txt
@@ -7,7 +7,7 @@ Reading ../oiio-images/png/oiio-logo-no-alpha.png
     ResolutionUnit: "inch"
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/png/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
 PASS
 Reading ../oiio-images/png/oiio-logo-with-alpha.png
@@ -19,7 +19,7 @@ Reading ../oiio-images/png/oiio-logo-with-alpha.png
     ResolutionUnit: "inch"
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/png/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
 Reading exif.png
@@ -30,7 +30,7 @@ exif.png             :   64 x   64, 3 channel, uint8 png
     Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 45.7 (45.7 mm)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 alphagamma:
    1 x    1, 4 channel, float png
     channel list: R, G, B, A
@@ -78,7 +78,7 @@ gimp_gradient:
     ICCProfile:profile_size: 672
     ICCProfile:profile_version: "4.4.0"
     ICCProfile:rendering_intent: "Perceptual"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     Stats Min: 0 0 0 0 (of 255)
     Stats Max: 255 255 0 255 (of 255)
     Stats Avg: 142.37 105.72 0.00 154.72 (of 255)
@@ -93,14 +93,35 @@ smallalpha.png       :    1 x    1, 4 channel, uint8 png
 cicp:
   16 x   16, 4 channel, float png
     channel list: R, G, B, A
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 removed_cicp:
   16 x   16, 4 channel, float png
     channel list: R, G, B, A
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 remove_cicp_via_set_colorspace:
   16 x   16, 4 channel, float png
     channel list: R, G, B, A
     oiio:ColorSpace: "g22_rec709_display"
+Reading g22_rec709_display.png
+g22_rec709_display.png :   64 x   64, 3 channel, uint8 png
+    SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
+    channel list: R, G, B
+    oiio:ColorSpace: "g22_rec709_display"
+Reading g22_rec709_scene.png
+g22_rec709_scene.png :   64 x   64, 3 channel, uint8 png
+    SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
+    channel list: R, G, B
+    oiio:ColorSpace: "g22_rec709_scene"
+    oiio:Gamma: 2.2
+Reading test16.png
+test16.png           :   16 x   16, 4 channel, uint16 png
+    SHA-1: 6BDC50A9C1C3E9735D95A08B410FF893AA767415
+    channel list: R, G, B, A
+    oiio:ColorSpace: "srgb_rec709_display"
+Reading test16.png
+test16.png           :   16 x   16, 4 channel, uint16 png
+    SHA-1: 6BDC50A9C1C3E9735D95A08B410FF893AA767415
+    channel list: R, G, B, A
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "test16.png" and "ref/test16.png"
 PASS

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -107,12 +107,12 @@ Reading g22_rec709_display.png
 g22_rec709_display.png :   64 x   64, 3 channel, uint8 png
     SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
     channel list: R, G, B
-    oiio:ColorSpace: "g22_rec709_display"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading g22_rec709_scene.png
 g22_rec709_scene.png :   64 x   64, 3 channel, uint8 png
     SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
     channel list: R, G, B
-    oiio:ColorSpace: "g22_rec709_scene"
+    oiio:ColorSpace: "g22_rec709_display"
     oiio:Gamma: 2.2
 Reading test16.png
 test16.png           :   16 x   16, 4 channel, uint16 png

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -7,7 +7,7 @@ Reading ../oiio-images/png/oiio-logo-no-alpha.png
     ResolutionUnit: "inch"
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/png/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
 PASS
 Reading ../oiio-images/png/oiio-logo-with-alpha.png
@@ -19,7 +19,7 @@ Reading ../oiio-images/png/oiio-logo-with-alpha.png
     ResolutionUnit: "inch"
     XResolution: 72
     YResolution: 72
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "../oiio-images/png/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
 Reading exif.png
@@ -30,7 +30,7 @@ exif.png             :   64 x   64, 3 channel, uint8 png
     Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 45.7 (45.7 mm)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 alphagamma:
    1 x    1, 4 channel, float png
     channel list: R, G, B, A
@@ -78,7 +78,7 @@ gimp_gradient:
     ICCProfile:profile_size: 672
     ICCProfile:profile_version: "4.4.0"
     ICCProfile:rendering_intent: "Perceptual"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     Stats Min: 0 0 0 0 (of 255)
     Stats Max: 255 255 0 255 (of 255)
     Stats Avg: 142.37 105.72 0.00 154.72 (of 255)
@@ -94,14 +94,37 @@ cicp:
   16 x   16, 4 channel, float png
     channel list: R, G, B, A
     CICP: 1, 13, 0, 1
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 removed_cicp:
   16 x   16, 4 channel, float png
     channel list: R, G, B, A
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 remove_cicp_via_set_colorspace:
   16 x   16, 4 channel, float png
     channel list: R, G, B, A
     oiio:ColorSpace: "g22_rec709_display"
+Reading g22_rec709_display.png
+g22_rec709_display.png :   64 x   64, 3 channel, uint8 png
+    SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
+    channel list: R, G, B
+    oiio:ColorSpace: "g22_rec709_display"
+Reading g22_rec709_scene.png
+g22_rec709_scene.png :   64 x   64, 3 channel, uint8 png
+    SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
+    channel list: R, G, B
+    oiio:ColorSpace: "g22_rec709_scene"
+    oiio:Gamma: 2.2
+Reading test16.png
+test16.png           :   16 x   16, 4 channel, uint16 png
+    SHA-1: 6BDC50A9C1C3E9735D95A08B410FF893AA767415
+    channel list: R, G, B, A
+    CICP: 1, 13, 0, 1
+    oiio:ColorSpace: "srgb_rec709_scene"
+Reading test16.png
+test16.png           :   16 x   16, 4 channel, uint16 png
+    SHA-1: 6BDC50A9C1C3E9735D95A08B410FF893AA767415
+    channel list: R, G, B, A
+    CICP: 1, 13, 0, 1
+    oiio:ColorSpace: "srgb_rec709_display"
 Comparing "test16.png" and "ref/test16.png"
 PASS

--- a/testsuite/png/run.py
+++ b/testsuite/png/run.py
@@ -50,7 +50,7 @@ command += info_command ("g22_rec709_display.png", safematch=True)
 command += info_command ("g22_rec709_scene.png", safematch=True)
 
 # Teset preference for scene referred color space
-command += info_command ("--oiioattrib color:prefer_image_state scene test16.png", safematch=True)
-command += info_command ("--oiioattrib color:prefer_image_state display test16.png", safematch=True)
+command += info_command ("--iconfig oiio:ImageStateDefault scene test16.png", safematch=True)
+command += info_command ("--iconfig oiio:ImageStateDefault display test16.png", safematch=True)
 
 outputs = [ "test16.png", "out.txt" ]

--- a/testsuite/png/run.py
+++ b/testsuite/png/run.py
@@ -43,4 +43,14 @@ command += oiiotool ("-echo removed_cicp: test16.png --eraseattrib Software --ci
 # Test that "set_colorspace" removes CICP metadata
 command += oiiotool ("-echo remove_cicp_via_set_colorspace: test16.png --eraseattrib Software --cicp 1,13 --iscolorspace g22_rec709_display --printinfo")
 
+# Test g22_rec709_display being written as sRGB
+command += oiiotool ("--create 64x64 3 --iscolorspace g22_rec709_display -o g22_rec709_display.png")
+command += oiiotool ("--create 64x64 3 --iscolorspace g22_rec709_scene -o g22_rec709_scene.png")
+command += info_command ("g22_rec709_display.png", safematch=True)
+command += info_command ("g22_rec709_scene.png", safematch=True)
+
+# Teset preference for scene referred color space
+command += info_command ("--oiioattrib color:prefer_image_state scene test16.png", safematch=True)
+command += info_command ("--oiioattrib color:prefer_image_state display test16.png", safematch=True)
+
 outputs = [ "test16.png", "out.txt" ]

--- a/testsuite/psd/ref/out-linuxarm.txt
+++ b/testsuite/psd/ref/out-linuxarm.txt
@@ -42,7 +42,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     photoshop:LayerName: 1, 2, 3
@@ -91,7 +91,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -141,7 +141,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -191,7 +191,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "3"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -246,7 +246,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     photoshop:LayerName: 1, 2, 3
@@ -296,7 +296,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -347,7 +347,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -398,7 +398,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "3"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -555,7 +555,7 @@ Reading ../oiio-images/psd/psd_indexed_trans.psd
     IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
     IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 2
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -645,7 +645,7 @@ Reading ../oiio-images/psd/psd_rgb_8.psd
     IPTC:MetadataDate: "2011-08-25T17:40-04:00"
     IPTC:ModifyDate: "2011-08-25T17:40-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -735,7 +735,7 @@ Reading ../oiio-images/psd/psd_rgb_16.psd
     IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -878,7 +878,7 @@ Reading ../oiio-images/psd/psd_rgba_8.psd
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -925,7 +925,7 @@ Reading ../oiio-images/psd/psd_rgba_8.psd
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer 1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1025,7 +1025,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1075,7 +1075,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "1"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
@@ -1126,7 +1126,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "2"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
@@ -1177,7 +1177,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "3"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
@@ -1230,7 +1230,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -1277,7 +1277,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer 0"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1326,7 +1326,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "line1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1375,7 +1375,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "line2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1522,7 +1522,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -1573,7 +1573,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Blue_Lagoon"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1625,7 +1625,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1677,7 +1677,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1735,7 +1735,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -1786,7 +1786,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Blue_Lagoon"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1838,7 +1838,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1890,7 +1890,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -42,7 +42,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     photoshop:LayerName: 1, 2, 3
@@ -91,7 +91,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -141,7 +141,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -191,7 +191,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "3"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -246,7 +246,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     photoshop:LayerName: 1, 2, 3
@@ -296,7 +296,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -347,7 +347,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -398,7 +398,7 @@ Reading ../oiio-images/psd/psd_123_nomaxcompat.psd
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "3"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -555,7 +555,7 @@ Reading ../oiio-images/psd/psd_indexed_trans.psd
     IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
     IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 2
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -645,7 +645,7 @@ Reading ../oiio-images/psd/psd_rgb_8.psd
     IPTC:MetadataDate: "2011-08-25T17:40-04:00"
     IPTC:ModifyDate: "2011-08-25T17:40-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -735,7 +735,7 @@ Reading ../oiio-images/psd/psd_rgb_16.psd
     IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -878,7 +878,7 @@ Reading ../oiio-images/psd/psd_rgba_8.psd
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -925,7 +925,7 @@ Reading ../oiio-images/psd/psd_rgba_8.psd
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer 1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1025,7 +1025,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1075,7 +1075,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "1"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
@@ -1126,7 +1126,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "2"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
@@ -1177,7 +1177,7 @@ Reading ../oiio-images/psd/psd_123.psd
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "3"
     oiio:UnassociatedAlpha: 1
     photoshop:ColorMode: 3
@@ -1230,7 +1230,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -1277,7 +1277,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer 0"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1326,7 +1326,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "line1"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1375,7 +1375,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "line2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1522,7 +1522,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -1573,7 +1573,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Blue_Lagoon"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1625,7 +1625,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1677,7 +1677,7 @@ src/Layers_8bit_RGB.psd :   48 x   27, 3 channel, uint8 psd
     IPTC:MetadataDate: "2024-04-01T19:35:40+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:40+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1735,7 +1735,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
@@ -1786,7 +1786,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Blue_Lagoon"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1838,7 +1838,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
@@ -1890,7 +1890,7 @@ src/Layers_16bit_RGB.psd :   48 x   27, 3 channel, uint16 psd
     IPTC:MetadataDate: "2024-04-01T19:35:30+02:00"
     IPTC:ModifyDate: "2024-04-01T19:35:30+02:00"
     IPTC:OriginalDocumentID: "xmp.did:68fcb000-4377-c148-974d-bdd193ca024d"
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     oiio:subimagename: "Layer2"
     photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"

--- a/testsuite/python-colorconfig/ref/out-ocio23.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio23.txt
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB - Display
+resolve('srgb'): sRGB - Texture
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False

--- a/testsuite/python-colorconfig/ref/out-ocio23.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio23.txt
@@ -1,8 +1,8 @@
-getNumColorSpaces = 15
-getColorSpaceNames = ['ACES2065-1', 'ACEScc', 'ACEScct', 'ACEScg', 'Linear P3-D65', 'Linear Rec.2020', 'Linear Rec.709 (sRGB)', 'Gamma 1.8 Rec.709 - Texture', 'Gamma 2.2 AP1 - Texture', 'Gamma 2.2 Rec.709 - Texture', 'Gamma 2.4 Rec.709 - Texture', 'sRGB Encoded AP1 - Texture', 'sRGB Encoded P3-D65 - Texture', 'sRGB - Texture', 'Raw']
-Index of 'lin_srgb' = 6
+getNumColorSpaces = 22
+getColorSpaceNames = ['CIE-XYZ-D65', 'sRGB - Display', 'Display P3 - Display', 'Rec.1886 Rec.709 - Display', 'Rec.2100-PQ - Display', 'ST2084-P3-D65 - Display', 'P3-D65 - Display', 'ACES2065-1', 'ACEScc', 'ACEScct', 'ACEScg', 'Linear P3-D65', 'Linear Rec.2020', 'Linear Rec.709 (sRGB)', 'Gamma 1.8 Rec.709 - Texture', 'Gamma 2.2 AP1 - Texture', 'Gamma 2.2 Rec.709 - Texture', 'Gamma 2.4 Rec.709 - Texture', 'sRGB Encoded AP1 - Texture', 'sRGB Encoded P3-D65 - Texture', 'sRGB - Texture', 'Raw']
+Index of 'lin_srgb' = 13
 Index of 'unknown' = -1
-Name of color space 2 = ACEScct
+Name of color space 2 = Display P3 - Display
 getNumLooks = 1
 getLookNames = ['ACES 1.3 Reference Gamut Compression']
 getNumDisplays = 6
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB - Texture
+resolve('srgb'): sRGB - Display
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False
@@ -28,7 +28,7 @@ equivalent('ACEScg', 'scene_linear'): True
 equivalent('lnf', 'scene_linear'): False
 get_color_interop_id('ACEScg') =  lin_ap1_scene
 get_color_interop_id('lin_srgb') =  lin_rec709_scene
-get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
+get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_display
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
 

--- a/testsuite/python-colorconfig/ref/out-ocio24.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio24.txt
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB - Display
+resolve('srgb'): sRGB Encoded Rec.709 (sRGB)
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False

--- a/testsuite/python-colorconfig/ref/out-ocio24.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio24.txt
@@ -1,8 +1,8 @@
-getNumColorSpaces = 23
-getColorSpaceNames = ['sRGB - Display', 'Display P3 - Display', 'Rec.1886 Rec.709 - Display', 'Rec.2100-PQ - Display', 'ST2084-P3-D65 - Display', 'P3-D65 - Display', 'ACES2065-1', 'ACEScc', 'ACEScct', 'ACEScg', 'sRGB Encoded Rec.709 (sRGB)', 'Gamma 1.8 Encoded Rec.709', 'Gamma 2.2 Encoded Rec.709', 'Gamma 2.4 Encoded Rec.709', 'sRGB Encoded P3-D65', 'Gamma 2.2 Encoded AdobeRGB', 'sRGB Encoded AP1', 'Gamma 2.2 Encoded AP1', 'Linear Rec.709 (sRGB)', 'Linear P3-D65', 'Linear AdobeRGB', 'Linear Rec.2020', 'Raw']
-Index of 'lin_srgb' = 18
+getNumColorSpaces = 25
+getColorSpaceNames = ['CIE XYZ-D65 - Display-referred', 'sRGB - Display', 'Display P3 - Display', 'Rec.1886 Rec.709 - Display', 'Rec.2100-PQ - Display', 'ST2084-P3-D65 - Display', 'P3-D65 - Display', 'ACES2065-1', 'ACEScc', 'ACEScct', 'ACEScg', 'sRGB Encoded Rec.709 (sRGB)', 'Gamma 1.8 Encoded Rec.709', 'Gamma 2.2 Encoded Rec.709', 'Gamma 2.4 Encoded Rec.709', 'sRGB Encoded P3-D65', 'Gamma 2.2 Encoded AdobeRGB', 'sRGB Encoded AP1', 'Gamma 2.2 Encoded AP1', 'Linear Rec.709 (sRGB)', 'Linear P3-D65', 'Linear AdobeRGB', 'Linear Rec.2020', 'CIE XYZ-D65 - Scene-referred', 'Raw']
+Index of 'lin_srgb' = 19
 Index of 'unknown' = -1
-Name of color space 2 = Rec.1886 Rec.709 - Display
+Name of color space 2 = Display P3 - Display
 getNumLooks = 1
 getLookNames = ['ACES 1.3 Reference Gamut Compression']
 getNumDisplays = 6
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB Encoded Rec.709 (sRGB)
+resolve('srgb'): sRGB - Display
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False
@@ -28,7 +28,7 @@ equivalent('ACEScg', 'scene_linear'): True
 equivalent('lnf', 'scene_linear'): False
 get_color_interop_id('ACEScg') =  lin_ap1_scene
 get_color_interop_id('lin_srgb') =  lin_rec709_scene
-get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
+get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_display
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
 

--- a/testsuite/python-colorconfig/ref/out-ocio25.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio25.txt
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB - Display
+resolve('srgb'): sRGB Encoded Rec.709 (sRGB)
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False

--- a/testsuite/python-colorconfig/ref/out-ocio25.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio25.txt
@@ -1,8 +1,8 @@
-getNumColorSpaces = 25
-getColorSpaceNames = ['sRGB - Display', 'Gamma 2.2 Rec.709 - Display', 'Display P3 - Display', 'Display P3 HDR - Display', 'P3-D65 - Display', 'Rec.1886 Rec.709 - Display', 'Rec.2100-PQ - Display', 'ST2084-P3-D65 - Display', 'ACES2065-1', 'ACEScc', 'ACEScct', 'ACEScg', 'sRGB Encoded Rec.709 (sRGB)', 'Gamma 1.8 Encoded Rec.709', 'Gamma 2.2 Encoded Rec.709', 'Gamma 2.4 Encoded Rec.709', 'sRGB Encoded P3-D65', 'Gamma 2.2 Encoded AdobeRGB', 'sRGB Encoded AP1', 'Gamma 2.2 Encoded AP1', 'Linear AdobeRGB', 'Linear P3-D65', 'Linear Rec.2020', 'Linear Rec.709 (sRGB)', 'Raw']
-Index of 'lin_srgb' = 23
+getNumColorSpaces = 27
+getColorSpaceNames = ['CIE XYZ-D65 - Display-referred', 'sRGB - Display', 'Gamma 2.2 Rec.709 - Display', 'Display P3 - Display', 'Display P3 HDR - Display', 'P3-D65 - Display', 'Rec.1886 Rec.709 - Display', 'Rec.2100-PQ - Display', 'ST2084-P3-D65 - Display', 'ACES2065-1', 'ACEScc', 'ACEScct', 'ACEScg', 'sRGB Encoded Rec.709 (sRGB)', 'Gamma 1.8 Encoded Rec.709', 'Gamma 2.2 Encoded Rec.709', 'Gamma 2.4 Encoded Rec.709', 'sRGB Encoded P3-D65', 'Gamma 2.2 Encoded AdobeRGB', 'sRGB Encoded AP1', 'Gamma 2.2 Encoded AP1', 'CIE XYZ-D65 - Scene-referred', 'Linear AdobeRGB', 'Linear P3-D65', 'Linear Rec.2020', 'Linear Rec.709 (sRGB)', 'Raw']
+Index of 'lin_srgb' = 25
 Index of 'unknown' = -1
-Name of color space 2 = Display P3 - Display
+Name of color space 2 = Gamma 2.2 Rec.709 - Display
 getNumLooks = 1
 getLookNames = ['ACES 1.3 Reference Gamut Compression']
 getNumDisplays = 8
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB Encoded Rec.709 (sRGB)
+resolve('srgb'): sRGB - Display
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False
@@ -28,7 +28,7 @@ equivalent('ACEScg', 'scene_linear'): True
 equivalent('lnf', 'scene_linear'): False
 get_color_interop_id('ACEScg') =  lin_ap1_scene
 get_color_interop_id('lin_srgb') =  lin_rec709_scene
-get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
+get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_display
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
 

--- a/testsuite/python-colorconfig/ref/out.txt
+++ b/testsuite/python-colorconfig/ref/out.txt
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB - Display
+resolve('srgb'): sRGB - Texture
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False

--- a/testsuite/python-colorconfig/ref/out.txt
+++ b/testsuite/python-colorconfig/ref/out.txt
@@ -18,7 +18,7 @@ resolve('foo'): foo
 resolve('linear'): Linear Rec.709 (sRGB)
 resolve('scene_linear'): ACEScg
 resolve('lin_srgb'): Linear Rec.709 (sRGB)
-resolve('srgb'): sRGB - Texture
+resolve('srgb'): sRGB - Display
 resolve('ACEScg'): ACEScg
 equivalent('lin_srgb', 'srgb'): False
 equivalent('scene_linear', 'srgb'): False
@@ -28,7 +28,7 @@ equivalent('ACEScg', 'scene_linear'): True
 equivalent('lnf', 'scene_linear'): False
 get_color_interop_id('ACEScg') =  lin_ap1_scene
 get_color_interop_id('lin_srgb') =  lin_rec709_scene
-get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
+get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_display
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
 

--- a/testsuite/python-imageinput/ref/out-alt.txt
+++ b/testsuite/python-imageinput/ref/out-alt.txt
@@ -8,7 +8,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   alpha channel =  -1
   z channel =  -1
   deep =  False
-  oiio:ColorSpace = "srgb_rec709_scene"
+  oiio:ColorSpace = "srgb_rec709_display"
   jpeg:subsampling = "4:2:0"
   Make = "HTC"
   Model = "T-Mobile G1"

--- a/testsuite/python-imageinput/ref/out-alt2.txt
+++ b/testsuite/python-imageinput/ref/out-alt2.txt
@@ -8,7 +8,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   alpha channel =  -1
   z channel =  -1
   deep =  False
-  oiio:ColorSpace = "srgb_rec709_scene"
+  oiio:ColorSpace = "srgb_rec709_display"
   jpeg:subsampling = "4:2:0"
   Make = "HTC"
   Model = "T-Mobile G1"

--- a/testsuite/python-imageinput/ref/out-py37-jpeg9d.txt
+++ b/testsuite/python-imageinput/ref/out-py37-jpeg9d.txt
@@ -8,7 +8,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   alpha channel =  -1
   z channel =  -1
   deep =  False
-  oiio:ColorSpace = "srgb_rec709_scene"
+  oiio:ColorSpace = "srgb_rec709_display"
   jpeg:subsampling = "4:2:0"
   Make = "HTC"
   Model = "T-Mobile G1"

--- a/testsuite/python-imageinput/ref/out-python3-win-2.txt
+++ b/testsuite/python-imageinput/ref/out-python3-win-2.txt
@@ -8,7 +8,7 @@ Opened "C:/a/OpenImageIO/OpenImageIO/build/testsuite/oiio-images/tahoe-gps.jpg" 
   alpha channel =  -1
   z channel =  -1
   deep =  False
-  oiio:ColorSpace = "srgb_rec709_scene"
+  oiio:ColorSpace = "srgb_rec709_display"
   jpeg:subsampling = "4:2:0"
   Make = "HTC"
   Model = "T-Mobile G1"

--- a/testsuite/python-imageinput/ref/out-python3-win.txt
+++ b/testsuite/python-imageinput/ref/out-python3-win.txt
@@ -8,7 +8,7 @@ Opened "D:/a/OpenImageIO/OpenImageIO/build/testsuite/oiio-images/tahoe-gps.jpg" 
   alpha channel =  -1
   z channel =  -1
   deep =  False
-  oiio:ColorSpace = "srgb_rec709_scene"
+  oiio:ColorSpace = "srgb_rec709_display"
   jpeg:subsampling = "4:2:0"
   Make = "HTC"
   Model = "T-Mobile G1"

--- a/testsuite/python-imageinput/ref/out-python3.txt
+++ b/testsuite/python-imageinput/ref/out-python3.txt
@@ -8,7 +8,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   alpha channel =  -1
   z channel =  -1
   deep =  False
-  oiio:ColorSpace = "srgb_rec709_scene"
+  oiio:ColorSpace = "srgb_rec709_display"
   jpeg:subsampling = "4:2:0"
   Make = "HTC"
   Model = "T-Mobile G1"

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -8,7 +8,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   alpha channel =  -1
   z channel =  -1
   deep =  False
-  oiio:ColorSpace = "srgb_rec709_scene"
+  oiio:ColorSpace = "srgb_rec709_display"
   jpeg:subsampling = "4:2:0"
   Make = "HTC"
   Model = "T-Mobile G1"

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -81,7 +81,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
     Exif:YCbCrPositioning: 2
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -251,7 +251,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:Sharpness: 2 (hard)
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/tiff-suite/ref/out-alt2.txt
+++ b/testsuite/tiff-suite/ref/out-alt2.txt
@@ -81,7 +81,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
     Exif:YCbCrPositioning: 2
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -251,7 +251,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:Sharpness: 2 (hard)
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -81,7 +81,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
     Exif:YCbCrPositioning: 2
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -251,7 +251,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:Sharpness: 2 (hard)
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
@@ -81,7 +81,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
     Exif:YCbCrPositioning: 2
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -251,7 +251,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:Sharpness: 2 (hard)
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -81,7 +81,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
     Exif:YCbCrPositioning: 2
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -251,7 +251,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:Sharpness: 2 (hard)
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/webp/ref/out-webp1.1.txt
+++ b/testsuite/webp/ref/out-webp1.1.txt
@@ -2,19 +2,19 @@ Reading ../oiio-images/webp/1.webp
 ../oiio-images/webp/1.webp :  550 x  368, 3 channel, uint8 webp
     SHA-1: C8D715F7E492E94E29FFF0E605E0F00F1892FC7A
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/webp/2.webp
 ../oiio-images/webp/2.webp :  550 x  404, 3 channel, uint8 webp
     SHA-1: 6679CBF3655C40A6ECE9188DDC136BE18599C138
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/webp/3.webp
 ../oiio-images/webp/3.webp : 1280 x  720, 3 channel, uint8 webp
     SHA-1: AC77455077A5C8E9271B16FCB3A3E520CBA42018
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"
 Reading ../oiio-images/webp/4.webp
 ../oiio-images/webp/4.webp : 1024 x  772, 3 channel, uint8 webp
     SHA-1: 8F42E3DCCE6FE15146BA06C440C15B7831F60572
     channel list: R, G, B
-    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:ColorSpace: "srgb_rec709_display"


### PR DESCRIPTION
## Description

* Display referred interop IDs are now chosen over scene referred ones by
  default on file read. This more closely matches the standards for CICP, ICC
  and other color metadata. Most images will now have `oiio:ColorSpace` set to
  `srgb_rec709_display` rather than `srgb_rec709_scene` on file read.

* To change the behavior to prefer scene default (as may be appropriate for
   textures), set `oiio:ImageStateDefault` to `scene` in `config` for
   `ImageInput.open` or with `oiiotool --iconfig`.

* There is also a new `ImageCache` attribute `image_state_default`. The default
  value here is also `display` as the `ImageCache` is used through OIIO for various
  purposes, but specifically for texture systems `scene` may be a better choice.

* Both `srgb_rec709_scene` and `srgb_rec709_display` are now (distinct) built-in
  color spaces. The built-in `sRGB` color space name remains an alias of
  `srgb_rec709_scene`.

  Documentation was updated to discourage the use of `sRGB` in favor of
  the more specific interop IDs.

* Previously only `srgb_rec709_scene` was recognized as sRGB for file metadata
  and display, now `srgb_rec709_display` and `g22_rec709_display` are treated as
  sRGB as well.

  The reason for `g22_rec709_display` behavior is that this type of display is
  often used to correct for the discrepancy where images are encoded as sRGB but
  usually decoded as gamma 2.2 by the physical display. By encoding it as gamma
  2.2 and claiming it's sRGB the transfer functions cancel out exactly.

* `g24_rec709_display` is now recognized as having gamma 2.4, and the name
  `g24_rec709_scene` was replaced with `ocio:g24_rec709_scene` since the
  former is not an official interop ID.

* This change also fixes an issue where tga and rla were incorrectly using
  `g22_rec709` and `g18_rec709` without `_scene` suffix, and not handling
  `g24_rec709`.

* `cio:itu709_rec709_scene` and `ocio:lin_ciexyzd65_display` were added to complete
  the list of interop IDs in OCIO configs that match a CICP.

* `ColorConfig` now includes inactive colorspaces. In older ACES configs (like
  v2.1.0 bundled with OpenColorIO 2.3), the display color spaces are inactive.
  But we now heavily rely on them.

## Tests

* Many test outputs were changed due to the new display referred default.
* Added test for `g22_rec709_display` behavior.
* Added test for `color:prefer_image_state`.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.