### PR TITLE
deps: Raise LibRaw minimum to 0.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,7 @@ jobs:
                              Robinmap_GIT_COMMIT=188c45569cc2a5dd768077c193830b51d33a5020
                              TIFF_BUILD_VERSION=4.0.0
                              TIFF_GIT_COMMIT=f7b79dc7dc86ccbaabe9882e2b9ffa5ee8dac917
+                             LIBRAW_VERSION=0.21.0
                             #  OpenJPEG_BUILD_VERSION=2.2.0
                             #  OpenJPEG_GIT_COMMIT=3d7cde5fc9fbc5618d02160900d32e02ed12a00e
             optional_deps_append: 'FFmpeg;LibRaw;Ptex;Qt6'
@@ -524,6 +525,7 @@ jobs:
                             TIFF_GIT_COMMIT=f7b79dc7dc86ccbaabe9882e2b9ffa5ee8dac917
                             openjph_CMAKE_C_COMPILER=gcc
                             openjph_CMAKE_CXX_COMPILER=g++
+                            LIBRAW_VERSION=0.21.0
                             #  OpenJPEG_BUILD_VERSION=2.2.0
                             #  OpenJPEG_GIT_COMMIT=3d7cde5fc9fbc5618d02160900d32e02ed12a00e
             optional_deps_append: 'FFmpeg;LibRaw;Ptex;Qt6'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for PNG files:
      * libPNG >= 1.6.0 (tested though 1.6.58)
  * If you want support for camera "RAW" formats:
-     * LibRaw >= 0.20 (tested though 0.22.2 and master; minimum of 0.21.3 recommended for security reasons)
+     * **LibRaw >= 0.21.0** (tested though 0.22.2 and master; minimum of 0.21.3 recommended for security reasons)
  * If you want support for a wide variety of video formats:
      * ffmpeg >= 4.0 (tested through 8.1)
  * If you want support for jpeg 2000 images:

--- a/src/build-scripts/build_libraw.bash
+++ b/src/build-scripts/build_libraw.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Which LibRaw to retrieve, how to build it
 LIBRAW_REPO=${LIBRAW_REPO:=https://github.com/LibRaw/LibRaw.git}
-LIBRAW_VERSION=${LIBRAW_VERSION:=0.21.5}
+LIBRAW_VERSION=${LIBRAW_VERSION:=0.22.2}
 
 # Where to install the final results
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -190,7 +190,7 @@ checked_find_package (Libheif VERSION_MIN 1.11
                       RECOMMEND_MIN_REASON "1.16 for orientation support, 1.17 for monochrome support")
 
 checked_find_package (LibRaw
-                      VERSION_MIN 0.20.0
+                      VERSION_MIN 0.21.0
                       RECOMMEND_MIN 0.21.3
                       RECOMMEND_MIN_REASON "0.21.3 for many security fixes"
                       PRINT LibRaw_r_LIBRARIES)

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -44,7 +44,7 @@ template<class T> using auto_ptr = unique_ptr<T>;
 #include <libraw/libraw.h>
 #include <libraw/libraw_version.h>
 
-#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 20, 0)
+#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
 #    error "OpenImageIO does not support such an old LibRaw"
 #endif
 
@@ -446,14 +446,12 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         return false;
     }
 
-#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
     // Cap LibRaw's internal allocations. This must be set *before* unpack().
     // Default max is 2048 MB.
     int maxmem = config.get_int_attribute("raw:max_raw_memory_mb", 2048);
     // In some versions of libraw, there is a known overflow if it's over
     // 16384, so cap it.
     m_processor->imgdata.rawparams.max_raw_memory_mb = std::min(maxmem, 16383);
-#endif
 
     // Guard against decompression bombs / corrupt headers before calling
     // unpack(). LibRaw's own caps (65535/dimension, max_raw_memory_mb) are
