### PR TITLE
feat(simd): x86_64 baseline of SSE4.2, architecture-aware USE_SIMD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,8 @@ jobs:
             build_local_deps: 'TIFF'
           - desc: oldest clang11/C++17 py3.9 exr3.1 ocio2.3
             # Oldest clang and versions of the dependencies that we support.
+            # Deliberately sets no `simd`, so that this job exercises the
+            # default SIMD level for x86_64 (sse4.2). Please leave it unset.
             nametag: linux-oldest-clang-ubuntu
             runner: ubuntu-22.04
             cxx_std: 17

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -190,6 +190,37 @@ system. This will obviously disable any functionality that requires the
 dependency. This works both as a CMake variable and
 also as an environment variable.
 
+**Selecting the SIMD instruction set**
+
+`USE_SIMD=...` : A comma-separated list of the machine / instruction set
+capabilities to generate code for, for example `USE_SIMD=avx2,f16c`. Like the
+options above, it works as a CMake variable, an environment variable, or a
+setting on the Make wrapper (`make USE_SIMD=avx2,f16c`).
+
+The recognized x86 tokens are `sse2`, `sse3`, `ssse3`, `sse4.1`, `sse4.2`,
+`avx`, `avx2`, `avx512f` (and the other `avx512*` subsets), `f16c`, `fma`,
+`aes`, and `popcnt`. On ARM you may pass `neon`, an architecture name such as
+`armv8.2-a+fp16`, or a CPU name such as `apple-m1`. Tokens naming an ISA that
+belongs to a different CPU family than the one being built for are ignored,
+so passing `avx2,f16c` on an ARM machine is harmless rather than fatal.
+
+The default depends on the target architecture:
+
+* x86_64 : `sse4.2`. Every 64 bit Intel/AMD CPU has supported SSE4.2 since
+  2008, so OIIO treats it as the floor. (Note that without this, gcc and
+  clang would generate only SSE2 code.)
+* arm64 / aarch64 : empty. NEON is architecturally mandatory on ARMv8-A, so
+  the compiler already enables it and there is nothing to request.
+
+`USE_SIMD=0` disables SIMD entirely, on any architecture.
+
+Beware that the resulting binaries will not run on a CPU that lacks the
+instructions you asked for. Also note that this only controls how OIIO itself
+is compiled. Because `simd.h` is a public header and gcc/clang only make the
+SSE4/AVX intrinsics available when the corresponding `-m` flag is present,
+downstream code that includes `simd.h` gets the SSE4 code paths only if it is
+compiled with `-msse4.2` (or better) itself.
+
 
 
 Building OpenImageIO on Linux or OS X
@@ -359,7 +390,8 @@ On the other hand, if you would prefer to open the generated Visual Studio
 solution, the "cmake configure" will have produced
 `{OIIO_ROOT}/build/OpenImageIO.sln` that can be opened in Visual Studio IDE.
 Note that the solution will be only for the Intel x64 architecture only; and
-will only target "min-spec" (SSE2) SIMD instruction set.
+will target the default SSE4.2 SIMD instruction set (see `USE_SIMD` above if
+you want something else).
 
 Optional packages that OIIO can use (e.g. libpng, Qt) can be build and pointed to OIIO build process in a similar way.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,9 +206,10 @@ so passing `avx2,f16c` on an ARM machine is harmless rather than fatal.
 
 The default depends on the target architecture:
 
-* x86_64 : `sse4.2`. Every 64 bit Intel/AMD CPU has supported SSE4.2 since
-  2008, so OIIO treats it as the floor. (Note that without this, gcc and
-  clang would generate only SSE2 code.)
+* x86_64 : `sse4.2`. OIIO defaults to SSE4.2 on x86_64 to enable newer fast
+  paths; if you need to run on older x86_64 CPUs, set `USE_SIMD` to a lower
+  level (e.g. `sse2`) or `0`. (Without this, gcc and clang would generate only
+  SSE2 code.)
 * arm64 / aarch64 : empty. NEON is architecturally mandatory on ARMv8-A, so
   the compiler already enables it and there is nothing to request.
 

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -317,11 +317,81 @@ endif ()
 # SIMD and machine architecture options.
 #
 # The USE_SIMD option may be set to a comma-separated list of machine /
