### PR TITLE
python: Switch default python bindings to nanobind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,11 @@ jobs:
             container: aswf/ci-osl:2023-clang15.2
             opencolorio_ver: v2.3.0
             python_ver: "3.10"
+            oiio_python_bindings_backend: pybind11
+            pybind11_ver: v2.10.0
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             fmt_commit: f5e54359df4c26b6230fc61d38aa294581393084
-            pybind11_ver: v2.10.0
             setenvs: export PUGIXML_VERSION=v1.13
             optional_deps_append: 'LibRaw;Ptex;Qt6'
           - desc: VFX2024 gcc11/C++17 py3.11 exr3.2 ocio2.3
@@ -104,10 +105,11 @@ jobs:
             container: aswf/ci-oiio:2024.6
             opencolorio_ver: v2.3.2
             python_ver: "3.11"
+            oiio_python_bindings_backend: pybind11
+            pybind11_ver: v2.12.0
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             fmt_commit: f5e54359df4c26b6230fc61d38aa294581393084
-            pybind11_ver: v2.12.0
             setenvs: export PUGIXML_VERSION=v1.14
             optional_deps_append: "LibRaw"
           - desc: VFX2024 clang/C++17 py3.11 exr3.2 ocio2.3
@@ -118,10 +120,11 @@ jobs:
             cxx_compiler: clang++
             opencolorio_ver: v2.3.2
             python_ver: "3.11"
+            oiio_python_bindings_backend: pybind11
+            pybind11_ver: v2.12.0
             simd: "avx2,f16c"
             fmt_ver: 10.1.1
             fmt_commit: f5e54359df4c26b6230fc61d38aa294581393084
-            pybind11_ver: v2.12.0
             setenvs: export PUGIXML_VERSION=v1.14
                             openjph_CMAKE_C_COMPILER=gcc
                             openjph_CMAKE_CXX_COMPILER=g++
@@ -132,10 +135,11 @@ jobs:
             container: aswf/ci-oiio:2025.5
             cxx_std: 17
             python_ver: "3.11"
+            oiio_python_bindings_backend: pybind11
+            pybind11_ver: v2.13.6
             simd: "avx2,f16c"
             fmt_ver: 11.2.0
             fmt_commit: 40626af88bd7df9a5fb80be7b25ac85b122d6c21
-            pybind11_ver: v2.13.6
             benchmark: 1
             setenvs: export PUGIXML_VERSION=v1.15
             optional_deps_append: "Qt6"
@@ -146,6 +150,7 @@ jobs:
             cxx_std: 17
             build_type: Debug
             ctest_test_timeout: "300"
+            oiio_python_bindings_backend: pybind11
             python_ver: "3.11"
             simd: "avx2,f16c"
             fmt_ver: 11.2.0
@@ -175,6 +180,7 @@ jobs:
             fmt_ver: 11.2.0
             fmt_commit: 40626af88bd7df9a5fb80be7b25ac85b122d6c21
             python_ver: "3.11"
+            oiio_python_bindings_backend: pybind11
             pybind11_ver: v2.13.6
             simd: "avx2,f16c"
             benchmark: 1
@@ -193,16 +199,19 @@ jobs:
             python_ver: "3.13"
             simd: "avx2,f16c"
             pybind11_ver: v3.0.0
+            oiio_python_bindings_backend: both
+            setenvs: export nanobind_GIT_TAG=v2.13.0
+                            nanobind_GIT_COMMIT=e2dc00f7a34f935c6cf91948776d59c4709e9fe6
             optional_deps_append: "Qt5;Qt6"
-
           - desc: VFX2027 gcc14/C++20 py3.13 exr3.4 ocio2.5
             nametag: linux-vfx2027
             runner: ubuntu-latest
             container: aswf/ci-oiio:2027
             cxx_std: 20
             python_ver: "3.13"
-            simd: "avx2,f16c"
+            oiio_python_bindings_backend: nanobind
             pybind11_ver: v3.0.4
+            simd: "avx2,f16c"
             benchmark: 1
           - desc: VFX2027 clang21/C++20 py3.13 exr3.4 ocio2.5
             nametag: linux-vfx2027-clang
