### PR TITLE
deps: Raise libtiff minimum from 4.0 (late 2011) to 4.1 (late 2019)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,8 +490,8 @@ jobs:
                              PIP_INSTALLS=numpy
                              Robinmap_BUILD_VERSION=1.3.0
                              Robinmap_GIT_COMMIT=188c45569cc2a5dd768077c193830b51d33a5020
-                             TIFF_BUILD_VERSION=4.0.0
-                             TIFF_GIT_COMMIT=f7b79dc7dc86ccbaabe9882e2b9ffa5ee8dac917
+                             TIFF_BUILD_VERSION=4.1.0
+                             TIFF_GIT_COMMIT=e0d707dc1524d8c0e20f03396f234e0f1b07b3f4
                              LIBRAW_VERSION=0.21.0
                             #  OpenJPEG_BUILD_VERSION=2.2.0
                             #  OpenJPEG_GIT_COMMIT=3d7cde5fc9fbc5618d02160900d32e02ed12a00e
@@ -521,8 +521,8 @@ jobs:
                             OIIO_CXX=clang++
                             Robinmap_BUILD_VERSION=1.3.0
                             Robinmap_GIT_COMMIT=188c45569cc2a5dd768077c193830b51d33a5020
-                            TIFF_BUILD_VERSION=4.0.0
-                            TIFF_GIT_COMMIT=f7b79dc7dc86ccbaabe9882e2b9ffa5ee8dac917
+                            TIFF_BUILD_VERSION=4.1.0
+                            TIFF_GIT_COMMIT=e0d707dc1524d8c0e20f03396f234e0f1b07b3f4
                             openjph_CMAKE_C_COMPILER=gcc
                             openjph_CMAKE_CXX_COMPILER=g++
                             LIBRAW_VERSION=0.21.0
@@ -563,8 +563,8 @@ jobs:
                              PIP_INSTALLS=numpy
                              Robinmap_BUILD_VERSION=1.3.0
                              Robinmap_GIT_COMMIT=188c45569cc2a5dd768077c193830b51d33a5020
-                             TIFF_BUILD_VERSION=4.0.0
-                             TIFF_GIT_COMMIT=f7b79dc7dc86ccbaabe9882e2b9ffa5ee8dac917
+                             TIFF_BUILD_VERSION=4.1.0
+                             TIFF_GIT_COMMIT=e0d707dc1524d8c0e20f03396f234e0f1b07b3f4
             required_deps: none
             build_local_deps: 'TIFF'
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * **CMake >= 3.23.0** (tested through 4.4)
  * Imath >= 3.1 (tested through 3.2 and main)
  * OpenEXR >= 3.1 (tested through 3.4 and main)
- * libTIFF >= 4.0 (tested through 4.7 and master)
+ * **libTIFF >= 4.1** (tested through 4.7 and master)
  * OpenColorIO >= 2.3 (tested through 2.5 and main)
  * libjpeg >= 8 (tested through jpeg9e), or libjpeg-turbo >= 2.1 (tested
    through 3.2)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -103,7 +103,7 @@ if (NOT TARGET Deflate::Deflate)
 endif ()
 
 checked_find_package (TIFF REQUIRED
-                      VERSION_MIN 4.0
+                      VERSION_MIN 4.1
                       RECOMMEND_MIN 4.5
                       RECOMMEND_MIN_REASON "4.2+ for GPS, 4.5+ various security fixes")
 alias_library_if_not_exists (TIFF::TIFF TIFF::tiff)

--- a/src/tiff.imageio/CMakeLists.txt
+++ b/src/tiff.imageio/CMakeLists.txt
@@ -7,6 +7,7 @@ add_oiio_plugin (tiffinput.cpp tiffoutput.cpp
                                 ZLIB::ZLIB
                                 $<TARGET_NAME_IF_EXISTS:libjpeg-turbo::jpeg>
                                 $<TARGET_NAME_IF_EXISTS:JPEG::JPEG>
+                                $<TARGET_NAME_IF_EXISTS:Deflate::Deflate>
                 )
 
 # TODO: It's not clear that we need to explicitly list the ZLIB and JPEG

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -52,12 +52,8 @@
 #    define OIIO_TIFFLIB_VERSION 40200
 #elif TIFFLIB_VERSION >= 20191103
 #    define OIIO_TIFFLIB_VERSION 40100