-# instruction set options, such as "avx3,f16c". The list will be parsed and
+# instruction set options, such as "avx2,f16c". The list will be parsed and
 # the proper compiler directives added to generate code for those ISA
 # capabilities.
 #
-set_cache (USE_SIMD "" "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512f, f16c, aes)")
+# The default depends on the architecture we are building for:
+#   * x86_64 : "sse4.2". Every 64 bit Intel/AMD CPU has supported SSE4.2
+#     since 2008, so there is no point in targeting a lower baseline. Without
+#     this, gcc and clang would generate only SSE2 code.
+#   * arm64 / aarch64 : "" (empty). NEON is architecturally mandatory on
+#     ARMv8-A, so the compiler enables it without any help from us.
+#   * anything else : "" (empty), i.e. whatever the compiler defaults to.
+# Setting USE_SIMD=0 disables SIMD entirely, regardless of architecture.
+#
+# Feature tokens naming an ISA belonging to some other CPU family than the
+# one we are building for are ignored rather than passed to the compiler, so
+# that a caller (or a CI matrix) may pass "avx2,f16c" without breaking an ARM
+# build.
+
+# Which CPU family(s) are we targeting? On Apple, CMAKE_OSX_ARCHITECTURES,
+# when set, overrides CMAKE_SYSTEM_PROCESSOR and may name more than one
+# architecture (a universal binary).
+if (CMAKE_OSX_ARCHITECTURES)
+    set (_simd_target_archs "${CMAKE_OSX_ARCHITECTURES}")
+else ()
+    set (_simd_target_archs "${CMAKE_SYSTEM_PROCESSOR}")
+endif ()
+set (SIMD_TARGET_X86_64 OFF)
+set (SIMD_TARGET_X86_32 OFF)
+set (SIMD_TARGET_ARM64 OFF)
+foreach (_arch ${_simd_target_archs})
+    string (TOLOWER "${_arch}" _arch)
+    if (_arch MATCHES "^(x86_64|amd64|x64)$")
+        set (SIMD_TARGET_X86_64 ON)
+    elseif (_arch MATCHES "^(i.86|x86)$")
+        set (SIMD_TARGET_X86_32 ON)
+    elseif (_arch MATCHES "^(arm64.*|aarch64)$")
+        set (SIMD_TARGET_ARM64 ON)
+    endif ()
+endforeach ()
+message (VERBOSE "SIMD target archs = ${_simd_target_archs}"
+                 " (x86_64=${SIMD_TARGET_X86_64} x86_32=${SIMD_TARGET_X86_32}"
+                 " arm64=${SIMD_TARGET_ARM64})")
+
+if (SIMD_TARGET_X86_64)
+    set (_simd_default "sse4.2")
+else ()
+    set (_simd_default "")
+endif ()
+set_cache (USE_SIMD "${_simd_default}"
+           "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512f, f16c, fma, aes, neon)")
+unset (_simd_default)
+
+# Tokens we recognize as naming an x86 or an ARM ISA feature. Anything not on
+# either list is passed through to the compiler as before.
+set (_simd_x86_features sse2 sse3 ssse3 sse4.1 sse4.2 avx avx2
+                        avx512f avx512dq avx512bw avx512vl avx512cd avx512ifma
+                        f16c fma aes popcnt)
+
+# For a universal binary we must attach the per-family flags to just the one
+# slice they apply to. Apple's clang has -Xarch_<arch> for exactly this.
+set (_simd_x86_xarch "")
+set (_simd_arm_xarch "")
+set (_simd_skip_x86 OFF)
+if (SIMD_TARGET_X86_64 AND SIMD_TARGET_ARM64)
+    if (APPLE)
+        set (_simd_x86_xarch "-Xarch_x86_64")
+        set (_simd_arm_xarch "-Xarch_arm64")
+    else ()
+        # No way to qualify a flag per-slice, so a global -msse4.2 would be
+        # handed to the ARM compilation too. Better to add nothing.
+        set (_simd_skip_x86 ON)
+        message (STATUS "Multi-architecture build: omitting x86 SIMD flags")
+    endif ()
+endif ()
+
 set (SIMD_COMPILE_FLAGS "")
 message (STATUS "Compiling with SIMD level ${USE_SIMD}")
 if (NOT USE_SIMD STREQUAL "")
