### PR TITLE
deps: Raise cmake minimum to 3.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
             python_ver: "3.9"
             python_action_ver: "3.9"
             gcc_action_ver: 9
-            setenvs: export  CMAKE_VERSION=3.22.0
+            setenvs: export  CMAKE_VERSION=3.23.0
                              PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.1.0
                              PUGIXML_VERSION=v1.11
@@ -510,7 +510,7 @@ jobs:
             python_ver: "3.9"
             python_action_ver: "3.9"
             llvm_action_ver: "11"
-            setenvs: export CMAKE_VERSION=3.22.0
+            setenvs: export CMAKE_VERSION=3.23.0
                             PTEX_VERSION=v2.3.2
                             WEBP_VERSION=v1.1.0
                             PUGIXML_VERSION=v1.11
@@ -550,7 +550,7 @@ jobs:
             gcc_action_ver: 9
             simd: 0
             setenvs: export  EMBEDPLUGINS=0
-                             CMAKE_VERSION=3.22.0
+                             CMAKE_VERSION=3.23.0
                              PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.1.0
                              USE_JPEGTURBO=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
             python_ver: "3.9"
             python_action_ver: "3.9"
             gcc_action_ver: 9
-            setenvs: export  CMAKE_VERSION=3.18.2
+            setenvs: export  CMAKE_VERSION=3.22.0
                              PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.1.0
                              PUGIXML_VERSION=v1.11
@@ -510,7 +510,7 @@ jobs:
             python_ver: "3.9"
             python_action_ver: "3.9"
             llvm_action_ver: "11"
-            setenvs: export CMAKE_VERSION=3.18.2
+            setenvs: export CMAKE_VERSION=3.22.0
                             PTEX_VERSION=v2.3.2
                             WEBP_VERSION=v1.1.0
                             PUGIXML_VERSION=v1.11
@@ -550,7 +550,7 @@ jobs:
             gcc_action_ver: 9
             simd: 0
             setenvs: export  EMBEDPLUGINS=0
-                             CMAKE_VERSION=3.18.2
+                             CMAKE_VERSION=3.22.0
                              PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.1.0
                              USE_JPEGTURBO=0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
-cmake_minimum_required (VERSION 3.18.2...4.0)
+cmake_minimum_required (VERSION 3.22.0...4.0)
 
 set (OpenImageIO_VERSION "3.2.0.2")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
@@ -29,15 +29,6 @@ if (${PROJECT_NAME}_SUPPORTED_RELEASE)
     set (${PROJECT_NAME}_DEV_RELEASE OFF)
 else ()
     set (${PROJECT_NAME}_DEV_RELEASE ON)
-endif ()
-
-# Set PROJECT_IS_TOP_LEVEL to ON if if this is the top level project (not
-# if this is included as a subproject of something else). Note that this is
-# handled automatically for CMake >= 3.21.
-if (CMAKE_VERSION VERSION_LESS 3.21)
-    if ("${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
-        set (PROJECT_IS_TOP_LEVEL ON)
-    endif ()
 endif ()
 
 # Set up module path for our own cmake modules and add some essential ones
@@ -85,6 +76,7 @@ message (STATUS "Project install prefix = ${CMAKE_INSTALL_PREFIX}")
 message (STATUS "Configuration types    = ${CMAKE_CONFIGURATION_TYPES}")
 message (STATUS "Build type             = ${CMAKE_BUILD_TYPE}")
 message (STATUS "Supported release      = ${${PROJECT_NAME}_SUPPORTED_RELEASE}")
+message (STATUS "Project is top level   = ${PROJECT_IS_TOP_LEVEL}")
 
 # Make the build area layout look a bit more like the final dist layout
 if (PROJECT_IS_TOP_LEVEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
-cmake_minimum_required (VERSION 3.22.0...4.0)
+cmake_minimum_required (VERSION 3.23.0...4.0)
 
 set (OpenImageIO_VERSION "3.2.0.2")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        OIIO's public APIs only require C++17 features.
  * Compilers: gcc 9.3 - 16, clang 10 - 22, MSVS 2017 - 2026 (v19.14
    and up), Intel OneAPI C++ compiler 2022+.
- * CMake >= 3.18.2 (tested through 4.4)
+ * **CMake >= 3.22.0** (tested through 4.4)
  * Imath >= 3.1 (tested through 3.2 and main)
  * OpenEXR >= 3.1 (tested through 3.4 and main)
  * libTIFF >= 4.0 (tested through 4.7 and master)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        OIIO's public APIs only require C++17 features.
  * Compilers: gcc 9.3 - 16, clang 10 - 22, MSVS 2017 - 2026 (v19.14
    and up), Intel OneAPI C++ compiler 2022+.
- * **CMake >= 3.22.0** (tested through 4.4)
+ * **CMake >= 3.23.0** (tested through 4.4)
  * Imath >= 3.1 (tested through 3.2 and main)
  * OpenEXR >= 3.1 (tested through 3.4 and main)
  * libTIFF >= 4.0 (tested through 4.7 and master)

--- a/src/cmake/dependency_utils.cmake
+++ b/src/cmake/dependency_utils.cmake
@@ -386,7 +386,7 @@ macro (checked_find_package pkgname)
         # PKGConfigVersion.cmake has might have arbitrary rules. Use our own
         # MIN_VERSION and MAX_VERSION parameters to manually check instead.
         #
-        if (_pkg_VERSION_MIN AND _pkg_VERSION_MAX AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
+        if (_pkg_VERSION_MIN AND _pkg_VERSION_MAX)
             set (_${pkgname}_version_range "${_pkg_VERSION_MIN}...<${_pkg_VERSION_MAX}")
         elseif (_pkg_VERSION_MIN)
             set (_${pkgname}_version_range "${_pkg_VERSION_MIN}")


### PR DESCRIPTION
This is still 5 years old, but versus the prior 3.18 minimum, it gets us presets, better support for Apple Silicon, CUDA, C++23, among other things.

There's not much simplification this lets us do right away (like, no catering to old cmake that we can get rid of), but it opens the door to future PRs where we can confidently use cmake features that were introduced between 3.19 and 3.22.

