### PR TITLE
fix(dicom): null-check DCMTK pixel-data accessors before use

### DIFF
--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -147,8 +147,7 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
 
     if (subimage < m_subimage) {
         // Want an earlier subimage, Easier to close and start again
-        close();
-        m_subimage = -1;
+        close();  // note: resets m_subimge to -1
     }
 
     // Open if it's not already opened
@@ -189,7 +188,6 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
         m_img.reset();
         return false;
     }
-    m_internal_data       = (const char*)m_dipixel->getData();
     EP_Representation rep = m_dipixel->getRepresentation();
     TypeDesc format;
     switch (rep) {

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -183,7 +183,12 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
         ++m_subimage;
     }
 
-    m_dipixel             = m_img->getInterData();
+    m_dipixel = m_img->getInterData();
+    if (!m_dipixel) {
+        errorfmt("Unable to read pixel data from DICOM file {}", m_filename);
+        m_img.reset();
+        return false;
+    }
     m_internal_data       = (const char*)m_dipixel->getData();
     EP_Representation rep = m_dipixel->getRepresentation();
     TypeDesc format;
@@ -197,6 +202,11 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
     default: break;
     }
     m_internal_data = (const char*)m_img->getOutputData(0, m_subimage, 0);
+    if (!m_internal_data) {
+        errorfmt("Unable to decode pixel data from DICOM file {}", m_filename);
+        m_img.reset();
+        return false;
+    }
 
     EP_Interpretation photo = m_img->getPhotometricInterpretation();
     struct PhotoTable {


### PR DESCRIPTION
DicomImage::getInterData() and getOutputData() can return null when a corrupt DICOM's frame fails to decode, but their results were used without checking.

Assisted-by: Claude Code / Claude Opus 4.8