@@ -212,8 +221,9 @@ jobs:
             cxx_compiler: clang++
             cxx_std: 20
             python_ver: "3.13"
-            simd: "avx2,f16c"
+            oiio_python_bindings_backend: nanobind
             pybind11_ver: v3.0.4
+            simd: "avx2,f16c"
 
           - desc: Sanitizers
             nametag: sanitizer
@@ -296,7 +306,7 @@ jobs:
       required_deps: ${{ matrix.required_deps || 'all' }}
       optional_deps: ${{ matrix.optional_deps || 'CUDAToolkit;DCMTK;JXL;Nuke;OpenGL;OpenVDB;Ptex;pystring;Qt5;R3DSDK;Libheif;' }}${{matrix.optional_deps_append}}
       build_local_deps: ${{ matrix.build_local_deps }}
-      oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || 'both' }}
+      oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || 'nanobind' }}
     strategy:
       fail-fast: false
       matrix:
@@ -333,6 +343,7 @@ jobs:
             openexr_ver: v3.4.13
             pybind11_ver: v3.0.4
             python_ver: "3.12"
+            oiio_python_bindings_backend: both
             simd: avx2,f16c
             gcc_action_ver: 15
             setenvs: export OIIO_CC=gcc-15 OIIO_CXX=g++-15
@@ -349,6 +360,8 @@ jobs:
                             UHDR_CMAKE_C_COMPILER=gcc
                             UHDR_CMAKE_CXX_COMPILER=g++
                             OPENCOLORIO_CXX=c++
+                            nanobind_GIT_TAG=v3.0.0
+                            nanobind_GIT_COMMIT=1bd3139721d6176dfb10979b7219ccb58ef8aafa
             # Ensure we are testing all the deps we think we are. We would
             # like this test to have minimal missing dependencies.
             required_deps: all
@@ -364,6 +377,7 @@ jobs:
             openexr_ver: main
             pybind11_ver: master
             python_ver: "3.12"
+            oiio_python_bindings_backend: both
             simd: avx2,f16c
             benchmark: 1
             gcc_action_ver: 16
@@ -384,6 +398,8 @@ jobs:
                             UHDR_CMAKE_C_COMPILER=gcc
                             UHDR_CMAKE_CXX_COMPILER=g++
                             OPENCOLORIO_CXX=c++
+                            nanobind_GIT_TAG=master
+                            nanobind_DEPENDENCY_BUILD_ALLOW_UNVERIFIED_TAGS=ON
             # Ensure we are testing all the deps we think we are. We would
             # like this test to have minimal missing dependencies.
             required_deps: all
@@ -397,6 +413,7 @@ jobs:
             fmt_ver: 12.1.0
             fmt_commit: 407c905e45ad75fc29bf0f9bb7c5c2fd3475976f
             python_ver: "3.10"
+            oiio_python_bindings_backend: both
             simd: avx2,f16c
             build_local_deps: all
             setenvs: export OpenImageIO_DEPENDENCY_BUILD_VERBOSE=ON
@@ -431,8 +448,9 @@ jobs:
             fmt_commit: 1be298e1bd68957e4cd352e1f676f00e07dcfb57
             opencolorio_ver: v2.5.2
             openexr_ver: v3.4.13
-            pybind11_ver: v3.0.4
             python_ver: "3.12"
+            pybind11_ver: v3.0.4
+            oiio_python_bindings_backend: both
             setenvs: export LIBJPEGTURBO_VERSION=3.2.0
                             LIBPNG_VERSION=v1.6.58
                             LIBRAW_VERSION=0.22.0
@@ -443,6 +461,8 @@ jobs:
                             WEBP_VERSION=v1.6.0
                             FREETYPE_VERSION=VER-2-14-1
                             USE_OPENVDB=0
+                            nanobind_GIT_TAG=v3.0.0
+                            nanobind_GIT_COMMIT=1bd3139721d6176dfb10979b7219ccb58ef8aafa
           - desc: Linux ARM latest releases clang18 C++20 py3.12 exr3.4 ocio2.4
             nametag: linux-arm-latest-releases-clang
             runner: ubuntu-24.04-arm
