### PR TITLE
deps: Raise LibRaw recommended min to 0.21.3 (hard min still 0.20.0)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for PNG files:
      * libPNG >= 1.6.0 (tested though 1.6.58)
  * If you want support for camera "RAW" formats:
-     * LibRaw >= 0.20 (tested though 0.22.2 and master)
+     * LibRaw >= 0.20 (tested though 0.22.2 and master; minimum of 0.21.3 recommended for security reasons)
  * If you want support for a wide variety of video formats:
      * ffmpeg >= 4.0 (tested through 8.1)
  * If you want support for jpeg 2000 images:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -191,6 +191,8 @@ checked_find_package (Libheif VERSION_MIN 1.11
 
 checked_find_package (LibRaw
                       VERSION_MIN 0.20.0
+                      RECOMMEND_MIN 0.21.3
+                      RECOMMEND_MIN_REASON "0.21.3 for many security fixes"
                       PRINT LibRaw_r_LIBRARIES)
 
 checked_find_package (OpenJPEG VERSION_MIN 2.0


### PR DESCRIPTION
Fixes #5382

We don't want to raise the true min this high, since it's less than 3 years old. But we can raise the *recommended* minimum to trigger a build-time warning reminding people that newer versions have security fixes they might want.
