### PR TITLE
style: Raise our clang-format standard to clang-format 22

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ Language:        Cpp
 BasedOnStyle:  WebKit
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: true
 AlignConsecutiveAssignments: true
 #AlignConsecutiveAssignments: Consecutive
 #AlignConsecutiveBitFields: Consecutive
@@ -14,14 +14,14 @@ AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: InlineOnly
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: TopLevel
+AllowShortNamespacesOnASingleLine: false
+BreakAfterReturnType: TopLevelDefinitions
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
@@ -83,7 +83,10 @@ IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 3
@@ -92,7 +95,7 @@ ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 4
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 40
+PenaltyBreakAssignment: 50
 PenaltyBreakBeforeFirstCallParameter: 100
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
@@ -102,6 +105,8 @@ PenaltyExcessCharacter: 75
 PenaltyReturnTypeOnItsOwnLine: 50
 PointerAlignment: Left
 ReflowComments:  false
+RemoveEmptyLinesInUnwrappedLines: true
+SkipMacroDefinitionBody: true
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
@@ -113,7 +118,7 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
+SpaceInEmptyBraces: Never
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles:  false
@@ -126,6 +131,8 @@ StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
+#TemplateNames:
+#TypeNames: 
 UseTab:          Never
 #...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
           # the console output).
           - desc: "clang-format"
             nametag: clang-format
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             cxx_std: 17
             extra_artifacts: "src/*.*"
             python_ver: "3.10"
@@ -318,8 +318,8 @@ jobs:
             skip_tests: 1
             setenvs: export SKIP_SYSTEM_DEPS_INSTALL=1 SKIP_APT_GET_UPDATE=1
                             INSTALL_OPENCV=0 QT_VERSION=0 USE_LIBHEIF=0
-                            EXTRA_DEP_PACKAGES="clang-format-17"
-                            CLANG_FORMAT_EXE=clang-format-17
+                            CLANG_FORMAT_EXE=clang-format-22
+                            EXTRA_DEP_PACKAGES="clang-format-22"
 
           - desc: latest releases gcc15 C++23 py3.12 avx2 exr3.4 ocio2.4
             nametag: linux-latest-releases

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -613,7 +613,7 @@ endif ()
 # Note: skip all of this checking, setup, and cmake-format target if this
 # is being built as a subproject.
 if (PROJECT_IS_TOP_LEVEL)
-    set (CLANG_FORMAT_EXE_HINT "" CACHE PATH "clang-format executable's directory (will search if not specified")
+    set_cache (CLANG_FORMAT_EXE_HINT "" "clang-format executable's directory (will search if not specified")
     set (CLANG_FORMAT_INCLUDES "src/*.h" "src/*.cpp" "testsuite/*.cpp" "testsuite/*.h"
         CACHE STRING "Glob patterns to include for clang-format")
     set (CLANG_FORMAT_EXCLUDES "*pugixml*" "*SHA1*" "*/farmhash.cpp"


### PR DESCRIPTION
Since we are very close to branching for 3.2, it's finally time to bump our clang-format standard from 17 to 22. We do this only every couple years or so (to avoid constant churn with every new clang release), and time it for right before a release, so we are simultaneously doing it in main and in what is imminently the next release family. (Diverging at any other time would make backports of other PRs through the year unnecessarily complicated with divergence.)

This PR is EXPECTED to fail the clang-format test, because we're bumping the clang-format version without fixing anything that subsequently needs reformatting in the code. This is ON PURPOSE. You can see from the failure logs the full accounting of what will change in the code. It's a lot (that's why we only do this every 4 or 5 LLVM versions / every few years), but in looking it over, I believe most changes are neutral or clear improvements, very few truly minor things that I preferred the old way. I did tweak some of the rules a bit to make things a little more pleasing to me, and for a couple headers that were previously excluded from clang-format, I bit the bullet and let it reformat those files (filesystem, imagebufalgo, string_view, thread).

After merging this, we will have a separate PR that makes the code conform to the new rules, after which we will pass the CI clang-format test again. This split allows the .clang-format rule changes to be backported or cherry-picked into other branches independently.

I expect that the way to proceed with PRs currently in flight is (a) cherry-pick this PR (.clang-format change) into the patch's branch, (b) run clang-format on just the changed code of the PR to make the patch's changed code conform to the new rules, (c) rebase the PR on main, and hopefully have no merge conflicts.