@@ -332,36 +402,67 @@ if (NOT USE_SIMD STREQUAL "")
         string (REPLACE "," ";" SIMD_FEATURE_LIST "${USE_SIMD}")
         foreach (feature ${SIMD_FEATURE_LIST})
             message (VERBOSE "SIMD feature: ${feature}")
-            if (MSVC OR CMAKE_COMPILER_IS_INTEL)
-                if (feature STREQUAL "sse2")
-                    list (APPEND SIMD_COMPILE_FLAGS "/D__SSE2__")
+            if (feature IN_LIST _simd_x86_features)
+                if (NOT (SIMD_TARGET_X86_64 OR SIMD_TARGET_X86_32))
+                    message (STATUS "  Ignoring SIMD feature '${feature}' (not an x86 target)")
+                    continue ()
                 endif ()
-                if (feature STREQUAL "sse4.1")
-                    list (APPEND SIMD_COMPILE_FLAGS "/D__SSE2__" "/D__SSE4_1__")
+                if (_simd_skip_x86)
+                    continue ()
                 endif ()
-                if (feature STREQUAL "sse4.2")
-                    list (APPEND SIMD_COMPILE_FLAGS "/D__SSE2__" "/D__SSE4_2__")
+                if (MSVC OR CMAKE_COMPILER_IS_INTEL)
+                    # The SSE levels are handled unconditionally below. Here we
+                    # only need to track the highest /arch: level requested.
+                    if (feature STREQUAL "avx" AND _highest_msvc_arch LESS 1)
+                        set(_highest_msvc_arch 1)
+                    endif ()
+                    if (feature STREQUAL "avx2" AND _highest_msvc_arch LESS 2)
+                        set(_highest_msvc_arch 2)
+                    endif ()
+                    if (feature STREQUAL "avx512f" AND _highest_msvc_arch LESS 3)
+                        set(_highest_msvc_arch 3)
+                    endif ()
+                else ()
+                    list (APPEND SIMD_COMPILE_FLAGS ${_simd_x86_xarch} "-m${feature}")
                 endif ()
