### PR TITLE
raw: allow vector types in multi-value hints

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2227,16 +2227,16 @@ options are supported:
        precedence over ``raw:greybox``, ``raw:user_mul``.
        (Default: 0)
    * - ``raw:greybox``
-     - int[4]
-     - White balance by averaging over the given box. The four values are the 
+     - int[4] or int2[2]
+     - White balance by averaging over the given box. The four values are the
        X and Y coordinate of the top-left corner, the width and the height.
        Only applies if the size is non-zero, and ``raw:use_camera_wb`` is not 
        equal to 0, ``raw:use_auto_wb`` is not equal to 0. Takes 
        precedence over ``raw:user_mul``.
        (Default: 0, 0, 0, 0; meaning no correction.)
    * - ``raw:cropbox``
-     - int[4]
-     - If present, sets the box to crop the image to. The four values are the 
+     - int[4] or int2[2]
+     - If present, sets the box to crop the image to. The four values are the
        X and Y coordinate of the top-left corner, the width and the height.
        If not present, the image is cropped to match the in-camera JPEG,
        assuming the necessary information is present in the metadata. The
@@ -2268,7 +2268,7 @@ options are supported:
      - int
      - If nonzero, outputs the image in half size. (Default: 0)
    * - ``raw:user_mul``
-     - float[4]
+     - float[4] or float4
      - Sets user white balance coefficients. Only applies if ``raw:use_camera_wb``
        is not equal to 0, ``raw:use_auto_wb`` is not equal to 0, and the 
        ``raw:greybox`` box is zero size.

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -532,12 +532,13 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         auto p = config.find_attribute("raw:aber");
         if (p) {
             auto type = p->type();
-            if (type == TypeDesc(TypeDesc::FLOAT, 2)
-                || type == TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC2)) {
+            if (type.equivalent(TypeDesc(TypeDesc::FLOAT, 2))
+                || type.equivalent(TypeFloat2)) {
                 m_processor->imgdata.params.aber[0] = p->get<float>(0);
                 m_processor->imgdata.params.aber[2] = p->get<float>(1);
-            } else if (type == TypeDesc(TypeDesc::DOUBLE, 2)
-                       || type == TypeDesc(TypeDesc::DOUBLE, TypeDesc::VEC2)) {
+            } else if (type.equivalent(TypeDesc(TypeDesc::DOUBLE, 2))
+                       || type.equivalent(
+                           TypeDesc(TypeDesc::DOUBLE, TypeDesc::VEC2))) {
                 m_processor->imgdata.params.aber[0] = p->get<double>(0);
                 m_processor->imgdata.params.aber[2] = p->get<double>(1);
             }
@@ -572,11 +573,9 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
             auto p = config.find_attribute("raw:greybox");
             if (p) {
                 auto type = p->type();
-                if (type == TypeDesc(TypeDesc::INT, 4)
-                    || type == TypeDesc(TypeDesc::INT, TypeDesc::VEC4)
-                    || type
-                           == TypeDesc(TypeDesc::INT, TypeDesc::VEC2,
-                                       TypeDesc::BOX, 2)) {
+                if (type.equivalent(TypeDesc(TypeDesc::INT, 4))
+                    || type.equivalent(TypeDesc(TypeDesc::INT, TypeDesc::VEC4))
+                    || type.is_box2(TypeDesc::INT)) {
                     m_processor->imgdata.params.greybox[0] = p->get<int>(0);
                     m_processor->imgdata.params.greybox[1] = p->get<int>(1);
                     m_processor->imgdata.params.greybox[2] = p->get<int>(2);
@@ -590,16 +589,15 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
             auto p = config.find_attribute("raw:user_mul");
             if (p) {
                 auto type = p->type();
-                if (type == TypeDesc(TypeDesc::FLOAT, 4)
-                    || type == TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC4)) {
+                if (type.equivalent(TypeDesc(TypeDesc::FLOAT, 4))
+                    || type.equivalent(TypeFloat4)) {
                     m_processor->imgdata.params.user_mul[0] = p->get<float>(0);
                     m_processor->imgdata.params.user_mul[1] = p->get<float>(1);
                     m_processor->imgdata.params.user_mul[2] = p->get<float>(2);
                     m_processor->imgdata.params.user_mul[3] = p->get<float>(3);
-                } else if (type == TypeDesc(TypeDesc::DOUBLE, 4)
-                           || type
-                                  == TypeDesc(TypeDesc::DOUBLE,
-                                              TypeDesc::VEC4)) {
+                } else if (type.equivalent(TypeDesc(TypeDesc::DOUBLE, 4))
+                           || type.equivalent(
+                               TypeDesc(TypeDesc::DOUBLE, TypeDesc::VEC4))) {
                     m_processor->imgdata.params.user_mul[0] = p->get<double>(0);
                     m_processor->imgdata.params.user_mul[1] = p->get<double>(1);
                     m_processor->imgdata.params.user_mul[2] = p->get<double>(2);
@@ -815,12 +813,9 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         auto p = config.find_attribute("raw:cropbox");
         if (p) {
             auto type = p->type();
-
-            if (type == TypeDesc(TypeDesc::INT, 4)
-                || type == TypeDesc(TypeDesc::INT, TypeDesc::VEC4)
-                || type
-                       == TypeDesc(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX,
-                                   2)) {
+            if (type.equivalent(TypeDesc(TypeDesc::INT, 4))
+                || type.equivalent(TypeDesc(TypeDesc::INT, TypeDesc::VEC4))
+                || type.is_box2(TypeDesc::INT)) {
                 crop_left   = p->get<int>(0);
                 crop_top    = p->get<int>(1);
                 crop_width  = p->get<int>(2);

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -530,13 +530,17 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         = config.get_int_attribute("raw:user_sat", 0);
     {
         auto p = config.find_attribute("raw:aber");
-        if (p && p->type() == TypeDesc(TypeDesc::FLOAT, 2)) {
-            m_processor->imgdata.params.aber[0] = p->get<float>(0);
-            m_processor->imgdata.params.aber[2] = p->get<float>(1);
-        }
-        if (p && p->type() == TypeDesc(TypeDesc::DOUBLE, 2)) {
-            m_processor->imgdata.params.aber[0] = p->get<double>(0);
-            m_processor->imgdata.params.aber[2] = p->get<double>(1);
+        if (p) {
+            auto type = p->type();
+            if (type == TypeDesc(TypeDesc::FLOAT, 2)
+                || type == TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC2)) {
+                m_processor->imgdata.params.aber[0] = p->get<float>(0);
+                m_processor->imgdata.params.aber[2] = p->get<float>(1);
+            } else if (type == TypeDesc(TypeDesc::DOUBLE, 2)
+                       || type == TypeDesc(TypeDesc::DOUBLE, TypeDesc::VEC2)) {
+                m_processor->imgdata.params.aber[0] = p->get<double>(0);
+                m_processor->imgdata.params.aber[2] = p->get<double>(1);
+            }
         }
     }
 
@@ -566,29 +570,41 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
             m_processor->imgdata.params.use_auto_wb = 1;
             // White balancing to a box requires use_auto_wb = 1
             auto p = config.find_attribute("raw:greybox");
-            if (p && p->type() == TypeDesc(TypeDesc::INT, 4)) {
-                // p->get<int>() didn't work for me here
-                m_processor->imgdata.params.greybox[0] = p->get_int_indexed(0);
-                m_processor->imgdata.params.greybox[1] = p->get_int_indexed(1);
-                m_processor->imgdata.params.greybox[2] = p->get_int_indexed(2);
-                m_processor->imgdata.params.greybox[3] = p->get_int_indexed(3);
+            if (p) {
+                auto type = p->type();
+                if (type == TypeDesc(TypeDesc::INT, 4)
+                    || type == TypeDesc(TypeDesc::INT, TypeDesc::VEC4)
+                    || type
+                           == TypeDesc(TypeDesc::INT, TypeDesc::VEC2,
+                                       TypeDesc::BOX, 2)) {
+                    m_processor->imgdata.params.greybox[0] = p->get<int>(0);
+                    m_processor->imgdata.params.greybox[1] = p->get<int>(1);
+                    m_processor->imgdata.params.greybox[2] = p->get<int>(2);
+                    m_processor->imgdata.params.greybox[3] = p->get<int>(3);
+                }
             }
         } else {
             // Set user white balance coefficients.
             // Only has effect if "raw:use_camera_wb" is equal to 0,
             // i.e. we are not using the camera white balance
             auto p = config.find_attribute("raw:user_mul");
-            if (p && p->type() == TypeDesc(TypeDesc::FLOAT, 4)) {
-                m_processor->imgdata.params.user_mul[0] = p->get<float>(0);
-                m_processor->imgdata.params.user_mul[1] = p->get<float>(1);
-                m_processor->imgdata.params.user_mul[2] = p->get<float>(2);
-                m_processor->imgdata.params.user_mul[3] = p->get<float>(3);
-            }
-            if (p && p->type() == TypeDesc(TypeDesc::DOUBLE, 4)) {
-                m_processor->imgdata.params.user_mul[0] = p->get<double>(0);
-                m_processor->imgdata.params.user_mul[1] = p->get<double>(1);
-                m_processor->imgdata.params.user_mul[2] = p->get<double>(2);
-                m_processor->imgdata.params.user_mul[3] = p->get<double>(3);
+            if (p) {
+                auto type = p->type();
+                if (type == TypeDesc(TypeDesc::FLOAT, 4)
+                    || type == TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC4)) {
+                    m_processor->imgdata.params.user_mul[0] = p->get<float>(0);
+                    m_processor->imgdata.params.user_mul[1] = p->get<float>(1);
+                    m_processor->imgdata.params.user_mul[2] = p->get<float>(2);
+                    m_processor->imgdata.params.user_mul[3] = p->get<float>(3);
+                } else if (type == TypeDesc(TypeDesc::DOUBLE, 4)
+                           || type
+                                  == TypeDesc(TypeDesc::DOUBLE,
+                                              TypeDesc::VEC4)) {
+                    m_processor->imgdata.params.user_mul[0] = p->get<double>(0);
+                    m_processor->imgdata.params.user_mul[1] = p->get<double>(1);
+                    m_processor->imgdata.params.user_mul[2] = p->get<double>(2);
+                    m_processor->imgdata.params.user_mul[3] = p->get<double>(3);
+                }
             }
         }
     }
@@ -797,11 +813,19 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         ushort top_margin  = 0;
 
         auto p = config.find_attribute("raw:cropbox");
-        if (p && p->type() == TypeDesc(TypeDesc::INT, 4)) {
-            crop_left   = p->get_int_indexed(0);
-            crop_top    = p->get_int_indexed(1);
-            crop_width  = p->get_int_indexed(2);
-            crop_height = p->get_int_indexed(3);
+        if (p) {
+            auto type = p->type();
+
+            if (type == TypeDesc(TypeDesc::INT, 4)
+                || type == TypeDesc(TypeDesc::INT, TypeDesc::VEC4)
+                || type
+                       == TypeDesc(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX,
+                                   2)) {
+                crop_left   = p->get<int>(0);
+                crop_top    = p->get<int>(1);
+                crop_width  = p->get<int>(2);
+                crop_height = p->get<int>(3);
+            }
         }
 #if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
         else if (m_processor->imgdata.sizes.raw_inset_crops[0].cwidth != 0) {


### PR DESCRIPTION

### Description

Adds more supported types to rawinput multi-value hints, i.e. white-balancing multipliers can be provided as either four floats, or a single float4 vector; the cropbox and greybox  can be provided as four ints, or 2x int2 box. 

### Tests

I haven't added any tests to the test suite, only tested manually. Happy to add some tests if we think that adding C++ or python tests is justified at this stage (so far we've only got oiiotool-based tests in rawinput).


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
