### PR TITLE
deps: bump minimum libjpeg to 9

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * OpenEXR >= 3.1 (tested through 3.4 and main)
  * **libTIFF >= 4.1** (tested through 4.7 and master)
  * OpenColorIO >= 2.3 (tested through 2.5 and main)
- * libjpeg >= 8 (tested through jpeg9e), or libjpeg-turbo >= 2.1 (tested
+ * **libjpeg >= 9** (tested through jpeg-10), or libjpeg-turbo >= 2.1 (tested
    through 3.2)
  * zlib >= 1.2.7 (tested through 1.3.2)
  * **[fmtlib](https://github.com/fmtlib/fmt) >= 9.0** (tested through 12.2 and master).

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -82,7 +82,8 @@ if (TARGET libjpeg-turbo::jpeg) # Try to find the non-turbo version
     set (JPEG_FOUND TRUE)
 else ()
     # Try to find the non-turbo version
-    checked_find_package (JPEG REQUIRED)
+    checked_find_package (JPEG REQUIRED
+                          VERSION_MIN 9.0)
 endif ()
 
 


### PR DESCRIPTION
8 is just soooo ooooold. Even the new minimum of 9.0 dates from 2013. 