@@ -453,8 +473,9 @@ jobs:
             fmt_commit: 407c905e45ad75fc29bf0f9bb7c5c2fd3475976f
             opencolorio_ver: v2.5.2
             openexr_ver: v3.4.13
-            pybind11_ver: v3.0.4
             python_ver: "3.12"
+            pybind11_ver: v3.0.4
+            oiio_python_bindings_backend: both
             setenvs: export LIBJPEGTURBO_VERSION=3.2.0
                             LIBPNG_VERSION=v1.6.58
                             LIBRAW_VERSION=0.22.0
@@ -465,6 +486,8 @@ jobs:
                             WEBP_VERSION=v1.6.0
                             FREETYPE_VERSION=VER-2-14-1
                             USE_OPENVDB=0
+                            nanobind_GIT_TAG=v3.0.0
+                            nanobind_GIT_COMMIT=1bd3139721d6176dfb10979b7219ccb58ef8aafa
 
           - desc: oldest gcc9/C++17 py3.9 exr3.1 ocio2.3
             # Oldest gcc and versions of the dependencies that we support.
@@ -480,6 +503,7 @@ jobs:
             pybind11_ver: v2.7.0
             python_ver: "3.9"
             python_action_ver: "3.9"
+            oiio_python_bindings_backend: pybind11
             gcc_action_ver: 9
             setenvs: export  CMAKE_VERSION=3.23.0
                              PTEX_VERSION=v2.3.2
@@ -509,6 +533,7 @@ jobs:
             pybind11_ver: v2.7.0
             python_ver: "3.9"
             python_action_ver: "3.9"
+            oiio_python_bindings_backend: both
             llvm_action_ver: "11"
             setenvs: export CMAKE_VERSION=3.23.0
                             PTEX_VERSION=v2.3.2
@@ -526,6 +551,8 @@ jobs:
                             openjph_CMAKE_C_COMPILER=gcc
                             openjph_CMAKE_CXX_COMPILER=g++
                             LIBRAW_VERSION=0.21.0
+                            nanobind_GIT_TAG=v2.8.0
+                            nanobind_GIT_COMMIT=0e7aa61a75052034453cd2b906a79fe222792697
                             #  OpenJPEG_BUILD_VERSION=2.2.0
                             #  OpenJPEG_GIT_COMMIT=3d7cde5fc9fbc5618d02160900d32e02ed12a00e
             optional_deps_append: 'FFmpeg;LibRaw;Ptex;Qt6'
@@ -547,6 +574,7 @@ jobs:
             pybind11_ver: v2.7.0
             python_ver: "3.9"
             python_action_ver: "3.9"
+            oiio_python_bindings_backend: pybind11
             gcc_action_ver: 9
             simd: 0
             setenvs: export  EMBEDPLUGINS=0
@@ -610,7 +638,7 @@ jobs:
       required_deps: ${{ matrix.required_deps || 'all' }}
       optional_deps: ${{ matrix.optional_deps || 'Nuke;R3DSDK;' }}${{matrix.optional_deps_append}}
       build_local_deps: ${{ matrix.build_local_deps }}
-      oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || 'both' }}
+      oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || 'nanobind' }}
     strategy:
       fail-fast: false
       matrix:
@@ -622,6 +650,7 @@ jobs:
             cxx_compiler: /usr/bin/clang++
             cxx_std: 17
             python_ver: "3.14"
+            oiio_python_bindings_backend: both
             simd: sse4.2,avx2
             ctest_test_timeout: 1200
             setenvs: export MACOSX_DEPLOYMENT_TARGET=12.0
@@ -635,6 +664,7 @@ jobs:
             cxx_compiler: /usr/bin/clang++
             cxx_std: 20
             python_ver: "3.13"
+            oiio_python_bindings_backend: both
           - desc: MacOS-15-ARM aclang16/C++20/py3.13
             runner: macos-15
             nametag: macos15-arm-py313
@@ -642,6 +672,7 @@ jobs:
             cxx_compiler: /usr/bin/clang++
             cxx_std: 20
             python_ver: "3.13"