@@ -677,24 +675,16 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         m_processor->imgdata.params.output_color = 6;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
-#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
     } else if (Strutil::iequals(cs, "DCI-P3")) {
         // DCI-P3
         m_processor->imgdata.params.output_color = 7;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
-#endif
     } else if (Strutil::iequals(cs, "Rec2020")) {
-#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
         // Rec2020
         m_processor->imgdata.params.output_color = 8;
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
-#else
-        errorfmt("raw:ColorSpace value of \"{}\" is not supported by libRaw {}",
-                 cs, LIBRAW_VERSION_STR);
-        return false;
-#endif
     } else {
         errorfmt("raw:ColorSpace set to unknown value \"{}\"", cs);
         return false;
@@ -821,9 +811,7 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
                 crop_width  = p->get<int>(2);
                 crop_height = p->get<int>(3);
             }
-        }
-#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
-        else if (m_processor->imgdata.sizes.raw_inset_crops[0].cwidth != 0) {
+        } else if (m_processor->imgdata.sizes.raw_inset_crops[0].cwidth != 0) {
             crop_left   = m_processor->imgdata.sizes.raw_inset_crops[0].cleft;
             crop_top    = m_processor->imgdata.sizes.raw_inset_crops[0].ctop;
             crop_width  = m_processor->imgdata.sizes.raw_inset_crops[0].cwidth;
@@ -831,16 +819,6 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
             left_margin = m_processor->imgdata.sizes.left_margin;
             top_margin  = m_processor->imgdata.sizes.top_margin;
         }
-#else
-        else if (m_processor->imgdata.sizes.raw_inset_crop.cwidth != 0) {
-            crop_left   = m_processor->imgdata.sizes.raw_inset_crop.cleft;
-            crop_top    = m_processor->imgdata.sizes.raw_inset_crop.ctop;
-            crop_width  = m_processor->imgdata.sizes.raw_inset_crop.cwidth;
-            crop_height = m_processor->imgdata.sizes.raw_inset_crop.cheight;
-            left_margin = m_processor->imgdata.sizes.left_margin;
-            top_margin  = m_processor->imgdata.sizes.top_margin;
-        }
-#endif
         if (crop_width > 0 && crop_height > 0) {
             ushort image_width  = m_processor->imgdata.sizes.width;
             ushort image_height = m_processor->imgdata.sizes.height;
@@ -1120,22 +1098,6 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         m_spec.attribute("Orientation", original_flip);
     }
 
-#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
-    if (m_processor->imgdata.thumbnail.tlength > 0) {
-        auto width  = m_processor->imgdata.thumbnail.twidth;
-        auto height = m_processor->imgdata.thumbnail.theight;
-
-        // see note below
-        if (width == 0)
-            width = -1;
-        if (height == 0)
-            height = -1;
-
-        m_spec.attribute("thumbnail_width", width);
-        m_spec.attribute("thumbnail_height", height);
-    }
-#else
-
     auto thumb_count = m_processor->imgdata.thumbs_list.thumbcount;
     if (thumb_count > 0) {
         m_thumb_index = config.get_int_attribute("raw:thumbnail_index", -1);
@@ -1211,8 +1173,6 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         m_spec.attribute("thumbnail_width", width);
         m_spec.attribute("thumbnail_height", height);
     }
-#endif
-
 
     get_lensinfo();
     get_shootinginfo();
@@ -1272,29 +1232,6 @@ RawInput::get_makernotes_canon()
     MAKERF(ExposureMode);
     MAKERF(AESetting);
     MAKERF(ImageStabilization);
