### PR TITLE
docs(color): Use color interop IDs and new views instead of legacy names

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -60,7 +60,8 @@ tiles.
      - Version of the BMP file format
    * - ``oiio:ColorSpace``
      - string
-     - currently, it is always ``"sRGB"`` (we presume all BMP files are sRGB)
+     - currently, it is always ``"srgb_rec709_display"`` or
+       ``"srgb_rec709_scene"`` (we presume all BMP files are sRGB)
 
 **Configuration settings for BMP input**
 

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -3074,13 +3074,13 @@ Color space conversion
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.exr");
-          ImageBuf Dst = ImageBufAlgo::ociodisplay (Src, "sRGB", "ACES 2.0 - SDR 100 nits (Rec.709)",
+          ImageBuf Dst = ImageBufAlgo::ociodisplay (Src, "sRGB - Display", "ACES 2.0 - SDR 100 nits (Rec.709)",
                                                     "lin_rec709_scene", "", true, "SHOT", "pe0012");
 
        .. code-tab:: py
 
           Src = ImageBuf("tahoe.jpg")
-          Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "ACES 2.0 - SDR 100 nits (Rec.709)",
+          Dst = ImageBufAlgo.ociodisplay (Src, "sRGB - Display", "ACES 2.0 - SDR 100 nits (Rec.709)",
                                           "lin_rec709_scene", "", True, "SHOT", "pe0012")
 
        .. code-tab:: bash oiiotool

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -2971,16 +2971,18 @@ Color space conversion
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.jpg");
-          ImageBuf Dst = ImageBufAlgo::colorconvert (Src, "sRGB", "acescg", true);
+          ImageBuf Dst = ImageBufAlgo::colorconvert (Src, "srgb_rec709_scene",
+                                                     "lin_ap1_scene", true);
 
        .. code-tab:: py
 
           Src = ImageBuf("tahoe.jpg")
-          Dst = ImageBufAlgo.colorconvert (Src, "sRGB", "acescg", True)
+          Dst = ImageBufAlgo.colorconvert (Src, "srgb_rec709_scene",
+                                           "lin_ap1_scene", True)
 
        .. code-tab:: bash oiiotool
 
-          oiiotool tahoe.jpg --colorconvert sRGB acescg -o tahoe_acescg.exr
+          oiiotool tahoe.jpg --colorconvert srgb_rec709_scene lin_ap1_scene -o tahoe_acescg.exr
 
 |
 
@@ -3072,18 +3074,18 @@ Color space conversion
        .. code-tab:: c++
 
           ImageBuf Src ("tahoe.exr");
-          ImageBuf Dst = ImageBufAlgo::ociodisplay (Src, "sRGB", "Film", "lnf",
-                                                    "", true, "SHOT", "pe0012");
+          ImageBuf Dst = ImageBufAlgo::ociodisplay (Src, "sRGB", "ACES 2.0 - SDR 100 nits (Rec.709)",
+                                                    "lin_rec709_scene", "", true, "SHOT", "pe0012");
 
        .. code-tab:: py
 
           Src = ImageBuf("tahoe.jpg")
-          Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "Film", "lnf",
-                                          "", True, "SHOT", "pe0012")
+          Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "ACES 2.0 - SDR 100 nits (Rec.709)",
+                                          "lin_rec709_scene", "", True, "SHOT", "pe0012")
 
        .. code-tab:: bash oiiotool
 
-          oiiotool tahoe.jpg --ociodisplay:from=lnf:unpremult=1:key=SHOT:value=pe0012 sRGB Film -o out.exr
+          oiiotool tahoe.jpg --ociodisplay:from=lin_rec709_scene:unpremult=1:key=SHOT:value=pe0012 sRGB "ACES 2.0 - SDR 100 nits (Rec.709)" -o out.exr
 
 |
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3751,7 +3751,7 @@ Color manipulation
     .. code-block:: python
 
         Src = ImageBuf ("tahoe.exr")
-        Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "ACES 2.0 - SDR 100 nits (Rec.709)",
+        Dst = ImageBufAlgo.ociodisplay (Src, "sRGB - Display", "ACES 2.0 - SDR 100 nits (Rec.709)",
                                         "lin_rec709_scene",
                                         context_key="SHOT", context_value="pe0012")
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3700,7 +3700,8 @@ Color manipulation
     .. code-block:: python
 
         Src = ImageBuf ("tahoe.jpg")
-        Dst = ImageBufAlgo.colorconvert (Src, "sRGB", "scene_linear")
+        Dst = ImageBufAlgo.colorconvert (Src, "srgb_rec709_scene",
+                                         "scene_linear")
 
 
 
@@ -3750,8 +3751,9 @@ Color manipulation
     .. code-block:: python
 
         Src = ImageBuf ("tahoe.exr")
-        Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "Film", "lnf",
-                                  context_key="SHOT", context_value="pe0012")
+        Dst = ImageBufAlgo.ociodisplay (Src, "sRGB", "ACES 2.0 - SDR 100 nits (Rec.709)",
+                                        "lin_rec709_scene",
+                                        context_key="SHOT", context_value="pe0012")
 
 
 

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -149,9 +149,13 @@ Color information
     - `"lin_ap1_scene"`, `"ACEScg"` :  ACEScg color space encoding.
     - `"lin_ap0_scene"` :  ACES2065-1, the recommended ACES space for
       interchange and archiving.
-    - `"srgb_rec709_scene"` : Using standard (piecewise) sRGB response and
-      primaries. The token `"sRGB"` is treated as a synonym.
-    - `"g22_rec709_scene"` : Rec709/sRGB primaries, but using a response curve
+    - `"srgb_rec709_display"` : Using standard (piecewise) sRGB response and
+      primaries.
+    - `"srgb_rec709_scene"` : Same response and primaries as
+      `"srgb_rec709_display"` but for scene referred images. The token `"sRGB"`
+      is treated as a synonym, but it is recommended to use the more specific
+      interop ID.
+    - `"g22_rec709_display"` : Rec709/sRGB primaries, but using a response curve
       corresponding to gamma 2.2.
 
     Additionally, `"scene_linear"` is a role that is appropriate for color


### PR DESCRIPTION
### Description

Some of the color space, display and view names were still from older SPI and ACES configs.

Ref #4980

### Tests

N/A

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.