+            oiio_python_bindings_backend: nanobind
             benchmark: 1
           - desc: MacOS-26-ARM aclang16/C++20/py3.14
             runner: macos-26
@@ -650,6 +681,7 @@ jobs:
             cxx_compiler: /usr/bin/clang++
             cxx_std: 20
             python_ver: "3.14"
+            oiio_python_bindings_backend: nanobind
             benchmark: 1
 
 
@@ -694,7 +726,7 @@ jobs:
       required_deps: ${{ matrix.required_deps || 'all' }}
       optional_deps: ${{ matrix.optional_deps || 'BZip2;CUDAToolkit;DCMTK;FFmpeg;GIF;JXL;Libheif;LibRaw;Nuke;OpenCV;OpenGL;OpenJPEG;OpenCV;OpenVDB;Ptex;pystring;Qt5;Qt6;TBB;R3DSDK;${{matrix.optional_deps_append}}' }}
       build_local_deps: ${{ matrix.build_local_deps }}
-      oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || 'both' }}
+      oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || 'nanobind' }}
     strategy:
       fail-fast: false
       matrix:
@@ -704,7 +736,7 @@ jobs:
             nametag: windows-2022
             generator: "Visual Studio 17 2022"
             python_ver: "3.12"
-            oiio_python_bindings_backend: nanobind
+            oiio_python_bindings_backend: both
             ctest_test_timeout: "240"
             setenvs: export OPENIMAGEIO_PYTHON_LOAD_DLLS_FROM_PATH=1
           - desc: Windows-2025 VS2026
@@ -712,7 +744,7 @@ jobs:
             nametag: windows-2025-vs2026
             generator: "Visual Studio 18 2026"
             python_ver: "3.12"
-            oiio_python_bindings_backend: both
+            oiio_python_bindings_backend: nanobind
             ctest_test_timeout: "240"
             setenvs: export OPENIMAGEIO_PYTHON_LOAD_DLLS_FROM_PATH=1
             benchmark: 1

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -23,6 +23,7 @@ on:
       - dev-3.*
       - "*wheel*"
       - "*python*"
+      - "*nanobind*"
   pull_request:
     # Workflow run on pull_request only when related files change, or when the
     # branch name itself contains the substrings 'wheel' or 'python'.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -165,11 +165,9 @@ Make wrapper (`make PkgName_ROOT=...`).
 
 `USE_PYTHON=0` : Omits building the Python bindings.
 
