### PR TITLE
Annotate spin_mutex and spin_rw_mutex for ThreadSanitizer

### DIFF
--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -41,6 +41,45 @@
 #endif
 
 
+// ThreadSanitizer cannot tell that the spin locks below are locks: they are
+// built out of atomics, so it never sees the happens-before edges they
+// establish and reports races on the data they protect. The __tsan_mutex_*
+// hooks tell it. Compiled away unless the TU is built with tsan.
+#if defined(__SANITIZE_THREAD__)
+#    define OIIO_TSAN_ANNOTATE_LOCKS 1
+#elif defined(__has_feature)
+#    if __has_feature(thread_sanitizer)
+#        define OIIO_TSAN_ANNOTATE_LOCKS 1
+#    endif
+#endif
+#ifndef OIIO_TSAN_ANNOTATE_LOCKS
+#    define OIIO_TSAN_ANNOTATE_LOCKS 0
+#endif
+
+#if OIIO_TSAN_ANNOTATE_LOCKS
+#    include <sanitizer/tsan_interface.h>
+#    define OIIO_TSAN_PRE_LOCK(m, f) __tsan_mutex_pre_lock((void*)(m), (f))
+#    define OIIO_TSAN_POST_LOCK(m, f) \
+        __tsan_mutex_post_lock((void*)(m), (f), 0)
+#    define OIIO_TSAN_PRE_UNLOCK(m, f) \
+        ((void)__tsan_mutex_pre_unlock((void*)(m), (f)))
+#    define OIIO_TSAN_POST_UNLOCK(m, f) \
+        __tsan_mutex_post_unlock((void*)(m), (f))
+#    define OIIO_TSAN_F_TRY __tsan_mutex_try_lock
+#    define OIIO_TSAN_F_TRY_FAILED \
+        (__tsan_mutex_try_lock | __tsan_mutex_try_lock_failed)
+#    define OIIO_TSAN_F_READ __tsan_mutex_read_lock
+#else
+#    define OIIO_TSAN_PRE_LOCK(m, f) ((void)0)
+#    define OIIO_TSAN_POST_LOCK(m, f) ((void)0)
+#    define OIIO_TSAN_PRE_UNLOCK(m, f) ((void)0)
+#    define OIIO_TSAN_POST_UNLOCK(m, f) ((void)0)
+#    define OIIO_TSAN_F_TRY 0
+#    define OIIO_TSAN_F_TRY_FAILED 0
+#    define OIIO_TSAN_F_READ 0
+#endif
+
+
 
 // Some helpful links:
 //
@@ -232,15 +271,21 @@ public:
     ///
     void unlock() noexcept
     {
+        OIIO_TSAN_PRE_UNLOCK(&m_locked, 0);
         // Fastest way to do it is with a clear with "release" semantics
         m_locked.clear(std::memory_order_release);
+        OIIO_TSAN_POST_UNLOCK(&m_locked, 0);
     }
 
     /// Try to acquire the lock.  Return true if we have it, false if
     /// somebody else is holding the lock.
     bool try_lock() noexcept
     {
-        return !m_locked.test_and_set(std::memory_order_acquire);
+        OIIO_TSAN_PRE_LOCK(&m_locked, OIIO_TSAN_F_TRY);
+        const bool got = !m_locked.test_and_set(std::memory_order_acquire);
+        OIIO_TSAN_POST_LOCK(&m_locked,
+                            got ? OIIO_TSAN_F_TRY : OIIO_TSAN_F_TRY_FAILED);
+        return got;
     }
 
     /// Helper class: scoped lock for a spin_mutex -- grabs the lock upon
@@ -294,9 +339,12 @@ public:
         // first increase the readers, and if it turned out nobody was
         // writing, we're done. This means that acquiring a read when nobody
         // is writing is a single atomic operation.
+        OIIO_TSAN_PRE_LOCK(&m_bits, OIIO_TSAN_F_READ);
         int oldval = m_bits.fetch_add(1, std::memory_order_acquire);
-        if (!(oldval & WRITER))
+        if (!(oldval & WRITER)) {
+            OIIO_TSAN_POST_LOCK(&m_bits, OIIO_TSAN_F_READ);
             return;
+        }
         // Oops, we incremented readers but somebody was writing. Backtrack
         // by subtracting, and do things the hard way.
         int expected = (--m_bits) & NOTWRITER;
