### PR TITLE
ci: Bump the 'latest releases' tests, some auto-builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,8 +340,8 @@ jobs:
             fmt_ver: 12.2.0
             fmt_commit: 1be298e1bd68957e4cd352e1f676f00e07dcfb57
             opencolorio_ver: v2.5.2
-            openexr_ver: v3.4.13
-            pybind11_ver: v3.0.4
+            openexr_ver: v3.4.14
+            pybind11_ver: v3.1.0
             python_ver: "3.12"
             oiio_python_bindings_backend: both
             simd: avx2,f16c
@@ -349,13 +349,13 @@ jobs:
             setenvs: export OIIO_CC=gcc-15 OIIO_CXX=g++-15
                             LIBJPEGTURBO_VERSION=3.2.0
                             LIBPNG_VERSION=v1.6.58
-                            LIBRAW_VERSION=0.22.0
+                            LIBRAW_VERSION=0.22.2
                             LIBTIFF_VERSION=v4.7.2
                             OPENJPEG_VERSION=v2.5.4
-                            PTEX_VERSION=v2.5.0
+                            PTEX_VERSION=v2.5.2
                             PUGIXML_VERSION=v1.16
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-14-1
+                            FREETYPE_VERSION=VER-2-14-3
                             USE_OPENVDB=0
                             UHDR_CMAKE_C_COMPILER=gcc
                             UHDR_CMAKE_CXX_COMPILER=g++
@@ -447,19 +447,19 @@ jobs:
             fmt_ver: 12.2.0
             fmt_commit: 1be298e1bd68957e4cd352e1f676f00e07dcfb57
             opencolorio_ver: v2.5.2
-            openexr_ver: v3.4.13
+            openexr_ver: v3.4.14
+            pybind11_ver: v3.1.0
             python_ver: "3.12"
-            pybind11_ver: v3.0.4
             oiio_python_bindings_backend: both
             setenvs: export LIBJPEGTURBO_VERSION=3.2.0
                             LIBPNG_VERSION=v1.6.58
-                            LIBRAW_VERSION=0.22.0
+                            LIBRAW_VERSION=0.22.2
                             LIBTIFF_VERSION=v4.7.2
                             OPENJPEG_VERSION=v2.5.4
-                            PTEX_VERSION=v2.4.3
+                            PTEX_VERSION=v2.5.2
                             PUGIXML_VERSION=v1.16
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-14-1
+                            FREETYPE_VERSION=VER-2-14-3
                             USE_OPENVDB=0
                             nanobind_GIT_TAG=v3.0.0
                             nanobind_GIT_COMMIT=1bd3139721d6176dfb10979b7219ccb58ef8aafa
@@ -469,22 +469,22 @@ jobs:
             cc_compiler: clang-18
             cxx_compiler: clang++-18
             cxx_std: 20
-            fmt_ver: 12.1.0
-            fmt_commit: 407c905e45ad75fc29bf0f9bb7c5c2fd3475976f
+            fmt_ver: 12.2.0
+            fmt_commit: 1be298e1bd68957e4cd352e1f676f00e07dcfb57
             opencolorio_ver: v2.5.2
-            openexr_ver: v3.4.13
+            openexr_ver: v3.4.14
+            pybind11_ver: v3.1.0
             python_ver: "3.12"
-            pybind11_ver: v3.0.4
             oiio_python_bindings_backend: both
             setenvs: export LIBJPEGTURBO_VERSION=3.2.0
                             LIBPNG_VERSION=v1.6.58
-                            LIBRAW_VERSION=0.22.0
+                            LIBRAW_VERSION=0.22.2
                             LIBTIFF_VERSION=v4.7.2
                             OPENJPEG_VERSION=v2.5.4
-                            PTEX_VERSION=v2.4.3
+                            PTEX_VERSION=v2.5.2
                             PUGIXML_VERSION=v1.16
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-14-1
+                            FREETYPE_VERSION=VER-2-14-3
                             USE_OPENVDB=0
                             nanobind_GIT_TAG=v3.0.0
                             nanobind_GIT_COMMIT=1bd3139721d6176dfb10979b7219ccb58ef8aafa

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        `nanobind` or `both`.  If not found at build time, nanobind will be
        automatically downloaded and built.
      * [pybind11](https://github.com/pybind/pybind11) >= 2.7 (tested through
-       3.0), if you are building with `OIIO_PYTHON_BINDINGS_BACKEND` set to
+       3.1), if you are building with `OIIO_PYTHON_BINDINGS_BACKEND` set to
        either `pybind11` or `both`.
      * NumPy (tested through 2.4.4)
  * If you want support for PNG files:
@@ -85,7 +85,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for JPEG XL images:
      * libjxl >= 0.10.1 (tested through 0.12.0)
  * If you want support for j2c files:
-     * OpenJPH >= 0.21.2 (tested through 0.30)
+     * OpenJPH >= 0.21.2 (tested through 0.31)
  * We use PugiXML for XML parsing. There is a version embedded in the OIIO
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distributions with policies against