-`OIIO_PYTHON_BINDINGS_BACKEND=pybind11|nanobind|both` : Select which Python
-binding backend(s) to configure for source/CMake builds. `both` keeps the
-existing pybind11 module and also builds the nanobind (WIP) module. The
-Python packaging path driven by `pyproject.toml` still targets the production
-pybind11 bindings today.
+`OIIO_PYTHON_BINDINGS_BACKEND=nanobind|pybind11|both` : Select which Python
+binding backend(s) to configure for source/CMake builds.  The Python packaging
+path driven by `pyproject.toml` targets the nanobind bindings.
 
 `OIIO_BUILD_TESTS=0` : Omits building tests (you probably don't need them
 unless you are a developer of OIIO or want to verify that your build
@@ -261,7 +259,7 @@ Additionally, a few helpful modifiers alter some build-time options:
 | make USE_QT=0 ...             |  Skip anything that needs Qt                                              |
 | make MYCC=xx MYCXX=yy ...     |  Use custom compilers                                                     |
 | make USE_PYTHON=0 ...         |  Don't build the Python binding                                           |
-| make OIIO_PYTHON_BINDINGS_BACKEND=both ... | For source/CMake builds, build the existing pybind11 bindings and the nanobind (WIP) module |
+| make OIIO_PYTHON_BINDINGS_BACKEND=both ... | For source/CMake builds, choosing nanobind (current), pybind11 (legacy) or both modules. |
 | make BUILD_SHARED_LIBS=0      |  Build static library instead of shared                                   |
 | make IGNORE_HOMEBREWED_DEPS=1 |  Ignore homebrew-managed dependencies                                     |
 | make LINKSTATIC=1 ...         |  Link with static external libraries when possible                        |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ build-backend = "scikit_build_core.build"
 requires = [
     "scikit-build-core>=0.10.6,<1",
     "pybind11>=2.13,<4",
+    "nanobind>=2.8,<4"
 ]
 
 [tool.scikit-build]

--- a/src/cmake/build_nanobind.cmake
+++ b/src/cmake/build_nanobind.cmake
@@ -17,7 +17,7 @@
 
 # NOTE: We are sticking with autobuild of nanobind defaulting to 2.13.0,
 # because nanobind 3.0+ requiers a minimum python of 3.10, whereas we
-# still support python 3.0.
+# still support python 3.9.
 set_cache (nanobind_BUILD_VERSION 2.13.0 "nanobind version for local builds")
 set (nanobind_GIT_REPOSITORY "https://github.com/wjakob/nanobind")
 set_cache (nanobind_GIT_TAG "v${nanobind_BUILD_VERSION}"

--- a/src/cmake/build_nanobind.cmake
+++ b/src/cmake/build_nanobind.cmake
@@ -15,6 +15,9 @@
 # the (unusually light) local build performed below.
 ######################################################################
 
+# NOTE: We are sticking with autobuild of nanobind defaulting to 2.13.0,
+# because nanobind 3.0+ requiers a minimum python of 3.10, whereas we
+# still support python 3.0.
 set_cache (nanobind_BUILD_VERSION 2.13.0 "nanobind version for local builds")
 set (nanobind_GIT_REPOSITORY "https://github.com/wjakob/nanobind")
 set_cache (nanobind_GIT_TAG "v${nanobind_BUILD_VERSION}"
@@ -65,4 +68,3 @@ set (nanobind_DIR "${nanobind_LOCAL_INSTALL_DIR}/nanobind/cmake" CACHE PATH
 # Signal to caller that we need to find again at the installed location
 set (nanobind_REFIND TRUE)
 set (nanobind_REFIND_ARGS CONFIG)
-set (nanobind_REFIND_VERSION ${nanobind_BUILD_VERSION})

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -137,7 +137,7 @@ endif ()
 if (USE_PYTHON AND OIIO_BUILD_PYTHON_NANOBIND)
     discover_nanobind_cmake_dir()
     checked_find_package (nanobind CONFIG REQUIRED
-                          VERSION_MIN 2.8.0
+                          VERSION_MIN 2.8.0 VERSION_MAX 3.9
                           BUILD_LOCAL missing)
 endif ()
 

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -8,10 +8,10 @@ set (PYTHON_VERSION "" CACHE STRING "Target version of python to find")
 option (PYLIB_INCLUDE_SONAME "If ON, soname/soversion will be set for Python module library" OFF)
 option (PYLIB_LIB_PREFIX "If ON, prefix the Python module with 'lib'" OFF)
 set (PYMODULE_SUFFIX "" CACHE STRING "Suffix to add to Python module init namespace")
-set_cache (OIIO_PYTHON_BINDINGS_BACKEND "pybind11"
-     "Which Python binding backend(s) to build: pybind11, nanobind, or both" VERBOSE)
+set_cache (OIIO_PYTHON_BINDINGS_BACKEND "nanobind"
+     "Which Python binding backend(s) to build: nanobind, pybind11, or both" VERBOSE)
 set_property (CACHE OIIO_PYTHON_BINDINGS_BACKEND PROPERTY STRINGS
-              pybind11 nanobind both)
+              nanobind pybind11 both)
 
 # Normalize and validate the user-facing backend selector early so the rest
 # of the file can make simple boolean decisions.


### PR DESCRIPTION
Change the default OIIO_PYTHON_BINDINGS_BACKEND to nanobind for the 3.2 release.

Shuffle the distribution in CI tests around -- building against old years tests pybind11, building against new tests mostly nanobind, sometimes both. Make the "bleeding edge" test against nanobind main, make "latest releases" test against nanobind 3.0.0.

The autobuild of nanobind still sticks with 2.13.0 by default, since the newer 3.0 requires a minimum python that's higher than our own minimum python.

