### PR TITLE
fix(IBA): keep nearest resample off the Highway path

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_hwy_pvt.h
+++ b/src/libOpenImageIO/imagebufalgo_hwy_pvt.h
@@ -1100,7 +1100,7 @@ hwy_binary_perpixel_op_rgba_rgb_roi(ImageBuf& R, const ImageBuf& A,
                 (void)ba;
 
                 using DstLaneT = HwyLaneTypeT<Rtype>;
-                auto d_dstlane = hn::Rebind<DstLaneT, decltype(d)>();
+                auto d_dstlane = hn::Rebind<DstLaneT, hn::ScalableTag<MathT>>();
                 hn::Vec<decltype(d_dstlane)> dr, dg, db, da;
                 hn::LoadInterleaved4(d_dstlane,
                                      reinterpret_cast<const DstLaneT*>(r_row
@@ -1189,7 +1189,7 @@ hwy_ternary_perpixel_op_rgba_rgb_roi(ImageBuf& R, const ImageBuf& A,
                 (void)ca;
 
                 using DstLaneT = HwyLaneTypeT<Rtype>;
-                auto d_dstlane = hn::Rebind<DstLaneT, decltype(d)>();
+                auto d_dstlane = hn::Rebind<DstLaneT, hn::ScalableTag<MathT>>();
                 hn::Vec<decltype(d_dstlane)> dr, dg, db, da;
                 hn::LoadInterleaved4(d_dstlane,
                                      reinterpret_cast<const DstLaneT*>(r_row

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -739,6 +739,40 @@ test_zover()
 
 
 // Test ImageBuf::resample
+// resample_hwy() ignores its `interpolate` argument and always bilerps, so
+// nearest sampling has to stay off that path. Highway is off by default, so a
+// reference image would not exercise this; compare the two settings instead.
+void
+test_resample_hwy_nearest()
+{
+    std::cout << "test resample nearest is not routed to Highway\n";
+
+    int prev_hwy = 0;
+    OIIO::getattribute("enable_hwy", prev_hwy);
+
+    // Neighbouring pixels must differ, or bilerp and nearest would agree and
+    // the test would pass on broken code.
+    ImageSpec srcspec(64, 48, 4, TypeFloat);
+    ImageBuf src(srcspec);
+    for (ImageBuf::Iterator<float> it(src); !it.done(); ++it)
+        for (int c = 0; c < 4; ++c)
+            it[c] = float(((it.x() + it.y() + c) % 7) * 0.125f);
+
+    ImageSpec dstspec(37, 29, 4, TypeFloat);
+    ImageBuf without_hwy(dstspec), with_hwy(dstspec);
+    OIIO::attribute("enable_hwy", 0);
+    OIIO_CHECK_ASSERT(ImageBufAlgo::resample(without_hwy, src, false));
+    OIIO::attribute("enable_hwy", 1);
+    OIIO_CHECK_ASSERT(ImageBufAlgo::resample(with_hwy, src, false));
+    OIIO::attribute("enable_hwy", prev_hwy);
+
+    OIIO_CHECK_EQUAL(memcmp(with_hwy.localpixels(), without_hwy.localpixels(),
+                            dstspec.image_bytes()),
+                     0);
+}
+
+
+
 void
 test_resample()
 {
@@ -1811,6 +1845,7 @@ main(int argc, char** argv)
     test_over(TypeFloat);
     test_over(TypeHalf);
     test_zover();
+    test_resample_hwy_nearest();
     test_resample();
     test_compare();
     test_isConstantColor();

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -1272,6 +1272,9 @@ static bool
 resample_hwy(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
              int nthreads)
 {
+    // This routine has no nearest case -- it always interpolates -- so
+    // resample_() must not route nearest sampling here.
+    OIIO_ASSERT(interpolate);
     using SimdType
         = std::conditional_t<std::is_same_v<DSTTYPE, double>, double, float>;
     using D      = hn::ScalableTag<SimdType>;
@@ -1435,7 +1438,10 @@ resample_(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
           int nthreads)
 {
 #if OIIO_USE_HWY
-    if (OIIO::pvt::enable_hwy && HwySupports<DSTTYPE>(dst, roi)
+    // Interpolating only: resample_hwy() ignores its `interpolate` argument
+    // and always bilerps, so sending nearest here silently returns filtered
+    // pixels instead of the source pixel the caller asked for.
+    if (interpolate && OIIO::pvt::enable_hwy && HwySupports<DSTTYPE>(dst, roi)
         && HwySupports<SRCTYPE>(src, ROI()))
         return resample_hwy<DSTTYPE, SRCTYPE>(dst, src, interpolate, roi,
                                               nthreads);


### PR DESCRIPTION
### Description

resample_hwy() ignores its `interpolate` argument and always bilerps, but resample_() routed nearest sampling to it whenever Highway was enabled, so ImageBufAlgo::resample(dst, src, false) returned filtered pixels instead of the source pixel the caller asked for. Measured against a 128x128 nearest resample of testsuite/common/grid.tif, 40.9% of pixels were wrong, with a maximum error of 0.608.

Latent today because enable_hwy defaults to 0, but it becomes a live behavior change as soon as Highway is turned on by default.

Also fixes an MSVC build failure in the same subsystem. The two hwy_*_perpixel_op_rgba_rgb_roi() lambdas derived a tag type with decltype(d), where d is captured from the enclosing function; MSVC yields a reference type there, and D::template Rebind<T> cannot be named through a reference. Naming the tag directly drops the dependency on how decltype treats a captured entity, and says what the tag is rather than what it matches.


### Tests

Case added: test_resample_hwy_nearest


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