@@ -304,49 +352,60 @@ public:
         // Do compare-and-exchange until we can increase the number of
         // readers by one and have no writers.
         if (m_bits.compare_exchange_weak(expected, expected + 1,
-                                         std::memory_order_acquire))
+                                         std::memory_order_acquire)) {
+            OIIO_TSAN_POST_LOCK(&m_bits, OIIO_TSAN_F_READ);
             return;
+        }
         atomic_backoff backoff;
         do {
             backoff();
             expected = m_bits.load() & NOTWRITER;
         } while (!m_bits.compare_exchange_weak(expected, expected + 1,
                                                std::memory_order_acquire));
+        OIIO_TSAN_POST_LOCK(&m_bits, OIIO_TSAN_F_READ);
     }
 
     /// Release the reader lock.
     ///
     void read_unlock() noexcept
     {
+        OIIO_TSAN_PRE_UNLOCK(&m_bits, OIIO_TSAN_F_READ);
         // Atomically reduce the number of readers.  It's at least 1,
         // and the WRITER bit should definitely not be set, so this just
         // boils down to an atomic decrement of m_bits.
         m_bits.fetch_sub(1, std::memory_order_release);
+        OIIO_TSAN_POST_UNLOCK(&m_bits, OIIO_TSAN_F_READ);
     }
 
     /// Acquire the writer lock.
     ///
     void write_lock() noexcept
     {
+        OIIO_TSAN_PRE_LOCK(&m_bits, 0);
         // Do compare-and-exchange until we have just ourselves as writer
         int expected = 0;
         if (m_bits.compare_exchange_weak(expected, WRITER,
-                                         std::memory_order_acquire))
+                                         std::memory_order_acquire)) {
+            OIIO_TSAN_POST_LOCK(&m_bits, 0);
             return;
+        }
         atomic_backoff backoff;
         do {
             backoff();
             expected = 0;
         } while (!m_bits.compare_exchange_weak(expected, WRITER,
                                                std::memory_order_acquire));
+        OIIO_TSAN_POST_LOCK(&m_bits, 0);
     }
 
     /// Release the writer lock.
     ///
     void write_unlock() noexcept
     {
+        OIIO_TSAN_PRE_UNLOCK(&m_bits, 0);
         // Remove the writer bit
         m_bits.fetch_sub(WRITER, std::memory_order_release);
+        OIIO_TSAN_POST_UNLOCK(&m_bits, 0);
     }
 
     /// lock() is a synonym for exclusive (write) lock.


### PR DESCRIPTION
### Problem

Building with `-fsanitize=thread` reports a data race inside `spin_mutex::lock`:

```
WARNING: ThreadSanitizer: data race
  Read of size 1 at 0x... by thread T2:
    #0 OpenImageIO::v3_1::spin_mutex::lock() OpenImageIO/thread.h:224:22
    #1 OpenImageIO::v3_1::spin_mutex::lock_guard::lock_guard(...) OpenImageIO/thread.h:253:18
```

Line 224 is the `OIIO_THREAD_ALLOW_DCLP` spin, `while (*(volatile bool*)&m_locked)` —
a non-atomic read of a word other threads write atomically. tsan cannot tell the
surrounding construct is a lock, because it is built on `std::atomic_flag` rather
than a mutex tsan recognises. `OIIO_THREAD_ALLOW_DCLP=0` avoids the report at the
cost of the fast path; the only other option downstream is suppressing every
`OpenImageIO::` frame, which also hides real bugs in the calling code.

### Change

`__tsan_mutex_*` annotations (`sanitizer/tsan_interface.h`) on the acquire and
release paths of `spin_mutex` and `spin_rw_mutex`. `try_lock` uses
`__tsan_mutex_try_lock` / `__tsan_mutex_try_lock_failed` so a failed attempt is not
recorded as an acquisition; `lock()` needs nothing of its own, since it spins on
`try_lock`.

Annotating an address makes tsan treat it as a mutex rather than data, so line 224
is no longer reported and the fast path is left exactly as written. This changes no
behaviour, only what tsan is told.

All of it sits behind `OIIO_TSAN_ANNOTATE_LOCKS`, detected via `__SANITIZE_THREAD__`
or `__has_feature(thread_sanitizer)`, expanding to `((void)0)` otherwise. No new
include and no effect on non-tsan builds.

### Testing

Two threads contending a `spin_lock` under `clang++ -std=c++20 -fsanitize=thread`:
reported before the change, clean after. The header also compiles with
`-fsyntax-only` both with and without the sanitizer. Happy to add the reproducer as
a test if you want one in-tree.