### PR TITLE
build: Fix autobuild stale-cache bugs, unify build_*.cmake scripts

### DIFF
--- a/src/cmake/build_Freetype.cmake
+++ b/src/cmake/build_Freetype.cmake
@@ -39,12 +39,9 @@ build_dependency_with_cmake(Freetype
         -D CMAKE_POLICY_VERSION_MINIMUM=3.5
 )
 
-# Set some things up that we'll need for a subsequent find_package to work
-
-set (Freetype_ROOT ${Freetype_LOCAL_INSTALL_DIR})
-
 # Signal to caller that we need to find again at the installed location
 set (Freetype_REFIND TRUE)
+set (Freetype_REFIND_VERSION ${Freetype_BUILD_VERSION})
 set (Freetype_REFIND_ARGS CONFIG)
 
 if (Freetype_BUILD_SHARED_LIBS)

--- a/src/cmake/build_GIF.cmake
+++ b/src/cmake/build_GIF.cmake
@@ -30,11 +30,10 @@ build_dependency_with_cmake(GIF
 unset(GIF_CMAKELISTS_TEMPLATE_PATH)
 
 
-# Set some things up that we'll need for a subsequent find_package to work
-set (GIF_ROOT ${GIF_LOCAL_INSTALL_DIR})
-
 # Signal to caller that we need to find again at the installed location
-find_package (GIF ${GIF_BUILD_VERSION} EXACT CONFIG REQUIRED)
+set (GIF_REFIND TRUE)
+set (GIF_REFIND_VERSION ${GIF_BUILD_VERSION})
+set (GIF_REFIND_ARGS EXACT CONFIG)
 
 if (GIF_BUILD_SHARED_LIBS)
     install_local_dependency_libs (GIF GIF)

--- a/src/cmake/build_OpenColorIO.cmake
+++ b/src/cmake/build_OpenColorIO.cmake
@@ -16,14 +16,6 @@ set_cache (OpenColorIO_BUILD_SHARED_LIBS  OFF
 # it all work with the static dependencies, it just makes things complicated
 # downstream.
 
-# Clear variables from the failed find_package
-unset (OPENCOLORIO_LIBRARY)
-unset (OPENCOLORIO_INCLUDE_DIR)
-unset (FIND_PACKAGE_MESSAGE_DETAILS_OpenColorIO)
-unset (OPENCOLORIO_VERSION_MAJOR)
-unset (OPENCOLORIO_VERSION_MINOR)
-unset (OpenColorIO_DIR)
-
 checked_find_package(pystring VERSION_MIN 1.1.3)
 checked_find_package(expat REQUIRED VERSION_MIN 2.6)
 checked_find_package(yaml-cpp REQUIRED VERSION_MIN 0.8.0)
@@ -58,15 +50,10 @@ build_dependency_with_cmake(OpenColorIO
         -D CMAKE_POLICY_VERSION_MINIMUM=3.5
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
-set (OpenColorIO_ROOT ${OpenColorIO_LOCAL_INSTALL_DIR})
-set (OpenColorIO_DIR ${OpenColorIO_LOCAL_INSTALL_DIR})
-
 # Signal to caller that we need to find again at the installed location
-# set (OpenColorIO_REFIND TRUE)
-# set (OpenColorIO_REFIND_ARGS CONFIG)
-find_package (OpenColorIO ${OpenColorIO_BUILD_VERSION} EXACT CONFIG REQUIRED)
-find_package(pystring REQUIRED)
+set (OpenColorIO_REFIND TRUE)
+set (OpenColorIO_REFIND_VERSION ${OpenColorIO_BUILD_VERSION})
+set (OpenColorIO_REFIND_ARGS EXACT CONFIG)
 
 if (OpenColorIO_BUILD_SHARED_LIBS)
     install_local_dependency_libs (OpenColorIO OpenColorIO)

--- a/src/cmake/build_OpenJPEG.cmake
+++ b/src/cmake/build_OpenJPEG.cmake
@@ -22,14 +22,9 @@ build_dependency_with_cmake(OpenJPEG
         -D BUILD_CODEC=OFF 
         -D CMAKE_POSITION_INDEPENDENT_CODE=ON
     )
-# Set some things up that we'll need for a subsequent find_package to work
-set (OpenJPEG_ROOT ${OpenJPEG_LOCAL_INSTALL_DIR})
-set (OpenJPEG_VERSION ${OpenJPEG_BUILD_VERSION})
-set (OPENJPEG_VERSION ${OpenJPEG_BUILD_VERSION})
-
-
 # Signal to caller that we need to find again at the installed location
 set (OpenJPEG_REFIND TRUE)
+set (OpenJPEG_REFIND_VERSION ${OpenJPEG_BUILD_VERSION})
 set (OpenJPEG_REFIND_ARGS CONFIG)
 set_invert (OpenJPEG_LINKSTATIC ${OpenJPEG_BUILD_SHARED_LIBS})
 

--- a/src/cmake/build_PNG.cmake
+++ b/src/cmake/build_PNG.cmake
@@ -20,18 +20,6 @@ if (PNG_BUILD_USE_CUSTOM_PREFIX)
 endif ()
 string (MAKE_C_IDENTIFIER ${PNG_BUILD_VERSION} PNG_VERSION_IDENT)
 
-unset (PNG_FOUND)
-unset (PNG_LIBRARY)
-unset (PNG_LIBRARY_RELEASE)
-unset (PNG_LIBRARY_DEBUG)
-unset (PNG_LIBRARIES)
-unset (PNG_INCLUDE_DIRS)
-unset (PNG_INCLUDE_DIR)
-unset (PNG_PNG_INCLUDE_DIR)
-unset (PNG_VERSION_STRING)
-unset (PNG_DEFINITIONS)
-unset (PNG_VERSION)
-
 build_dependency_with_cmake (PNG
     VERSION         ${PNG_BUILD_VERSION}
     GIT_REPOSITORY  ${PNG_BUILD_GIT_REPOSITORY}
@@ -49,33 +37,16 @@ build_dependency_with_cmake (PNG
         ${PNG_BUILD_EXTRA_CMAKE_ARGS}
     )
 
-    
-set (PNG_REFIND FALSE)
+# Signal to caller that we need to find again at the installed location.
+# HINTS + NO_DEFAULT_PATH keep this from ever picking up a system PNG.
+set (PNG_REFIND TRUE)
 set (PNG_REFIND_VERSION ${PNG_BUILD_VERSION})
-set (PNG_REFIND_ARGS EXACT REQUIRED)
-set (PNG_FIND_VERSION_EXACT ON)
-unset (PNG_FOUND)
-unset (PNG_LIBRARY)
-unset (PNG_LIBRARY_RELEASE)
-unset (PNG_LIBRARY_DEBUG)
-unset (PNG_LIBRARIES)
-unset (PNG_INCLUDE_DIRS)
-unset (PNG_INCLUDE_DIR)
-unset (PNG_PNG_INCLUDE_DIR)
-unset (PNG_VERSION_STRING)
-unset (PNG_DEFINITIONS)
-unset (PNG_VERSION)
-
+set (PNG_REFIND_ARGS EXACT
+     HINTS ${PNG_LOCAL_INSTALL_DIR}/lib/cmake/PNG ${PNG_LOCAL_INSTALL_DIR}
+     NO_DEFAULT_PATH)
 if (PNG_BUILD_VERSION VERSION_GREATER 1.6.43)
     list (APPEND PNG_REFIND_ARGS CONFIG)
 endif ()
-
-find_package(PNG ${PNG_REFIND_VERSION} ${PNG_REFIND_ARGS}
-             HINTS 
-                    ${PNG_LOCAL_INSTALL_DIR}/lib/cmake/PNG
-                    ${PNG_LOCAL_INSTALL_DIR}
-             NO_DEFAULT_PATH
-            )
 
 set (PNG_INCLUDE_DIRS ${PNG_LOCAL_INSTALL_DIR}/include)
 include_directories(BEFORE ${PNG_INCLUDE_DIRS})

--- a/src/cmake/build_TIFF.cmake
+++ b/src/cmake/build_TIFF.cmake
@@ -51,15 +51,9 @@ build_dependency_with_cmake(TIFF
         ${MORE_TIFF_CMAKE_ARGS}
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
-
-set (TIFF_ROOT ${TIFF_LOCAL_INSTALL_DIR})
-set (TIFF_DIR ${TIFF_LOCAL_INSTALL_DIR})
-set (TIFF_VERSION ${TIFF_BUILD_VERSION})
-
 # Signal to caller that we need to find again at the installed location
-# set (TIFF_REFIND TRUE)
-find_package (TIFF REQUIRED)
+set (TIFF_REFIND TRUE)
+set (TIFF_REFIND_VERSION ${TIFF_BUILD_VERSION})
 
 if (TIFF_BUILD_SHARED_LIBS)
     install_local_dependency_libs (TIFF TIFF)

--- a/src/cmake/build_WebP.cmake
+++ b/src/cmake/build_WebP.cmake
@@ -35,9 +35,6 @@ build_dependency_with_cmake(WebP
         -D CMAKE_INSTALL_LIBDIR=lib
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
-set (WebP_ROOT ${WebP_LOCAL_INSTALL_DIR})
-
 # Signal to caller that we need to find again at the installed location
 set (WebP_REFIND TRUE)
 set (WebP_REFIND_VERSION ${WebP_BUILD_VERSION})

--- a/src/cmake/build_ZLIB.cmake
+++ b/src/cmake/build_ZLIB.cmake
@@ -30,12 +30,8 @@ build_dependency_with_cmake(ZLIB
         -D CMAKE_POLICY_VERSION_MINIMUM=3.5
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
-set (ZLIB_ROOT ${ZLIB_LOCAL_INSTALL_DIR})
-
 # Signal to caller that we need to find again at the installed location
 set (ZLIB_REFIND TRUE)
-set (ZLIB_VERSION ${ZLIB_BUILD_VERSION})
 set (ZLIB_REFIND_VERSION ${ZLIB_BUILD_VERSION})
 
 if (ZLIB_BUILD_SHARED_LIBS)

--- a/src/cmake/build_expat.cmake
+++ b/src/cmake/build_expat.cmake
@@ -43,16 +43,8 @@ build_dependency_with_cmake(expat
 
 # Set some things up that we'll need for a subsequent find_package to work
 set (expat_REFIND TRUE)
-set (expat_VERSION ${expat_BUILD_VERSION})
-set (expat_DIR ${expat_ROOT}/lib/cmake/expat-${expat_VERSION})
-
-if (WIN32)
-    # Set the expat_LIBRARY variable to the full path to ${EXPAT_LIBRARIES}.
-    # For some reason, find_package(expat) behaves differently on Windows
-    find_package (expat ${expat_BUILD_VERSION} EXACT REQUIRED)
-    set_cache(expat_LIBRARY ${EXPAT_LIBRARIES} "Full path to the expat library")
-    message(STATUS "expat_LIBRARY = ${expat_LIBRARY}")
-endif ()
+set (expat_REFIND_VERSION ${expat_BUILD_VERSION})
+set (expat_REFIND_ARGS CONFIG)
 
 if (expat_BUILD_SHARED_LIBS)
     install_local_dependency_libs (expat expat)

--- a/src/cmake/build_expat.cmake
+++ b/src/cmake/build_expat.cmake
@@ -41,7 +41,7 @@ build_dependency_with_cmake(expat
         -D EXPAT_SHARED_LIBS=${expat_BUILD_SHARED_LIBS}
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
+# Signal to caller that we need to find again at the installed location
 set (expat_REFIND TRUE)
 set (expat_REFIND_VERSION ${expat_BUILD_VERSION})
 set (expat_REFIND_ARGS CONFIG)

--- a/src/cmake/build_fmt.cmake
+++ b/src/cmake/build_fmt.cmake
@@ -27,4 +27,5 @@ build_dependency_with_cmake(fmt
 
 # Signal to caller that we need to find again at the installed location
 set (fmt_REFIND TRUE)
+set (fmt_REFIND_ARGS CONFIG)
 set (fmt_VERSION ${fmt_BUILD_VERSION})

--- a/src/cmake/build_libdeflate.cmake
+++ b/src/cmake/build_libdeflate.cmake
@@ -28,10 +28,6 @@ build_dependency_with_cmake(libdeflate
         -D LIBDEFLATE_BUILD_GZIP=OFF
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
-
-set (libdeflate_ROOT ${libdeflate_LOCAL_INSTALL_DIR})
-
 # Signal to caller that we need to find again at the installed location
 set (libdeflate_REFIND TRUE)
 set (libdeflate_REFIND_ARGS CONFIG)

--- a/src/cmake/build_libjpeg-turbo.cmake
+++ b/src/cmake/build_libjpeg-turbo.cmake
@@ -23,12 +23,9 @@ build_dependency_with_cmake(libjpeg-turbo
         -D CMAKE_POSITION_INDEPENDENT_CODE=1
 
     )
-# Set some things up that we'll need for a subsequent find_package to work
-set (libjpeg-turbo_ROOT ${libjpeg-turbo_LOCAL_INSTALL_DIR})
-
-
 # Signal to caller that we need to find again at the installed location
 set (libjpeg-turbo_REFIND TRUE)
+set (libjpeg-turbo_REFIND_VERSION ${libjpeg-turbo_BUILD_VERSION})
 set (libjpeg-turbo_REFIND_ARGS CONFIG)
 
 if (libjpeg-turbo_BUILD_SHARED_LIBS)

--- a/src/cmake/build_libuhdr.cmake
+++ b/src/cmake/build_libuhdr.cmake
@@ -51,11 +51,11 @@ if (WIN32)
     unset (_header_files)
 endif ()
 
-set (libuhdr_ROOT ${libuhdr_LOCAL_INSTALL_DIR})
-
-find_package(libuhdr REQUIRED)
-
-set (libuhdr_VERSION ${libuhdr_BUILD_VERSION})
+# Signal to caller that we need to find again at the installed location.
+# libuhdr has no upstream CMake package config, only our own MODULE-mode
+# Findlibuhdr.cmake, so REFIND_ARGS must not force CONFIG.
+set (libuhdr_REFIND TRUE)
+set (libuhdr_REFIND_VERSION ${libuhdr_BUILD_VERSION})
 
 if (libuhdr_BUILD_SHARED_LIBS)
     install_local_dependency_libs (uhdr uhdr)

--- a/src/cmake/build_minizip-ng.cmake
+++ b/src/cmake/build_minizip-ng.cmake
@@ -52,8 +52,7 @@ build_dependency_with_cmake(minizip-ng
     )
 
 
-set (minizip-ng_DIR ${minizip-ng_LOCAL_INSTALL_DIR}/lib/cmake/minizip-ng)
-set (minizip-ng_VERSION ${minizip-ng_BUILD_VERSION})
+# Signal to caller that we need to find again at the installed location
 set (minizip-ng_REFIND TRUE)
 set (minizip-ng_REFIND_VERSION ${minizip-ng_BUILD_VERSION})
-set (minizip-ng_REFIND_ARGS REQUIRED)
+set (minizip-ng_REFIND_ARGS CONFIG)

--- a/src/cmake/build_openjph.cmake
+++ b/src/cmake/build_openjph.cmake
@@ -28,10 +28,6 @@ build_dependency_with_cmake(openjph
         -D CMAKE_CXX_COMPILER=${openjph_CMAKE_CXX_COMPILER}
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
-set (openjph_ROOT ${openjph_LOCAL_INSTALL_DIR})
-set (openjph_VERSION ${openjph_BUILD_VERSION})
-
 # Signal to caller that we need to find again at the installed location
 set (openjph_REFIND TRUE)
 set (openjph_REFIND_VERSION ${openjph_BUILD_VERSION})

--- a/src/cmake/build_pystring.cmake
+++ b/src/cmake/build_pystring.cmake
@@ -27,12 +27,10 @@ build_dependency_with_cmake(pystring
         -D CMAKE_INSTALL_LIBDIR=lib
 )
 
-set (pystring_VERSION ${pystring_BUILD_VERSION})
-unset (PYSTRING_LIBRARY)
-unset (PYSTRING_INCLUDE_DIR)
-
-set (pystring_REFIND FALSE)
+# Signal to caller that we need to find again at the installed location
+set (pystring_REFIND TRUE)
 set (pystring_REFIND_VERSION ${pystring_BUILD_VERSION})
+set (pystring_VERSION ${pystring_BUILD_VERSION})
 
 
 if (pystring_BUILD_SHARED_LIBS)

--- a/src/cmake/build_yaml-cpp.cmake
+++ b/src/cmake/build_yaml-cpp.cmake
@@ -30,10 +30,7 @@ build_dependency_with_cmake(yaml-cpp
         -D CMAKE_POLICY_VERSION_MINIMUM=3.5
     )
 
-set (yaml-cpp_ROOT ${yaml-cpp_LOCAL_INSTALL_DIR})
-set (yaml-cpp_DIR ${yaml-cpp_LOCAL_INSTALL_DIR})
-set (yaml-cpp_VERSION ${yaml-cpp_BUILD_VERSION})
-
+# Signal to caller that we need to find again at the installed location
 set (yaml-cpp_REFIND TRUE)
 set (yaml-cpp_REFIND_ARGS CONFIG)
 set (yaml-cpp_REFIND_VERSION ${yaml-cpp_BUILD_VERSION})

--- a/src/cmake/dependency_utils.cmake
+++ b/src/cmake/dependency_utils.cmake
@@ -470,9 +470,9 @@ macro (checked_find_package pkgname)
         if (${pkgname}_REFIND)
             message (STATUS "Refinding ${pkgname} with ${pkgname}_ROOT=${${pkgname}_ROOT}")
             # A prior find_package() may have left a bunch of cruft from a
-            # rejected an unsuitable system install that were set in its Find
-            # module.  Clear them all here so they are not polluting our
-            # attempt to use the new one we built and are about to re-find.
+            # rejected, unsuitable system install in its Find module. Clear it
+            # here so it does not pollute our attempt to use the one we just
+            # built and are about to re-find.
             foreach (_v IN ITEMS
                      ${pkgname}_LIBRARY ${pkgname}_LIBRARIES
                      ${pkgname}_LIBRARY_RELEASE ${pkgname}_LIBRARY_DEBUG

--- a/src/cmake/dependency_utils.cmake
+++ b/src/cmake/dependency_utils.cmake
@@ -469,6 +469,26 @@ macro (checked_find_package pkgname)
         #   ${pkgname}_REFIND_ARGS    : additional arguments to pass to find_package
         if (${pkgname}_REFIND)
             message (STATUS "Refinding ${pkgname} with ${pkgname}_ROOT=${${pkgname}_ROOT}")
+            # A prior find_package() may have left a bunch of cruft from a
+            # rejected an unsuitable system install that were set in its Find
+            # module.  Clear them all here so they are not polluting our
+            # attempt to use the new one we built and are about to re-find.
+            foreach (_v IN ITEMS
+                     ${pkgname}_LIBRARY ${pkgname}_LIBRARIES
+                     ${pkgname}_LIBRARY_RELEASE ${pkgname}_LIBRARY_DEBUG
+                     ${pkgname}_INCLUDE_DIR ${pkgname}_INCLUDE_DIRS
+                     ${pkgname_upper}_LIBRARY ${pkgname_upper}_LIBRARIES
+                     ${pkgname_upper}_LIBRARY_RELEASE ${pkgname_upper}_LIBRARY_DEBUG
+                     ${pkgname_upper}_INCLUDE_DIR ${pkgname_upper}_INCLUDE_DIRS)
+                unset (${_v})
+                unset (${_v} CACHE)
+            endforeach ()
+            # Same for a stale <Pkg>_DIR (the CONFIG-mode search hint).
+            # CACHE-only: some build scripts set it as a plain variable on
+            # purpose as a hint for this find_package() call.
+            foreach (_v IN ITEMS ${pkgname}_DIR ${pkgname_upper}_DIR)
+                unset (${_v} CACHE)
+            endforeach ()
             find_package (${pkgname} ${${pkgname}_REFIND_VERSION} REQUIRED ${_pkg_UNPARSED_ARGUMENTS} ${${pkgname}_REFIND_ARGS})
             unset (${pkgname}_REFIND)
         endif()


### PR DESCRIPTION
We've had a longstanding issue where the autobuild works great when a dependency is not found on the system, but not when the dependency is already on the system, but not an adequately new version to satisfy our requirements. We have been plagued with the re-find sometimes picking up components from the wrong, old version.

The first find_package() call is rejected after finding the too-old dependency. But it had already cached `<pkg>_INCLUDE_DIR` and similar items. find_path() and find_library() skip searching again once those cache variables are set. So the second find_package call silently reuses parts of the rejected library.  We'd accumulated some cruft in the build_DEP.cmake files to try to work around this, but not in a uniform way, and still with some problems.

The fix is in dependency_utils.cmake. It lives in the shared `<pkg>_REFIND` logic. Right before the refind's find_package() call, it now clears those stale cache entries. This clears both the MODULE-mode variables (`<PKG>_LIBRARY`, `<PKG>_INCLUDE_DIR`, etc.) and the CONFIG-mode `<Pkg>_DIR`.

After fixing this for TIFF initially, an audit of the other `build_*.cmake` scripts found the same raw find_package() pattern in two more places: build_GIF.cmake and build_libuhdr.cmake. Converted both to REFIND too.

While in there, unified all 21 build_*.cmake scripts on one minimal REFIND footer. This removed clutter that had built up per script over time. Some scripts had a Pkg_ROOT assignment that just duplicated what build_dependency_with_cmake() already sets after install. Some had a hand-forced Pkg_VERSION assignment that papered over whatever the refind actually found. OpenColorIO and PNG each had a manual unset() block too. It duplicated what the shared REFIND cache-clearing now handles centrally.

Also fixed pystring's REFIND flag, which was FALSE. So pystring never re-found itself after a local build. OpenColorIO's script had grown its own workaround for this: a manual find_package(pystring REQUIRED) call. That workaround is no longer needed.

Removed expat's Windows-only block: a find_package() call plus set_cache(expat_LIBRARY ...). That variable is never read anywhere else in the tree. expat now forces CONFIG mode on every platform. It no longer relies on case-insensitive filesystems to match CMake's stock FindEXPAT.cmake by accident.

Assisted-by: Claude Code / claude-sonnet-5
