### PR TITLE
Add zstd as a compression option for the OpenEXR plugin in OIIO

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1614,8 +1614,9 @@ The official OpenEXR site is http://www.openexr.com/.
    * - ``compression``
      - string
      - one of: ``"none"``, ``"rle"``, ``"zip"``, ``"zips"``, ``"piz"``,
-       ``"pxr24"``, ``"b44"``, ``"b44a"``, ``"dwaa"``, ``"dwab"``, ``"htj2k256"`` or ``"htj2k32"``.
+       ``"pxr24"``, ``"b44"``, ``"b44a"``, ``"dwaa"``, ``"dwab"``, ``"htj2k256"``, ``"htj2k32"`` or ``"zstd"``.
        (``"htj2k256"`` and ``"htj2k32"`` are only supported with OpenEXR 3.4 or later.)
+       (``"zstd"`` are only supported with OpenEXR 3.5 or later.)
        If the writer receives a request for a compression type it does not
        recognize or is not supported by the version of OpenEXR on the
        system, it will use ``"zip"`` by default. For ``"dwaa"`` and
@@ -1625,6 +1626,9 @@ The official OpenEXR site is http://www.openexr.com/.
        compression, a level from 1 to 9 may be appended (the default is
        ``"zip:4"``), but note that this is only honored when building
        against OpenEXR 3.1.3 or later.
+       For ``"zstd"`` compression, a level from 1 to 22 may be appended (the default is
+       ``"zstd:5"``), but note that this is only honored when building
+       against OpenEXR 3.5.0 or later.
    * - ``textureformat``
      - string
      - ``"Plain Texture"`` for MIP-mapped OpenEXR files, ``"CubeFace

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -452,6 +452,9 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
 #ifdef IMF_HTJ2K32_COMPRESSION
         case Imf::HTJ2K32_COMPRESSION: comp = "htj2k32"; break;
 #endif
+#ifdef IMF_ZSTD_COMPRESSION
+        case Imf::ZSTD_COMPRESSION: comp = "zstd"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -580,6 +580,9 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
 #ifdef IMF_HTJ2K32_COMPRESSION
         case EXR_COMPRESSION_HTJ2K32: comp = "htj2k32"; break;
 #endif
+#ifdef IMF_ZSTD_COMPRESSION
+        case ZSTD_COMPRESSION: comp = "zstd"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -951,6 +951,14 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
         header.zipCompressionLevel() = (qual >= 1 && qual <= 9) ? qual : 4;
     }
 #endif
+#if OPENEXR_CODED_VERSION >= 30500
+    // OpenEXR 3.5.0 and later allow us to pick the quality level. We've found
+    // that 5 is a great tradeoff between size and speed, so that is our
+    // default.
+    if (Strutil::istarts_with(comp, "zstd")) {
+        header.zstdCompressionLevel() = (qual >= 1 && qual <= 22) ? qual : 5;
+    }
+#endif
     if (Strutil::istarts_with(comp, "dwa") && qual > 0) {
 #if OPENEXR_CODED_VERSION >= 30103
         // OpenEXR 3.1.3 and later have an API for setting the quality level
@@ -1204,6 +1212,10 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
 #ifdef IMF_HTJ2K32_COMPRESSION
             else if (Strutil::iequals(str, "htj2k32"))
                 header.compression() = Imf::HTJ2K32_COMPRESSION;
+#endif
+#ifdef ZSTD_COMPRESSION
+            else if (Strutil::iequals(str, "zstd"))
+                header.compression() = Imf::ZSTD_COMPRESSION;
 #endif
         }
         return true;


### PR DESCRIPTION
### Description

After adding the new zstd compression codec to OpenEXR, here we enable it in the OIIO stack so it will be recognized by the library and binary tools, such as using oiiotool to directly change compression type into zstd.

I'm also trying to study if more changes on the OIIO side is required to enabled the new zstd codec throughout the OIIO tool chain... suggestions welcome.

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [ ] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
