### PR TITLE
testing: Fix brittle behavior of tests that need to cmake

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -103,9 +103,15 @@ macro (oiio_add_tests)
             set (_test_disabled TRUE)
         endif ()
     endforeach ()
-    # For OCIO 2.2+, have the testsuite use the default built-in config
+    # Things we add to the environment for tests:
+    # - For OCIO 2.2+, have the testsuite use the default built-in config.
+    # - Some tests (e.g. cmake-consumer) configure their own child cmake
+    #   project that does find_package(OpenImageIO). Point them at this
+    #   build's install location so that works out of the box, without users
+    #   needing to set OpenImageIO_ROOT in their environment themselves.
     list (APPEND _ats_ENVIRONMENT "OCIO=ocio://default"
-                                  "OIIO_TESTSUITE_OCIOCONFIG=ocio://default")
+                                  "OIIO_TESTSUITE_OCIOCONFIG=ocio://default"
+                                  "OpenImageIO_ROOT=${CMAKE_INSTALL_PREFIX}")
     if (_test_disabled)
         message (STATUS "Skipping test(s) ${_ats_UNPARSED_ARGUMENTS} because of disabled ${_ats_ENABLEVAR}")
     elseif (_test_notfound)

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -426,6 +426,11 @@ def runtest (command: str, outputs: list[str], failureok: int=0) -> int :
             print ("#### Error: this command failed: ", sub_command)
             print ("FAIL")
             err = 1
+            if os.path.isfile("build.txt") :
+                print ("---   BUILD LOG   ---\n")
+                with open("build.txt", "r") as fbuild :
+                    print (fbuild.read())
+                print ("--- END BUILD LOG ---\n")
 
     for out in outputs :
         (prefix, extension) = os.path.splitext(out)


### PR DESCRIPTION
Some tests (like cmake-consumer, but also the newly added imagebufalgo-opencv and openexr-partialtile) build their own executable, and so have their own CMakeLists.txt that needs to find_package(OpenImageIO).

This only works in our CI because it sets OpenImageIO_ROOT (and, as it turns out, locally for me it works because I habitually have that set as well). But it can fail for users who don't have OpenImageIO_ROOT set to the place where the build being tested has installed itself.

Fix it by setting this environment variable for all tests. This makes it work if the person running the tests has failed to set the variable, and it also ensure that things will work right if it IS set, but to the wrong place (like a different install than the build we're trying to test).

Also make failed tests echo build.txt to the main log, if it exists, so that these in-test build failures can be more easily discerned from viewing the main CI log.

Fixes #5358
