### PR TITLE
Add Lossy HTJ2K compression option for the OpenEXR plugin in OIIO

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -451,6 +451,9 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
 #ifdef IMF_HTJ2K32_COMPRESSION
         case Imf::HTJ2K32_COMPRESSION: comp = "htj2k32"; break;
 #endif
+#ifdef IMF_HTJ2KL256_COMPRESSION
+        case Imf::HTJ2KL256_COMPRESSION: comp = "htj2kl256"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -577,6 +577,9 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
 #ifdef IMF_HTJ2K32_COMPRESSION
         case EXR_COMPRESSION_HTJ2K32: comp = "htj2k32"; break;
 #endif
+#ifdef IMF_HTJ2KL256_COMPRESSION
+        case EXR_COMPRESSION_HTJ2KL256: comp = "htj2kl256"; break;
+#endif
         default: break;
         }
         if (comp)

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -951,6 +951,14 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
         header.zipCompressionLevel() = (qual >= 1 && qual <= 9) ? qual : 4;
     }
 #endif
+    if (Strutil::istarts_with(comp, "htj2k") && qual > 110) {
+#if OPENEXR_CODED_VERSION >= 30500
+        // OpenEXR 3.5.0 and later have an API for setting the quality level
+        // in the Header object. Older ones do it by setting an attribute, as
+        // below.
+        header.lossyHTJ2KQuality() = float(qual);
+#endif
+        ================
     if (Strutil::istarts_with(comp, "dwa") && qual > 0) {
 #if OPENEXR_CODED_VERSION >= 30103
         // OpenEXR 3.1.3 and later have an API for setting the quality level
@@ -1204,6 +1212,10 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
 #ifdef IMF_HTJ2K32_COMPRESSION
             else if (Strutil::iequals(str, "htj2k32"))
                 header.compression() = Imf::HTJ2K32_COMPRESSION;
+#endif
+#ifdef HTJ2KL256_COMPRESSION
+            else if (Strutil::iequals(str, "htj2kl256"))
+                header.compression() = Imf::HTJ2KL256_COMPRESSION;
 #endif
         }
         return true;


### PR DESCRIPTION

### Description

After adding the new lossy htj2k compression codec to OpenEXR, here we enable it in the OIIO stack so it will be recognized by the library and binary tools, such as using oiiotool to directly change compression type into lossy htj2k.

I'm also trying to study if more changes on the OIIO side is required to enabled the new lossy htj2k codec throughout the OIIO tool chain... suggestions welcome.


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [ ] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