-#elif TIFFLIB_VERSION >= 20120922
-#    define OIIO_TIFFLIB_VERSION 40003
-#elif TIFFLIB_VERSION >= 20111221
-#    define OIIO_TIFFLIB_VERSION 40000
 #else
-#    error "libtiff 4.0.0 or later is required"
+#    error "libtiff 4.1.0 or later is required"
 #endif
 // clang-format on
 
@@ -819,12 +815,11 @@ static std::pair<int, const char*>  tiff_input_compressions[] = {
     { COMPRESSION_SGILOG,        "sgilog" },      // SGI log luminance RLE
     { COMPRESSION_SGILOG24,      "sgilog24" },    // SGI log 24bit
     { COMPRESSION_JP2000,        "jp2000" },      // Leadtools JPEG2000
-#if defined(TIFF_VERSION_BIG) && OIIO_TIFFLIB_VERSION >= 40003
-    // Others supported in more recent TIFF library versions.
     { COMPRESSION_T85,           "T85" },         // TIFF/FX T.85 JBIG
     { COMPRESSION_T43,           "T43" },         // TIFF/FX T.43 color layered JBIG
     { COMPRESSION_LZMA,          "lzma" },        // LZMA2
-#endif
+    { COMPRESSION_ZSTD,          "zstd" },        // zstd
+    { COMPRESSION_WEBP,          "webp" },        // webp
 };
 
 // clang-format on

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <memory>
 
+#include <tiffconf.h>
 #include <tiffio.h>
 #include <zlib.h>
 
@@ -41,12 +42,8 @@
 #    define OIIO_TIFFLIB_VERSION 40200
 #elif TIFFLIB_VERSION >= 20191103
 #    define OIIO_TIFFLIB_VERSION 40100
-#elif TIFFLIB_VERSION >= 20120922
-#    define OIIO_TIFFLIB_VERSION 40003
-#elif TIFFLIB_VERSION >= 20111221
-#    define OIIO_TIFFLIB_VERSION 40000
 #else
-#    error "libtiff 4.0.0 or later is required"
+#    error "libtiff 4.1.0 or later is required"
 #endif
 // clang-format on
 
@@ -317,24 +314,23 @@ static std::pair<int, const char*> tiff_output_compressions[] = {
     //  { COMPRESSION_NEXT,          "next" },        // NeXT 2-bit RLE
     //  { COMPRESSION_CCITTRLEW,     "ccittrle2" },   // #1 w/ word alignment
     { COMPRESSION_PACKBITS, "packbits" },  // Macintosh RLE
-//  { COMPRESSION_THUNDERSCAN,   "thunderscan" }, // ThundeScan RLE
-//  { COMPRESSION_IT8CTPAD,      "IT8CTPAD" },    // IT8 CT w/ patting
-//  { COMPRESSION_IT8LW,         "IT8LW" },       // IT8 linework RLE
-//  { COMPRESSION_IT8MP,         "IT8MP" },       // IT8 monochrome picture
-//  { COMPRESSION_IT8BL,         "IT8BL" },       // IT8 binary line art
-//  { COMPRESSION_PIXARFILM,     "pixarfilm" },   // Pixar 10 bit LZW
-//  { COMPRESSION_PIXARLOG,      "pixarlog" },    // Pixar 11 bit ZIP
-//  { COMPRESSION_DCS,           "dcs" },         // Kodak DCS encoding
-//  { COMPRESSION_JBIG,          "isojbig" },     // ISO JBIG
-//  { COMPRESSION_SGILOG,        "sgilog" },      // SGI log luminance RLE
-//  { COMPRESSION_SGILOG24,      "sgilog24" },    // SGI log 24bit
-//  { COMPRESSION_JP2000,        "jp2000" },      // Leadtools JPEG2000
-#if defined(TIFF_VERSION_BIG) && OIIO_TIFFLIB_VERSION >= 40003
-// Others supported in more recent TIFF library versions.
-//  { COMPRESSION_T85,           "T85" },         // TIFF/FX T.85 JBIG
-//  { COMPRESSION_T43,           "T43" },         // TIFF/FX T.43 color layered JBIG
-//  { COMPRESSION_LZMA,          "lzma" },        // LZMA2
-#endif
+    //  { COMPRESSION_THUNDERSCAN,   "thunderscan" }, // ThundeScan RLE
+    //  { COMPRESSION_IT8CTPAD,      "IT8CTPAD" },    // IT8 CT w/ patting
+    //  { COMPRESSION_IT8LW,         "IT8LW" },       // IT8 linework RLE
+    //  { COMPRESSION_IT8MP,         "IT8MP" },       // IT8 monochrome picture
+    //  { COMPRESSION_IT8BL,         "IT8BL" },       // IT8 binary line art
+    //  { COMPRESSION_PIXARFILM,     "pixarfilm" },   // Pixar 10 bit LZW
+    //  { COMPRESSION_PIXARLOG,      "pixarlog" },    // Pixar 11 bit ZIP
+    //  { COMPRESSION_DCS,           "dcs" },         // Kodak DCS encoding
+    //  { COMPRESSION_JBIG,          "isojbig" },     // ISO JBIG
+    //  { COMPRESSION_SGILOG,        "sgilog" },      // SGI log luminance RLE
+    //  { COMPRESSION_SGILOG24,      "sgilog24" },    // SGI log 24bit
+    //  { COMPRESSION_JP2000,        "jp2000" },      // Leadtools JPEG2000
+    //  { COMPRESSION_T85,           "T85" },         // TIFF/FX T.85 JBIG
+    //  { COMPRESSION_T43,           "T43" },         // TIFF/FX T.43 color layered JBIG
+    //  { COMPRESSION_LZMA,          "lzma" },        // LZMA2
+    //  { COMPRESSION_ZSTD,          "zstd" },        // zstd
+    //  { COMPRESSION_WEBP,          "webp" },        // webp
 };
 
 static int
