### PR TITLE
fix(oiiotool): don't dereference specs of a failed read

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -433,6 +433,13 @@ Oiiotool::read(ImageRecRef img, ReadPolicy readpolicy, string_view channel_set)
     total_imagecache_readtime += post_ic_time - pre_ic_time;
     total_readtime.add_seconds(pre_ic_time - post_ic_time);
 
+    // A failed read leaves the ImageRec with no subimages, so bail out before
+    // anything below tries to examine its specs.
+    if (!ok || !img->subimages()) {
+        error("read", format_read_error(img->name(), img->geterror()));
+        return false;
+    }
+
     // If this is the first tiled image we have come across, use it to
     // set our tile size (unless the user explicitly set a tile size, or
     // explicitly instructed scanline output).
@@ -445,9 +452,7 @@ Oiiotool::read(ImageRecRef img, ReadPolicy readpolicy, string_view channel_set)
     // channel name that we encounter.
     remember_input_channelformats(img);
 
-    if (!ok)
-        error("read", format_read_error(img->name(), img->geterror()));
-    return ok;
+    return true;
 }
 
 
@@ -471,9 +476,13 @@ Oiiotool::read_nativespec(ImageRecRef img)
     imagecache->getattribute("stat:fileio_time", post_ic_time);
     total_imagecache_readtime += post_ic_time - pre_ic_time;
 
-    if (!ok)
+    // A failed read leaves the ImageRec with no subimages, so callers must
+    // not be handed back a "success" they will dereference.
+    if (!ok || !img->subimages()) {
         error("read", format_read_error(img->name(), img->geterror()));
-    return ok;
+        return false;
+    }
+    return true;
 }
 
 
@@ -5707,16 +5716,20 @@ input_file(Oiiotool& ot, cspan<const char*> argv)
             if (ot.input_config_set)
                 ot.curimg->configspec(ot.input_config);
             ot.curimg->input_dataformat(input_dataformat);
+            bool ok;
             if (readnow) {
                 ReadPolicy policy = native ? ReadNativeNoCache : ReadNoCache;
-                ot.read(policy, channel_set);
-            } else
-                ot.read_nativespec();
+                ok                = ot.read(policy, channel_set);
+            } else {
+                ok = ot.read_nativespec();
+            }
+            if (!ok)
+                break;  // error already reported by the read
+            const ImageSpec* nspec = ot.curimg->nativespec();
             if (!ot.first_input_dimensions_is_set()) {
                 ImageSpec new_first_dims;
-                new_first_dims.copy_dimensions(*ot.curimg->nativespec());
-                new_first_dims.channelnames
-                    = ot.curimg->nativespec()->channelnames;
+                new_first_dims.copy_dimensions(*nspec);
+                new_first_dims.channelnames = nspec->channelnames;
                 ot.set_first_input_dimensions(new_first_dims);
                 if (ot.parent_oiiotool)
                     ot.parent_oiiotool->set_first_input_dimensions(

--- a/testsuite/null/ref/out.txt
+++ b/testsuite/null/ref/out.txt
@@ -36,3 +36,18 @@ bar.null?RES=128x128&CHANNELS=3&TILE=64x64&TEX=1&TYPE=uint16&PIXEL=0.25,0.5,1 : 
       Constant Color: 16384.00 32768.00 65535.00 (of 65535)
       Monochrome: No
 Writing outtile.null
+oiiotool ERROR: read : file not found: "bad.null?CHANNELS=-1"
+Full command line was:
+> oiiotool --info bad.null?CHANNELS=-1
+oiiotool ERROR: read : file not found: "bad.null?CHANNELS=2000000000"
+Full command line was:
+> oiiotool --info bad.null?CHANNELS=2000000000
+oiiotool ERROR: read : file not found: "bad.null?RES=-4x-4"
+Full command line was:
+> oiiotool --info bad.null?RES=-4x-4
+oiiotool ERROR: read : file not found: "bad.null?RES=0x0"
+Full command line was:
+> oiiotool --info bad.null?RES=0x0
+oiiotool ERROR: read : file not found: "bad.null?RES=64x64&TILE=-4x-4"
+Full command line was:
+> oiiotool --info bad.null?RES=64x64&TILE=-4x-4

--- a/testsuite/null/run.py
+++ b/testsuite/null/run.py
@@ -12,3 +12,11 @@ command += oiiotool ('-v -info -stats ' +
                      '"bar.null?RES=128x128&CHANNELS=3&TILE=64x64&TEX=1&TYPE=uint16&PIXEL=0.25,0.5,1" ' +
                      '-o:tile=64x64 outtile.null'
                      )
+
+# The null reader synthesizes pixels but still parses the query arguments.
+# These used to abort on an uncaught length_error (negative CHANNELS), hang
+# building channel names (huge CHANNELS), or hand back a negative-sized spec.
+redirect = " >> out.txt 2>&1 "
+for args in [ "CHANNELS=-1", "CHANNELS=2000000000", "RES=-4x-4", "RES=0x0",
+              "RES=64x64&TILE=-4x-4" ]:
+    command += oiiotool ('--info "bad.null?' + args + '"', failureok=True)


### PR DESCRIPTION
Add "null reader" test cases for invalid procedural specifiers (negative or huge CHANNELS, degenerate RES, negative TILE).

That was all I was originally trying to do, but it crashed oiiotool under ASan.

The null reader claims supports("procedural"), so input_file() skips the missing-file path and proceeds to read even when the query string is invalid. The read then fails, leaving the ImageRec with no subimages, and Oiiotool::error() only aborts the ArgParse loop -- it does not return from input_file(). Two sites then dereferenced the nonexistent spec:

* Oiiotool::read() bound `(*img)().nativespec()` before testing the read's return value, indexing an empty m_subimages.
* input_file() ignored the read result entirely and dereferenced curimg->nativespec(), which is null when there are no subimages.

Both read wrappers now report the error and return false if the read failed or produced no subimages, and input_file() breaks out on failure.

Assisted-by: GitHub Copilot / Claude Opus 4.8 (for help generating the new null test cases)

Assisted-by: Claude Code / Claude Opus 5 (for help diagnosing why it was crashing oiiotool)