-#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
-    MAKERF(HighlightTonePriority);
-    MAKERF(FocusMode);
-    MAKER(AFPoint, 0);
-    MAKERF(FocusContinuous);
-    //  short        AFPointsInFocus30D;
-    //  uchar        AFPointsInFocus1D[8];
-    //  ushort       AFPointsInFocus5D;        /* bytes in reverse*/
-    MAKERF(AFAreaMode);
-    if (mn.AFAreaMode) {
-        MAKERF(NumAFPoints);
-        MAKERF(ValidAFPoints);
-        MAKERF(AFImageWidth);
-        MAKERF(AFImageHeight);
-        //  short        AFAreaWidths[61];
-        //  short        AFAreaHeights[61];
-        //  short        AFAreaXPositions[61];
-        //  short        AFAreaYPositions[61];
-        //  short        AFPointsInFocus[4]
-        //  short        AFPointsSelected[4];
-        //  ushort       PrimaryAFPoint;
-    }
-#endif
     MAKERF(FlashMode);
     MAKERF(FlashActivity);
     MAKER(FlashBits, 0);
@@ -1341,27 +1278,6 @@ RawInput::get_makernotes_nikon()
     MAKERF(ImageStabilization);
     MAKER(VibrationReduction, 0);
     MAKERF(VRMode);
-#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
-    MAKER(FocusMode, 0);
-    MAKERF(AFPoint);
-    MAKER(AFPointsInFocus, 0);
-    MAKERF(ContrastDetectAF);
-    MAKERF(AFAreaMode);
-    MAKERF(PhaseDetectAF);
-    if (mn.PhaseDetectAF) {
-        MAKER(PrimaryAFPoint, 0);
-        // uchar AFPointsUsed[29];
-    }
-    if (mn.ContrastDetectAF) {
-        MAKER(AFImageWidth, 0);
-        MAKER(AFImageHeight, 0);
-        MAKER(AFAreaXPposition, 0);
-        MAKER(AFAreaYPosition, 0);
-        MAKER(AFAreaWidth, 0);
-        MAKER(AFAreaHeight, 0);
-        MAKER(ContrastDetectAFInFocus, 0);
-    }
-#endif
     MAKER(FlashSetting, 0);
     MAKER(FlashType, 0);
     MAKERF(FlashExposureCompensation);
@@ -1481,11 +1397,6 @@ RawInput::get_makernotes_fuji()
     MAKERF(ExrMode);
     MAKERF(Macro);
     MAKERF(Rating);
-#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
-    MAKERF(FrameRate);
-    MAKERF(FrameWidth);
-    MAKERF(FrameHeight);
-#endif
 }
 
 
@@ -1660,12 +1571,7 @@ RawInput::get_colorinfo()
         add("raw", "dng:version", m_processor->imgdata.idata.dng_version);
 
         auto const& c = m_processor->imgdata.rawdata.color;
-
-#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 20, 0)
         add("raw", "dng:baseline_exposure", c.dng_levels.baseline_exposure);
-#else
-        add("raw", "dng:baseline_exposure", c.baseline_exposure);
-#endif
 
         for (int i = 0; i < 2; i++) {
             std::string index = std::to_string(i + 1);
@@ -1890,14 +1796,6 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
         return false;
     }
 
-#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
-    int errcode = m_processor->unpack_thumb();
-    if (errcode != 0) {
-        if (errcode != LIBRAW_REQUEST_FOR_NONEXISTENT_IMAGE)
-            _errorfmt(this, m_thumb_index, "unpack_thumb error");
-        return false;
-    }
-#else
     int errcode;
     if (m_thumb_index == -1)
         errcode = m_processor->unpack_thumb();
@@ -1909,7 +1807,6 @@ RawInput::get_thumbnail(ImageBuf& thumb, int subimage)
             _errorfmt(this, m_thumb_index, "unpack_thumb_ex error");
         return false;
     }
-#endif
 
     if (!m_thumb) {
         m_thumb = m_processor->dcraw_make_mem_thumb(&errcode);


### PR DESCRIPTION
This LibRaw 0.21.0 release dates from Dec 2022, so will be nearly 4 years old by the time we release 3.2. The old/current enforced minimum of 0.20.0 dates from mid-2020, so is pretty old.

Raising the minimum to 0.21.0 allows us to get rid of much `#if` clutter that catered to older versions.

Change in main (OIIO 3.2) only, since we don't raise dependency minimums within minor releases.
