### PR TITLE
fix(oiiotool): minor safety fix for error message marshalling

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5666,7 +5666,7 @@ input_file(Oiiotool& ot, cspan<const char*> argv)
                 // Try to get a more precise error message to report.
                 auto in         = ImageInput::open(filename);
                 std::string err = in ? in->geterror() : OIIO::geterror();
-                errmsg = Strutil::format(ot.format_read_error(filename, err));
+                errmsg          = ot.format_read_error(filename, err);
             }
             // Second chances: do we have a substitute image policy?
             ImageSpec substitute_spec;


### PR DESCRIPTION
It's not safe to pass a string as the sole argument to Strutil::format.  When it's ok, it's just a no-op, so remove the format call and just assign to errmsg.