--- a/src/build-scripts/build_Freetype.bash
+++ b/src/build-scripts/build_Freetype.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of Freetype to download if we don't have it yet
 FREETYPE_REPO=${FREETYPE_REPO:=https://github.com/freetype/freetype.git}
-FREETYPE_VERSION=${FREETYPE_VERSION:=VER-2-14-1}
+FREETYPE_VERSION=${FREETYPE_VERSION:=VER-2-14-3}
 
 # Where to put Freetype repo source (default to the ext area)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of libpng to download if we don't have it yet
 LIBPNG_REPO=${LIBPNG_REPO:=https://github.com/pnggroup/libpng.git}
-LIBPNG_VERSION=${LIBPNG_VERSION:=v1.6.50}
+LIBPNG_VERSION=${LIBPNG_VERSION:=v1.6.58}
 
 # Where to put libpng repo source (default to the ext area)
 LIBPNG_SRC_DIR=${LIBPNG_SRC_DIR:=${PWD}/ext/libpng}

--- a/src/build-scripts/build_openjph.bash
+++ b/src/build-scripts/build_openjph.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of openjph to download if we don't have it yet
 OPENJPH_REPO=${OPENJPH_REPO:=https://github.com/aous72/OpenJPH.git}
-OPENJPH_VERSION=${OPENJPH_VERSION:=0.30.1}
+OPENJPH_VERSION=${OPENJPH_VERSION:=0.31.0}
 
 # Where to put openjph repo source (default to the ext area)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/cmake/build_Freetype.cmake
+++ b/src/cmake/build_Freetype.cmake
@@ -6,10 +6,10 @@
 # Freetype by hand!
 ######################################################################
 
-set_cache (Freetype_BUILD_VERSION 2.14.1 "Freetype version for local builds")
+set_cache (Freetype_BUILD_VERSION 2.14.3 "Freetype version for local builds")
 set (Freetype_GIT_REPOSITORY "https://github.com/freetype/freetype")
-set (Freetype_GIT_TAG "VER-2-14-1")
-set (Freetype_GIT_COMMIT "526ec5c47b9ebccc4754c85ac0c0cdf7c85a5e9b")
+set (Freetype_GIT_TAG "VER-2-14-3")
+set (Freetype_GIT_COMMIT "0a0221a1347e2f1e07c395263540026e9a0aa7c7")
 set_cache (Freetype_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
            DOC "Should a local Freetype build, if necessary, build shared libraries" ADVANCED)
 # We would prefer to build a static Freetype, but haven't figured out how to make

--- a/src/cmake/build_PNG.cmake
+++ b/src/cmake/build_PNG.cmake
@@ -6,10 +6,10 @@
 # PNG by hand!
 ######################################################################
 
-set_cache (PNG_BUILD_VERSION 1.6.50 "PNG version for local builds")
+set_cache (PNG_BUILD_VERSION 1.6.58 "PNG version for local builds")
 super_set (PNG_BUILD_GIT_REPOSITORY "https://github.com/pnggroup/libpng")
 super_set (PNG_BUILD_GIT_TAG "v${PNG_BUILD_VERSION}")
-super_set (PNG_BUILD_GIT_COMMIT "2b978915d82377df13fcbb1fb56660195ded868a")
+super_set (PNG_BUILD_GIT_COMMIT "3061454d980de7d53608f594194cfac722721d2a")
 super_set (PNG_BUILD_EXTRA_CMAKE_ARGS "")
 set_cache (PNG_BUILD_SHARED_LIBS OFF
            DOC "Should execute a local PNG build, if necessary, build shared libraries" ADVANCED)

--- a/src/cmake/build_openjph.cmake
+++ b/src/cmake/build_openjph.cmake
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
-set_cache (openjph_BUILD_VERSION 0.30.1 "openjph version for local builds")
+set_cache (openjph_BUILD_VERSION 0.31.0 "openjph version for local builds")
 set (openjph_GIT_REPOSITORY "https://github.com/aous72/OpenJPH.git")
 set (openjph_GIT_TAG "${openjph_BUILD_VERSION}")
-set_cache (openjph_GIT_COMMIT "1ce857c7f14dd78dd8f4bdfabe43dc17f8408a42"
+set_cache (openjph_GIT_COMMIT "c68064d0e4cad8e96bab9a068f6cc4e7799744fc"
            "commit hash to verify tag against")
 set_cache (openjph_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
            DOC "Should a local openjph build, if necessary, build shared libraries" ADVANCED)


### PR DESCRIPTION
Make sure the "latest releases" CI tests are bumped to the latest releases of dependencies where possible.

Bump several default versions for auto-build and CI build to the latest:

* PNG - 1.6.58
* Freetype - 2.14.3
* OpenJPH - 0.31.0

This does not change the minimum OIIO dependency requirements, it is only adjusting what is the newest version we test in CI.