@@ -1088,7 +1084,6 @@ TIFFOutput::put_parameter(const ParamValue& param)
 bool
 TIFFOutput::write_exif_data()
 {
-#if defined(TIFF_VERSION_BIG) && OIIO_TIFFLIB_VERSION >= 40003
     // Older versions of libtiff do not support writing Exif directories
 
     if (m_spec.get_int_attribute("tiff:write_exif", 1) == 0) {
@@ -1112,25 +1107,25 @@ TIFFOutput::write_exif_data()
                 continue;  // libtiff doesn't understand these
             any_exif = true;
         }
-#    if OIIO_TIFFLIB_VERSION >= 40200
+#if OIIO_TIFFLIB_VERSION >= 40200
         if (!any_gps && gps_tag_lookup(p.name(), tag, tifftype, count)
             && tifftype != TIFF_NOTYPE) {
             any_gps = true;
         }
-#    endif
+#endif
         if (any_exif && any_gps)
             break;  // If we've found both kinds, we're done
     }
     if (!any_exif && !any_gps)
         return true;
 
-#    if ENABLE_JPEG_COMPRESSION
+#if ENABLE_JPEG_COMPRESSION
     if (m_compression == COMPRESSION_JPEG) {
         // For reasons we don't understand, JPEG-compressed TIFF seems
         // to not output properly without a directory checkpoint here.
         TIFFCheckpointDirectory(m_tif);
     }
-#    endif
+#endif
 
     // First, finish writing the current directory
     if (!TIFFWriteDirectory(m_tif)) {
@@ -1147,7 +1142,7 @@ TIFFOutput::write_exif_data()
         }
         exif_dir_offset = write_extra_tag_directory("Exif");
     }
-#    if OIIO_TIFFLIB_VERSION >= 40200
+#if OIIO_TIFFLIB_VERSION >= 40200
     uint64_t gps_dir_offset = 0;
     if (any_gps) {
         // Create a GPS directory
@@ -1157,17 +1152,16 @@ TIFFOutput::write_exif_data()
         }
         gps_dir_offset = write_extra_tag_directory("GPS");
     }
-#    endif
+#endif
 
     // Go back to the first directory, and add the EXIFIFD pointer.
     // std::cout << "diffdir = " << tiffdir << "\n";
     TIFFSetDirectory(m_tif, 0);
     if (exif_dir_offset)
         TIFFSetField(m_tif, TIFFTAG_EXIFIFD, exif_dir_offset);
-#    if OIIO_TIFFLIB_VERSION >= 40200
+#if OIIO_TIFFLIB_VERSION >= 40200
     if (gps_dir_offset)
         TIFFSetField(m_tif, TIFFTAG_GPSIFD, gps_dir_offset);
-#    endif
 #endif
 
     return true;  // all is ok


### PR DESCRIPTION
Still well over our "3-5 years back" guidelines for supporting dependencies.
