### PR TITLE
fix(oiiotool): don't discard the reader's specific error message

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -767,8 +767,8 @@ ImageCacheFile::open(ImageCachePerThreadInfo* thread_info)
         // an unnecessary file open.
         std::string fmt;
         if (m_imagecache.trust_file_extensions()
-            && m_filename.find('?') != m_filename.npos)
-            fmt = OIIO::Filesystem::extension(fmt, false);
+            && m_filename.find('?') == m_filename.npos)
+            fmt = OIIO::Filesystem::extension(m_filename.string(), false);
         else
             fmt = m_filename.string();
         inp = ImageInput::create(fmt, false, &configspec, nullptr,

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -210,6 +210,21 @@ ImageRec::ImageRec(const std::string& name, const ImageSpec& spec,
 
 
 
+// When the ImageCache can't supply an image, it has already recorded the
+// underlying reader's specific complaint (bad resolution, corrupt header,
+// etc.). Retrieve it rather than replacing it with a generic message.
+static std::string
+imagecache_error(const std::shared_ptr<ImageCache>& imagecache,
+                 string_view name)
+{
+    std::string err = imagecache->geterror();
+    if (err.empty())
+        err = Strutil::fmt::format("file not found: \"{}\"", name);
+    return err;
+}
+
+
+
 bool
 ImageRec::read_nativespec()
 {
@@ -224,7 +239,7 @@ ImageRec::read_nativespec()
     ustring uname(name());
     if (!m_imagecache->get_image_info(uname, 0, 0, u_subimages, TypeInt,
                                       &subimages)) {
-        errorfmt("file not found: \"{}\"", name());
+        errorfmt("{}", imagecache_error(m_imagecache, name()));
         return false;  // Image not found
     }
     m_subimages.resize(subimages);
@@ -263,7 +278,7 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
     ustring uname(name());
     if (!m_imagecache->get_image_info(uname, 0, 0, u_subimages, TypeInt,
                                       &subimages)) {
-        errorfmt("file not found: \"{}\"", name());
+        errorfmt("{}", imagecache_error(m_imagecache, name()));
         return false;  // Image not found
     }
     m_subimages.resize(subimages);

--- a/testsuite/null/ref/out.txt
+++ b/testsuite/null/ref/out.txt
@@ -36,18 +36,18 @@ bar.null?RES=128x128&CHANNELS=3&TILE=64x64&TEX=1&TYPE=uint16&PIXEL=0.25,0.5,1 : 
       Constant Color: 16384.00 32768.00 65535.00 (of 65535)
       Monochrome: No
 Writing outtile.null
-oiiotool ERROR: read : file not found: "bad.null?CHANNELS=-1"
+oiiotool ERROR: read : Invalid image file "bad.null?CHANNELS=-1": null image resolution must be at least 1x1, but the file specified 1024x1024x1, -1 chans. Possible corrupt input?
 Full command line was:
 > oiiotool --info bad.null?CHANNELS=-1
-oiiotool ERROR: read : file not found: "bad.null?CHANNELS=2000000000"
+oiiotool ERROR: read : Invalid image file "bad.null?CHANNELS=2000000000": null does not support 2000000000-channel images. Possible corrupt input?
 Full command line was:
 > oiiotool --info bad.null?CHANNELS=2000000000
-oiiotool ERROR: read : file not found: "bad.null?RES=-4x-4"
+oiiotool ERROR: read : Invalid image file "bad.null?RES=-4x-4": null image resolution must be at least 1x1, but the file specified -4x-4x1, 4 chans. Possible corrupt input?
 Full command line was:
 > oiiotool --info bad.null?RES=-4x-4
-oiiotool ERROR: read : file not found: "bad.null?RES=0x0"
+oiiotool ERROR: read : Invalid image file "bad.null?RES=0x0": null image resolution must be at least 1x1, but the file specified 0x0x1, 4 chans. Possible corrupt input?
 Full command line was:
 > oiiotool --info bad.null?RES=0x0
-oiiotool ERROR: read : file not found: "bad.null?RES=64x64&TILE=-4x-4"
+oiiotool ERROR: read : Invalid image file "bad.null?RES=64x64&TILE=-4x-4": null tile size may not be negative, but was -4x-4x1. Possible corrupt input?
 Full command line was:
 > oiiotool --info bad.null?RES=64x64&TILE=-4x-4


### PR DESCRIPTION
In oiiotool, a failed read, where no reader could successfully open the file, was reporting a generic "file not found" even when the format reader had explained exactly what was wrong. For example,

    oiiotool ERROR: read : file not found: "bad.null?RES=-4x-4"

where iinfo, going straight through ImageInput, reported the real reason:

    null image resolution must be at least 1x1, but the file specified
    -4x-4x1, 4 chans. Possible corrupt input?

The message survives the "try every reader" logic; ImageInput::create() stashes the best-guess plugin's complaint and returns it if all other readers also fail to open. But it was thrown away when ImageRec::read() and read_nativespec() checked get_image_info()'s return value but never called ImageCache::geterror(), substituting a fixed string.  They now retrieve it, falling back to the generic text only if it is empty.

Also fix ImageCacheFile::open(), which took the trust_file_extensions shortcut on exactly the wrong branch and passed the still-empty `fmt` to Filesystem::extension() instead of the filename. With trust_file_extensions set, every REST-ful name failed with "ImageInput::create() called with no filename", clobbering the reader's message before the cache ever saw it.

This replaces some test output where the error messages have improved.

Assisted-by: Claude Code / Claude Opus 5