-                if (feature STREQUAL "avx" AND _highest_msvc_arch LESS 1)
-                    set(_highest_msvc_arch 1)
+                if (feature STREQUAL "fma" AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
+                    # If fma is requested, for numerical accuracy sake, turn it
+                    # off by default except when we explicitly use madd. At some
+                    # future time, we should look at this again carefully and
+                    # see if we want to use it more widely by ffp-contract=fast.
+                    add_compile_options ("-ffp-contract=off")
                 endif ()
-                if (feature STREQUAL "avx2" AND _highest_msvc_arch LESS 2)
-                    set(_highest_msvc_arch 2)
+            elseif (feature STREQUAL "neon" OR feature MATCHES "^(armv|apple-|m(arch|cpu|tune)=)")
+                if (NOT SIMD_TARGET_ARM64)
+                    message (STATUS "  Ignoring SIMD feature '${feature}' (not an ARM target)")
+                    continue ()
                 endif ()
-                if (feature STREQUAL "avx512f" AND _highest_msvc_arch LESS 3)
-                    set(_highest_msvc_arch 3)
+                if (feature STREQUAL "neon")
+                    # NEON is mandatory on ARMv8-A; nothing to ask the
+                    # compiler for. Accepted so that it can be named
+                    # explicitly for symmetry with the x86 tokens.
+                elseif (feature MATCHES "^armv")
+                    list (APPEND SIMD_COMPILE_FLAGS ${_simd_arm_xarch} "-march=${feature}")
+                elseif (feature MATCHES "^apple-")
+                    list (APPEND SIMD_COMPILE_FLAGS ${_simd_arm_xarch} "-mcpu=${feature}")
+                else () # already in march=/mcpu=/mtune= form
+                    list (APPEND SIMD_COMPILE_FLAGS ${_simd_arm_xarch} "-${feature}")
                 endif ()
             else ()
-                list (APPEND SIMD_COMPILE_FLAGS "-m${feature}")
-            endif ()
-            if (feature STREQUAL "fma" AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
-                # If fma is requested, for numerical accuracy sake, turn it
-                # off by default except when we explicitly use madd. At some
-                # future time, we should look at this again carefully and
-                # see if we want to use it more widely by ffp-contract=fast.
-                add_compile_options ("-ffp-contract=off")
+                # Unrecognized token: pass it through the way we always have.
+                if (NOT (MSVC OR CMAKE_COMPILER_IS_INTEL))
+                    list (APPEND SIMD_COMPILE_FLAGS "-m${feature}")
+                endif ()
             endif ()
         endforeach()
+
+        if ((MSVC OR CMAKE_COMPILER_IS_INTEL) AND SIMD_TARGET_X86_64)
+            # MSVC makes every intrinsic through AVX2 available regardless of
+            # the /arch: setting, and it never predefines the __SSE*__ macros
+            # that simd.h keys off. Since all x86-64 hardware is SSE4.2 or
+            # better, just say so.
+            list (APPEND SIMD_COMPILE_FLAGS "/D__SSE2__" "/D__SSE4_1__" "/D__SSE4_2__")
+        endif ()
 
         # Only add a single /arch flag representing the highest level of support.
         if (MSVC OR CMAKE_COMPILER_IS_INTEL)
@@ -377,8 +478,14 @@ if (NOT USE_SIMD STREQUAL "")
         endif ()
         unset(_highest_msvc_arch)
     endif ()
+    message (VERBOSE "SIMD compile flags: ${SIMD_COMPILE_FLAGS}")
     add_compile_options (${SIMD_COMPILE_FLAGS})
 endif ()
+unset (_simd_target_archs)
+unset (_simd_x86_features)
+unset (_simd_x86_xarch)
+unset (_simd_arm_xarch)
+unset (_simd_skip_x86)
 
 
 ###########################################################################

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -322,8 +322,9 @@ endif ()
 # capabilities.
 #
 # The default depends on the architecture we are building for:
-#   * x86_64 : "sse4.2". Every 64 bit Intel/AMD CPU has supported SSE4.2
-#     since 2008, so there is no point in targeting a lower baseline. Without
+#   * x86_64 : "sse4.2". OIIO defaults to SSE4.2 for x86_64 builds to enable
+#     newer fast paths; if you need compatibility with older x86_64 CPUs, set
+#     USE_SIMD to a lower level (e.g. sse2) or to 0 to disable SIMD. Without
 #     this, gcc and clang would generate only SSE2 code.
 #   * arm64 / aarch64 : "" (empty). NEON is architecturally mandatory on
 #     ARMv8-A, so the compiler enables it without any help from us.

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -76,6 +76,17 @@
 // OIIO_SIMD_HAS_MATRIX4 : nonzero if matrix44 is defined
 // OIIO_SIMD_HAS_SIMD8 : nonzero if vfloat8, vint8, vbool8 are defined
 // OIIO_SIMD_HAS_SIMD16 : nonzero if vfloat16, vint16, vbool16 are defined
+//
+// A note on baselines: OIIO considers SSE4.2 to be the floor for x86_64 and
+// NEON to be the floor for aarch64. NEON takes care of itself, being
+// architecturally mandatory on ARMv8-A. For x86_64, however, gcc and clang
+// only make the SSE3/SSSE3/SSE4 intrinsics available when told to with -m
+// flags, so this header cannot simply assume them -- it must keep honoring
+// __SSE4_1__ and friends. OIIO's own build passes -msse4.2 (see USE_SIMD in
+// src/cmake/compiler.cmake); a downstream translation unit that includes this
+// header will only get the SSE4 code paths if it too is compiled with
+// -msse4.2 or better. MSVC is the exception: it exposes all intrinsics
+// regardless of /arch:, so we can and do assume SSE4 there unconditionally.
 
 #ifdef OIIO_NO_SIMD /* Request to disable all SIMD */
 #  define OIIO_NO_SSE 1
@@ -141,6 +152,15 @@
        * comparisons and CRCs, which don't currently seem relevant to OIIO,
        * so for simplicity, we sweep this difference under the rug.
        */
+#  elif defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_LLVM_COMPILER) \
+        && (defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC)
+#    define OIIO_SIMD_SSE 4
+     /* MSVC never predefines the __SSE*__ macros, but it makes every
+      * intrinsic through AVX2 available regardless of the /arch: setting,
+      * and all x86-64 hardware is SSE4.2 or better. So just use SSE4.
+      * (Note that clang-cl and icx define _MSC_VER but do gate intrinsics
+      * on -m flags, so they must take the branch above instead.)
+      */
 #  elif defined(__SSSE3__)
 #    define OIIO_SIMD_SSE 3
      /* N.B. We only use OIIO_SIMD_SSE = 3 when fully at SSSE3. In theory,

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -156,8 +156,9 @@
         && (defined(_M_X64) || defined(_M_AMD64)) && !defined(_M_ARM64EC)
 #    define OIIO_SIMD_SSE 4
      /* MSVC never predefines the __SSE*__ macros, but it makes every
-      * intrinsic through AVX2 available regardless of the /arch: setting,
-      * and all x86-64 hardware is SSE4.2 or better. So just use SSE4.
+      * intrinsic through AVX2 available regardless of the /arch: setting.
+      * For OIIO we treat SSE4.x as the baseline for x86-64 builds, so enable
+      * the SSE4 code paths here unconditionally.
       * (Note that clang-cl and icx define _MSC_VER but do gate intrinsics
       * on -m flags, so they must take the branch above instead.)
       */


### PR DESCRIPTION
USE_SIMD defaulted to empty, so we inherited whatever the compiler chose: SSE2 for gcc/clang on Linux, penryn (SSE4.1, no 4.2) for Apple clang, and plain SSE2 for MSVC, which never predefines the __SSE*__ macros that simd.h keys off and which no Windows CI job overrides. Every x86-64 CPU has had SSE4.2 since 2008, so we were leaving the 32 OIIO_SIMD_SSE >= 4 fast paths on the floor for no reason.

Default USE_SIMD to sse4.2 when targeting x86_64, and leave it empty elsewhere -- NEON is architecturally mandatory on ARMv8-A, so aarch64 needs no help. USE_SIMD=0 still disables everything.

The block also had no notion of the target architecture at all: -m${feature} was a blind passthrough, so USE_SIMD=avx2,f16c on ARM emitted -mavx2 and failed to compile, which is why every ARM CI job leaves USE_SIMD unset. Now tokens are classified, tokens for the wrong CPU family are skipped with a status message, ARM tokens (neon, armv8.2-a+fp16, apple-m1, mcpu=...) are understood, and universal Apple builds qualify the x86 flags with -Xarch_x86_64 rather than handing -msse4.2 to the arm64 slice.

For MSVC on x64, emit the SSE4 defines unconditionally rather than only when the user names those tokens, and let simd.h reach the same conclusion on its own so that downstream users of the installed header benefit too. This is safe because MSVC exposes every intrinsic through AVX2 regardless of /arch:. gcc and clang do gate intrinsics on -m flags, so the header cannot do the same for them; that limitation is now documented in simd.h and INSTALL.md.

Assisted-by: Claude Code / claude-opus-5
