### PR TITLE
fix(exr): decode each compressed chunk once when reading 1 scanline

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -442,6 +442,11 @@ macro (oiio_add_all_tests)
         # OpenEXR 3.1.10 is the first release where the exr core library
         # properly supported all compression types (DWA in particular).
         list (APPEND all_openexr_tests openexr-compression)
+        # openexr-scanlines reads a DWA-compressed file, so it needs the same
+        # minimum as openexr-compression for the core-library test variant.
+        if (USE_PYTHON AND NOT SANITIZE)
+            list (APPEND all_openexr_tests openexr-scanlines)
+        endif ()
     endif ()
     if (OpenEXR_VERSION VERSION_GREATER_EQUAL 3.3)
         # OpenEXR 3.3 is when IDManifest was introduced

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -231,6 +231,22 @@ Disk file format info/hints
     unassociated with the color (i.e., color not "premultiplied" by the
     alpha coverage value).
 
+.. option:: "oiio:RowsPerChunk" : int
+
+    Some file formats containing scanlines are more efficient to read when a a
+    multiple of a certain number of scanlines are read at one time. TIFF and
+    OpenEXR are examples of this (TIFF RowsPerStrip or OpenEXR chunk size,
+    respectively), usually because they may compress groups of scanlines
+    together, making it impossible to decompress one individually without
+    reading and decompressing the whole group.
+
+    For file readers for which this performance difference is the case, the
+    reader will set this hint to convey the ideal number of scanlines to read
+    at a time for higher performance. Image file readers that have no such
+    preference will not set this hint.
+
+    This metadata was added in OpenImageIO 3.2.
+
 .. option:: "planarconfig" : string
 
     `contig` indicates that the file has contiguous pixels (RGB RGB RGB...),

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -110,9 +110,9 @@ public:
     ///
     ///           If `autotile` is set to 0 (the default), an untiled image
     ///           will be treated as if it were a single tile of the
-    ///           resolution of the whole image.  This is simple and fast,
-    ///           but can lead to poor cache behavior if you are
-    ///           simultaneously accessing many large untiled images.
+    ///           resolution of the whole image.  This is simple and fast, but
+    ///           can lead to poor cache behavior if you are simultaneously
+    ///           accessing many large untiled images.
     ///
     ///           If `autotile` is nonzero (e.g., 64 is a good recommended
     ///           value), any untiled images will be read and cached as if
@@ -129,6 +129,17 @@ public:
     ///           default) or if they will be as wide as the image (but only
     ///           `autotile` scanlines high).  You should try in your
     ///           application to see which leads to higher performance.
+    ///
+    ///           This is advisory, and there is an important exception: a
+    ///           file that can only be read in whole groups of scanlines
+    ///           (TIFF strips, OpenEXR compressed chunks) is always autotiled
+    ///           to improve efficiency. Its tiles are as wide as the image,
+    ///           and as many scanlines high as it takes to hold a whole
+    ///           number of those groups -- at least 64, or `autotile` if that
+    ///           is more. If the groups are so big that this would make a
+    ///           tile of more than 16 MB, the tiles are that minimum height
+    ///           instead and are not aligned to the groups.
+    ///
     /// - `int autoscanline` :
     ///           autotile using full width tiles
     /// - `int automip` :

--- a/src/libOpenImageIO/imagecache_test.cpp
+++ b/src/libOpenImageIO/imagecache_test.cpp
@@ -17,6 +17,8 @@ using namespace OIIO;
 
 static ustring udimpattern;
 static ustring checkertex;
+static ustring onestriptex;
+static ustring bigstriptex;
 static std::vector<ustring> files_to_delete;
 
 
@@ -39,6 +41,32 @@ create_temp_textures()
                                    checkertex, config);
         check.write(checkertex);
         files_to_delete.push_back(checkertex);
+    }
+
+    // Two untiled TIFFs that are each a single strip, to exercise the
+    // ImageCache's autotiling of files that read in whole groups of
+    // scanlines. Setting "tiff:RowsPerStrip" to the height is what asks the
+    // TIFF writer for one strip holding the whole image.
+    {
+        std::string temp_dir = Filesystem::temp_directory_path();
+
+        // Small enough (1 MB) that a strip-aligned tile is fine.
+        onestriptex = ustring::fmtformat("{}/onestrip.tif", temp_dir);
+        ImageSpec onestripspec(512, 512, 4, TypeUInt8);
+        onestripspec.attribute("tiff:RowsPerStrip", onestripspec.height);
+        ImageBuf onestrip(onestripspec);
+        ImageBufAlgo::zero(onestrip);
+        onestrip.write(onestriptex);
+        files_to_delete.push_back(onestriptex);
+
+        // Big enough (32 MB) that a strip-aligned tile would be unreasonable.
+        bigstriptex = ustring::fmtformat("{}/bigstrip.tif", temp_dir);
+        ImageSpec bigstripspec(1024, 8192, 4, TypeUInt8);
+        bigstripspec.attribute("tiff:RowsPerStrip", bigstripspec.height);
+        ImageBuf bigstrip(bigstripspec);
+        ImageBufAlgo::zero(bigstrip);
+        bigstrip.write(bigstriptex);
+        files_to_delete.push_back(bigstriptex);
     }
 
     ustring badfile("badfile.exr");
@@ -252,8 +280,11 @@ test_tileptr()
     Strutil::print("tile @ 4,4 format {} ROI {}\n",
                    imagecache->tile_format(tile), imagecache->tile_roi(tile));
     OIIO_CHECK_EQUAL(imagecache->tile_format(tile), TypeHalf);
+    // checkertex is an untiled EXR, and its compression reads whole groups
+    // of scanlines, so the IC autotiles it into full-width 64-row tiles even
+    // though autotile is off.
     OIIO_CHECK_EQUAL(imagecache->tile_roi(tile),
-                     ROI(0, 256, 0, 256, 0, 1, 0, 3));
+                     ROI(0, 256, 0, 64, 0, 1, 0, 3));
     TypeDesc tileformat;
     OIIO_CHECK_ASSERT(imagecache->tile_pixels(tile, tileformat) != nullptr);
     OIIO_CHECK_ASSERT(tileformat == TypeHalf);
@@ -264,6 +295,40 @@ test_tileptr()
     OIIO_CHECK_ASSERT(imagecache->get_tile(hand, nullptr, 1, 0, 400, 400, 0)
                       == nullptr);  // nonexistent tile
 
+    imagecache->release_tile(tile);
+}
+
+
+
+// A file that can only be read in whole groups of scanlines is autotiled
+// even when autotile is off, in tiles holding a whole number of groups --
+// unless that would make the tile too big, in which case we settle for
+// small unaligned tiles.
+void
+test_autotile_chunks()
+{
+    Strutil::print("\nTesting autotiling of chunked scanline files\n");
+    auto imagecache = ImageCache::create(false /* not shared */);
+    int autotile    = -1;
+    OIIO_CHECK_ASSERT(imagecache->getattribute("autotile", autotile));
+    OIIO_CHECK_EQUAL(autotile, 0);
+
+    // 512x512, one 512-row strip: a strip-sized tile is only 1 MB, so the
+    // tiles are the whole strip.
+    auto hand = imagecache->get_image_handle(onestriptex);
+    auto tile = imagecache->get_tile(hand, nullptr, 0, 0, 4, 4, 0);
+    OIIO_CHECK_ASSERT(tile != nullptr);
+    OIIO_CHECK_EQUAL(imagecache->tile_roi(tile),
+                     ROI(0, 512, 0, 512, 0, 1, 0, 4));
+    imagecache->release_tile(tile);
+
+    // 1024x8192, one 8192-row strip: a strip-sized tile would be 32 MB, so
+    // we give up on alignment and use the 64-row minimum instead.
+    hand = imagecache->get_image_handle(bigstriptex);
+    tile = imagecache->get_tile(hand, nullptr, 0, 0, 4, 4, 0);
+    OIIO_CHECK_ASSERT(tile != nullptr);
+    OIIO_CHECK_EQUAL(imagecache->tile_roi(tile),
+                     ROI(0, 1024, 0, 64, 0, 1, 0, 4));
     imagecache->release_tile(tile);
 }
 
@@ -386,6 +451,7 @@ main(int /*argc*/, char* /*argv*/[])
     test_custom_threadinfo();
     test_imagespec();
     test_get_cache_dimensions();
+    test_autotile_chunks();
 
     auto ic = ImageCache::create();
     Strutil::print("\n\n{}\n", ic->getstats(5));

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -44,11 +44,16 @@ static thread_local InputErrorMessages input_error_messages;
 static std::atomic_int64_t input_next_id(0);
 
 
+// How many scanlines does this file want to be read at a time? Formats that
+// store scanlines in indivisible groups -- TIFF strips, OpenEXR compressed
+// chunks -- say so in "oiio:RowsPerChunk". Reading in whole multiples of
+// that keeps us from decompressing the same group more than once. Formats
+// that don't say don't care, so pick 64 and move on.
 static int
-safe_rows_per_strip(const ImageSpec& spec)
+safe_rows_per_chunk(const ImageSpec& spec)
 {
-    int rps = spec.get_int_attribute("tiff:RowsPerStrip", 64);
-    return rps > 0 ? rps : 64;
+    int rpc = spec.get_int_attribute("oiio:RowsPerChunk", 0);
+    return rpc > 0 ? rpc : 64;
 }
 
 
@@ -390,7 +395,7 @@ ImageInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
         spec.copy_dimensions(m_spec);
         // For scanline files, we also need one piece of metadata
         if (!spec.tile_width)
-            rps = safe_rows_per_strip(m_spec);
+            rps = safe_rows_per_chunk(m_spec);
         // FIXME: does the above search of metadata have a significant cost?
     }
     if (spec.image_bytes() < 1) {
@@ -438,7 +443,7 @@ ImageInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
     // No such luck.  Read scanlines in chunks.
 
     // Split into reasonable chunks -- try to use around 64 MB, but
-    // round up to a multiple of the TIFF rows per strip (or 64).
+    // round up to a multiple of the file's rows per chunk (or 64).
     int chunk = std::max(1, (1 << 26) / int(spec.scanline_bytes(true)));
     chunk     = std::max(chunk, int(oiio_read_chunk));
     chunk     = round_to_multiple(chunk, rps);
@@ -1133,7 +1138,7 @@ ImageInput::read_image(int subimage, int miplevel, int chbegin, int chend,
         spec.copy_dimensions(m_spec);
         // For scanline files, we also need one piece of metadata
         if (!spec.tile_width)
-            rps = safe_rows_per_strip(m_spec);
+            rps = safe_rows_per_chunk(m_spec);
     }
     if (spec.image_bytes() < 1) {
         errorfmt("Invalid image size {} x {} ({} chans)", m_spec.width,
@@ -1183,7 +1188,7 @@ ImageInput::read_image(int subimage, int miplevel, int chbegin, int chend,
     } else {  // Scanline image -- rely on read_scanlines.
         // Split into reasonable chunks -- try to use around 64 MB or the
         // oiio_read_chunk value, which ever is bigger, but also round up to
-        // a multiple of the TIFF rows per strip (or 64).
+        // a multiple of the file's rows per chunk (or 64).
         int chunk = std::max(1, (1 << 26) / int(spec.scanline_bytes(true)));
         chunk     = std::max(chunk, int(oiio_read_chunk));
         chunk     = round_to_multiple(chunk, rps);
@@ -1226,7 +1231,7 @@ ImageInput::read_image(int subimage, int miplevel, int chbegin, int chend,
         spec.copy_dimensions(m_spec);
         // For scanline files, we also need one piece of metadata
         if (!spec.tile_width)
-            rps = safe_rows_per_strip(m_spec);
+            rps = safe_rows_per_chunk(m_spec);
     }
     if (spec.image_bytes() < 1) {
         errorfmt("Invalid image size {} x {} ({} chans)", m_spec.width,
@@ -1267,7 +1272,7 @@ ImageInput::read_image(int subimage, int miplevel, int chbegin, int chend,
     } else {  // Scanline image -- rely on read_scanlines.
         // Split into reasonable chunks -- try to use around 64 MB or the
         // oiio_read_chunk value, which ever is bigger, but also round up to
-        // a multiple of the TIFF rows per strip (or 64).
+        // a multiple of the file's rows per chunk (or 64).
         int chunk = std::max(1, (1 << 26) / int(spec.scanline_bytes(true)));
         chunk     = std::max(chunk, int(oiio_read_chunk));
         chunk     = round_to_multiple(chunk, rps);

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -28,11 +28,14 @@
 OIIO_NAMESPACE_3_1_BEGIN
 
 
+// How many scanlines does this file want to be written at a time? Formats
+// that store scanlines in indivisible groups say so in "oiio:RowsPerChunk"
+// when they open the file for writing. If the format doesn't say, pick 64.
 static int
-safe_rows_per_strip(const ImageSpec& spec)
+safe_rows_per_chunk(const ImageSpec& spec)
 {
-    int rps = spec.get_int_attribute("tiff:RowsPerStrip", 64);
-    return rps > 0 ? rps : 64;
+    int rpc = spec.get_int_attribute("oiio:RowsPerChunk", 0);
+    return rpc > 0 ? rpc : 64;
 }
 
 
@@ -690,8 +693,8 @@ ImageOutput::write_image(TypeDesc format, const void* data, stride_t xstride,
         }
     } else {  // Scanline image
         // Split into reasonable chunks -- try to use around 64 MB, but
-        // round up to a multiple of the TIFF rows per strip (or 64).
-        int rps   = safe_rows_per_strip(m_spec);
+        // round up to a multiple of the file's rows per chunk (or 64).
+        int rps   = safe_rows_per_chunk(m_spec);
         int chunk = std::max(1, (1 << 26) / int(m_spec.scanline_bytes(true)));
         chunk     = round_to_multiple(chunk, rps);
 

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -50,6 +50,15 @@ spin_mutex ImageCacheImpl::m_perthread_info_mutex;
 
 namespace {  // anonymous
 
+// When a file can only be read in whole groups of scanlines, we make our
+// fake tiles hold a whole number of those groups (see the autotile logic in
+// ImageCacheFile::open). This caps how big that is allowed to make one tile.
+// Beyond this, so few tiles fit in the cache that the extra eviction costs
+// more than the redundant decompression it saves, so we stop aligning and
+// keep the tiles small.
+static const imagesize_t max_autotile_bytes = 16 * 1024 * 1024;
+
+
 static thread_local tsl::robin_map<uint64_t, std::string> imcache_error_messages;
 static std::shared_ptr<ImageCache> shared_image_cache;
 static spin_mutex shared_image_cache_mutex;
@@ -864,13 +873,23 @@ ImageCacheFile::open(ImageCachePerThreadInfo* thread_info)
             if (tempspec.tile_width == 0 || tempspec.tile_height == 0) {
                 si.untiled   = true;
                 int autotile = imagecache().autotile();
-                // Special consideration: for TIFF files, there is extra
-                // efficiency from making our fake tiles correspond to the
-                // strips. (N.B.: for non-TIFF files, this attribute will
-                // be absent and thus default to 0.)
-                int rps = tempspec["tiff:RowsPerStrip"].get<int>();
-                if (rps > 1)
-                    autotile = round_to_multiple(std::max(autotile, 64), rps);
+                // Special consideration: a file that reads groups of
+                // scanlines at a time (TIFF strips, EXR compressed chunks) is
+                // better to break into "tiles" of a reasonable multiple of
+                // that number of scanlines, and full image width. (N.B.: for
+                // files that don't read in groups, this attribute will be
+                // absent and thus default to 0.)
+                int rps = tempspec["oiio:RowsPerChunk"].get<int>();
+                if (rps > 1) {
+                    int target  = std::max(autotile, 64);
+                    int aligned = round_to_multiple(target, rps);
+                    // But not if that makes one tile so big that too few of
+                    // them fit in the cache.
+                    autotile = (imagesize_t(aligned) * tempspec.scanline_bytes()
+                                <= max_autotile_bytes)
+                                   ? aligned
+                                   : target;
+                }
                 si.autotiled = (autotile != 0);
                 if (autotile) {
                     // Automatically make it appear as if it's tiled

--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -9,15 +9,19 @@
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>
+#include <OpenImageIO/memory.h>
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/string_view.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/typedesc.h>
 
+#include <mutex>
+
 #include <ImathBox.h>
 #include <OpenEXR/IexThrowErrnoExc.h>
 #include <OpenEXR/ImfChannelList.h>
+#include <OpenEXR/ImfCompression.h>
 #include <OpenEXR/ImfIO.h>
 #include <OpenEXR/ImfRgbaFile.h>
 
@@ -54,6 +58,118 @@ void split_name(string_view fullname, string_view& layer, string_view& suffix);
 bool channels_are_rgb(const ImageSpec& spec);
 
 }  // namespace pvt
+
+
+
+// Scanlines packed into each compressed chunk of a scanline file, by
+// compression scheme. Fixed by the EXR file format. Imf::numLinesInBuffer()
+// reports the same thing, but it lives in ImfCompressor.h, which OpenEXR only
+// began installing as a public header in 3.3 -- OIIO still supports back to
+// 3.1. An unrecognized scheme returns 1, which just disables the chunk cache.
+inline int
+exr_scanlines_per_chunk(Imf::Compression c)
+{
+    switch (c) {
+    case Imf::ZIP_COMPRESSION:
+    case Imf::PXR24_COMPRESSION: return 16;
+    case Imf::PIZ_COMPRESSION:
+    case Imf::B44_COMPRESSION:
+    case Imf::B44A_COMPRESSION:
+    case Imf::DWAA_COMPRESSION: return 32;
+    case Imf::DWAB_COMPRESSION: return 256;
+#ifdef IMF_HTJ2K256_COMPRESSION
+    case Imf::HTJ2K256_COMPRESSION: return 256;
+#endif
+#ifdef IMF_HTJ2K32_COMPRESSION
+    case Imf::HTJ2K32_COMPRESSION: return 32;
+#endif
+    default: return 1;
+    }
+}
+
+
+
+// Cache of one decoded scanline chunk, used by both EXR readers.
+//
+// Compression schemes pack many scanlines into each chunk -- 16 for zip, 32
+// for piz and dwaa, 256 for dwab -- and a chunk can only be decompressed
+// whole. A client that asks for less than a chunk at a time (one scanline,
+// say) would otherwise make the reader decode the same chunk over and over,
+// once per call. Keeping the chunk we decoded most recently turns that back
+// into one decode per chunk.
+//
+// The chunk is identified by which subimage, miplevel, scanline range, and
+// channel range it holds. Bytes per scanline follow from those, so they
+// aren't part of the key.
+class ExrChunkCache {
+public:
+    // If we hold the chunk [cbegin,cend) of this subimage, miplevel, and
+    // channel range, copy scanlines [ybegin,yend) of it to data and return
+    // true. Otherwise return false, and the caller must decode the chunk.
+    bool fetch(int subimage, int miplevel, int cbegin, int cend, int chbegin,
+               int chend, int ybegin, int yend, size_t scanlinebytes,
+               void* data)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_subimage != subimage || m_miplevel != miplevel
+            || m_ybegin != cbegin || m_yend != cend || m_chbegin != chbegin
+            || m_chend != chend)
+            return false;
+        // The key implies the size, so this should never differ. Check it
+        // anyway rather than trust a caller's arithmetic with a memcpy.
+        if (scanlinebytes * size_t(cend - cbegin) != m_pixels.size())
+            return false;
+        memcpy(data, m_pixels.data() + scanlinebytes * size_t(ybegin - cbegin),
+               scanlinebytes * size_t(yend - ybegin));
+        return true;
+    }
+
+    // Take ownership of a freshly decoded chunk (leaving `pixels` holding
+    // whatever the cache used to have), to serve the calls that follow.
+    // Chunks bigger than the size limit are dropped rather than retained: for
+    // the outsized images where one chunk is that big, the memory isn't worth
+    // the time it saves.
+    void adopt(int subimage, int miplevel, int cbegin, int cend, int chbegin,
+               int chend, default_init_vector<uint8_t>& pixels)
+    {
+        if (pixels.size() > max_bytes)
+            return;
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_pixels.swap(pixels);
+        m_subimage = subimage;
+        m_miplevel = miplevel;
+        m_ybegin   = cbegin;
+        m_yend     = cend;
+        m_chbegin  = chbegin;
+        m_chend    = chend;
+    }
+
+    void clear()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_pixels.clear();
+        m_pixels.shrink_to_fit();
+        m_subimage = -1;
+        m_miplevel = -1;
+    }
+
+    // Largest chunk we will hold onto, in bytes. This is per open file, so
+    // it bounds what an application holding many files at once can accrue.
+    // In practice the ImageCache never populates this cache at all, because
+    // it reads whole chunks (see the autotile logic in ImageCacheFile::open),
+    // and only a partial-chunk read stores anything.
+    static constexpr size_t max_bytes = 32 * 1024 * 1024;
+
+private:
+    std::mutex m_mutex;
+    default_init_vector<uint8_t> m_pixels;  ///< The decoded chunk
+    int m_subimage = -1;                    ///< Which subimage it's from
+    int m_miplevel = -1;                    ///< Which miplevel it's from
+    int m_ybegin   = 0;                     ///< First scanline held
+    int m_yend     = 0;                     ///< One past the last scanline
+    int m_chbegin  = 0;                     ///< First channel held
+    int m_chend    = 0;                     ///< One past the last channel
+};
 
 
 
@@ -183,6 +299,7 @@ private:
         bool cubeface;          ///< It's a cubeface environment map
         bool luminance_chroma;  ///< It's a luminance chroma image
         int nmiplevels;         ///< How many MIP levels are there?
+        int scansperchunk = 1;  ///< Scanlines in each compressed chunk
         Imath::Box2i top_datawindow;
         Imath::Box2i top_displaywindow;
         std::vector<Imf::PixelType> pixeltype;  ///< Imf pixel type for each chan
@@ -202,6 +319,7 @@ private:
             , cubeface(p.cubeface)
             , luminance_chroma(p.luminance_chroma)
             , nmiplevels(p.nmiplevels)
+            , scansperchunk(p.scansperchunk)
             , top_datawindow(p.top_datawindow)
             , top_displaywindow(p.top_displaywindow)
             , pixeltype(p.pixeltype)
@@ -230,9 +348,11 @@ private:
     int m_miplevel;                     ///< What MIP level are we looking at?
     std::vector<float> m_missingcolor;  ///< Color for missing tile/scanline
     std::string m_filename;             // filename, if known
+    ExrChunkCache m_chunkcache;
 
     void init()
     {
+        m_chunkcache.clear();
         m_input_stream             = NULL;
         m_input_multipart          = NULL;
         m_scanline_input_part      = NULL;
@@ -247,6 +367,12 @@ private:
         m_missingcolor.clear();
         m_filename.clear();
     }
+
+    // Read scanlines [ybegin,yend) out of the chunk [cbegin,cend), decoding
+    // that chunk if the cache doesn't already hold it.
+    bool read_cached_chunk(int subimage, int miplevel, int ybegin, int yend,
+                           int chbegin, int chend, int cbegin, int cend,
+                           size_t scanlinebytes, void* data);
 
     bool read_native_scanlines_individually(int subimage, int miplevel,
                                             int ybegin, int yend, int z,

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -456,6 +456,17 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         }
         if (comp)
             spec.attribute("compression", comp);
+        if (spec.tile_width == 0 && !spec.deep) {
+            // Scanline file: advertise how many scanlines are packed into
+            // each compressed chunk, so that callers can align their reads
+            // to whole chunks (see ImageInput::read_image, read_scanlines).
+            // Must match what exrinput_c.cpp reports for the same file, and
+            // that comes from the library, which says 1 for a deep scanline
+            // file no matter what its compression attribute claims.
+            scansperchunk = exr_scanlines_per_chunk(compressattr->value());
+            if (scansperchunk > 1)
+                spec.attribute("oiio:RowsPerChunk", scansperchunk);
+        }
     }
 
     for (auto hit = header->begin(); hit != header->end(); ++hit) {
@@ -1256,6 +1267,33 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
 }
 
 
+
+// Serve scanlines [ybegin,yend) out of the chunk [cbegin,cend), which is a
+// full chunk of the file, decoding that chunk if we don't already have it in
+// hand. Only called when the request is a proper subset of the chunk.
+bool
+OpenEXRInput::read_cached_chunk(int subimage, int miplevel, int ybegin,
+                                int yend, int chbegin, int chend, int cbegin,
+                                int cend, size_t scanlinebytes, void* data)
+{
+    if (m_chunkcache.fetch(subimage, miplevel, cbegin, cend, chbegin, chend,
+                           ybegin, yend, scanlinebytes, data))
+        return true;
+
+    // Cache miss. Decode the whole chunk. This recursive call asks for
+    // exactly one full chunk, so it won't come back here.
+    default_init_vector<uint8_t> chunk(scanlinebytes * size_t(cend - cbegin));
+    if (!read_native_scanlines(subimage, miplevel, cbegin, cend, 0, chbegin,
+                               chend, chunk.data()))
+        return false;
+    memcpy(data, chunk.data() + scanlinebytes * size_t(ybegin - cbegin),
+           scanlinebytes * size_t(yend - ybegin));
+    m_chunkcache.adopt(subimage, miplevel, cbegin, cend, chbegin, chend, chunk);
+    return true;
+}
+
+
+
 bool
 OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
                                     int yend, int z, int chbegin, int chend,
@@ -1278,6 +1316,65 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     size_t scanlinebytes = (size_t)m_spec.width * pixelbytes;
     char* buf            = (char*)data - m_spec.x * stride_t(pixelbytes)
                            - ybegin * stride_t(scanlinebytes);
+
+    int endy = m_spec.y + m_spec.height;
+    yend     = std::min(endy, yend);
+    if (ybegin >= yend)
+        return true;
+
+#if OPENEXR_CODED_VERSION >= 30302 && OPENEXR_CODED_VERSION < 30403
+    // These versions of the classic ScanLineInputFile keep one decoded
+    // ScanLineProcess alive across readPixels() calls, and only choose the
+    // pixel-unpack routine on the first of them. Later calls refresh the
+    // destination pointers but keep that routine, and the specialized
+    // routines write every channel through channels[0].decode_to_ptr. So
+    // after a full-channel read, a channel-subset read overruns the caller's
+    // buffer (or writes through a null pointer, if channel 0 was one of the
+    // ones dropped). Introduced in 3.3.2 and 3.4.0 by OpenEXR PR 1899, fixed
+    // in 3.4.3 by PR 2150, which resets the cached process in
+    // setFrameBuffer(); never fixed on the 3.3 branch. Work around it by
+    // reading every channel into a scratch buffer -- the layout the cached
+    // routine expects -- and copying out the range that was asked for.
+    if ((chbegin != 0 || chend != m_spec.nchannels) && !part.luminance_chroma) {
+        size_t fullpixelbytes = m_spec.pixel_bytes(true);
+        size_t fullscanbytes  = size_t(m_spec.width) * fullpixelbytes;
+        default_init_vector<uint8_t> scratch(fullscanbytes
+                                             * size_t(yend - ybegin));
+        if (!read_native_scanlines(subimage, miplevel, ybegin, yend, z, 0,
+                                   m_spec.nchannels, scratch.data()))
+            return false;
+        size_t choff = m_spec.pixel_bytes(0, chbegin, true);
+        for (int y = ybegin; y < yend; ++y) {
+            const uint8_t* src = scratch.data()
+                                 + size_t(y - ybegin) * fullscanbytes + choff;
+            char* dst = (char*)data + size_t(y - ybegin) * scanlinebytes;
+            for (int x = 0; x < m_spec.width; ++x) {
+                memcpy(dst, src, pixelbytes);
+                src += fullpixelbytes;
+                dst += pixelbytes;
+            }
+        }
+        return true;
+    }
+#endif
+
+    // If the request is only part of a single chunk, go through the chunk
+    // cache: decoding a whole chunk to hand back a few of its scanlines is
+    // expensive, and a client that reads a scanline (or any other sub-chunk
+    // swath) at a time will ask for the rest of that chunk next. (The
+    // library has a stash of its own, but it drops it every time we set the
+    // frame buffer, which we must do on every read.)
+    if (part.scansperchunk > 1 && !part.luminance_chroma
+        && ybegin >= m_spec.y) {
+        int ychunkstart = m_spec.y
+                          + round_down_to_multiple(ybegin - m_spec.y,
+                                                   part.scansperchunk);
+        int ychunkend   = std::min(ychunkstart + part.scansperchunk, endy);
+        if (yend <= ychunkend && (ybegin > ychunkstart || yend < ychunkend))
+            return read_cached_chunk(subimage, miplevel, ybegin, yend, chbegin,
+                                     chend, ychunkstart, ychunkend,
+                                     scanlinebytes, data);
+    }
 
     try {
         if (part.luminance_chroma) {

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -156,6 +156,9 @@ public:
 
 private:
     const ImageSpec& init_part(int subimage, int miplevel);
+    bool read_cached_chunk(int subimage, int miplevel, int ybegin, int yend,
+                           int chbegin, int chend, int cbegin, int cend,
+                           size_t scanlinebytes, void* data);
     struct PartInfo {
         std::atomic_bool initialized;
         ImageSpec spec;
@@ -208,6 +211,8 @@ private:
     exr_context_t m_exr_context = nullptr;
     oiioexr_filebuf_struct m_userdata;
 
+    ExrChunkCache m_chunkcache;
+
     std::unique_ptr<Filesystem::IOProxy> m_local_io;
     int m_nsubimages;                   ///< How many subimages are there?
     std::vector<float> m_missingcolor;  ///< Color for missing tile/scanline
@@ -221,6 +226,7 @@ private:
         m_local_io.reset();
         m_missingcolor.clear();
         m_filename.clear();
+        m_chunkcache.clear();
     }
 
     bool valid_file_or_proxy(const std::string& filename,
@@ -584,6 +590,17 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
         }
         if (comp)
             spec.attribute("compression", comp);
+    }
+
+    if (spec.tile_width == 0) {
+        // Scanline file: advertise how many scanlines are packed into each
+        // compressed chunk, so that callers can align their reads to whole
+        // chunks (see ImageInput::read_image, read_scanlines).
+        int32_t scansperchunk = 1;
+        if (exr_get_scanlines_per_chunk(ctxt, subimage, &scansperchunk)
+                == EXR_ERR_SUCCESS
+            && scansperchunk > 1)
+            spec.attribute("oiio:RowsPerChunk", scansperchunk);
     }
 
     int32_t attrcount = 0;
@@ -1253,6 +1270,33 @@ OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
 
 
 
+// Serve scanlines [ybegin,yend) out of the chunk [cbegin,cend), which is a
+// full chunk of the file, decoding that chunk if we don't already have it in
+// hand. Only called when the request is a proper subset of the chunk.
+bool
+OpenEXRCoreInput::read_cached_chunk(int subimage, int miplevel, int ybegin,
+                                    int yend, int chbegin, int chend,
+                                    int cbegin, int cend, size_t scanlinebytes,
+                                    void* data)
+{
+    if (m_chunkcache.fetch(subimage, miplevel, cbegin, cend, chbegin, chend,
+                           ybegin, yend, scanlinebytes, data))
+        return true;
+
+    // Cache miss. Decode the whole chunk. This recursive call asks for
+    // exactly one full chunk, so it won't come back here.
+    default_init_vector<uint8_t> chunk(scanlinebytes * size_t(cend - cbegin));
+    if (!read_native_scanlines(subimage, miplevel, cbegin, cend, 0, chbegin,
+                               chend, chunk.data()))
+        return false;
+    memcpy(data, chunk.data() + scanlinebytes * size_t(ybegin - cbegin),
+           scanlinebytes * size_t(yend - ybegin));
+    m_chunkcache.adopt(subimage, miplevel, cbegin, cend, chbegin, chend, chunk);
+    return true;
+}
+
+
+
 bool
 OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
                                         int yend, int /*z*/, int chbegin,
@@ -1284,10 +1328,26 @@ OpenEXRCoreInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
            m_userdata.m_io->filename(), subimage, miplevel, ybegin, yend,
            yend - ybegin, chbegin, chend - 1, pixelbytes, scanlinebytes,
            scansperchunk);
-    int endy        = spec.y + spec.height;
-    yend            = std::min(endy, yend);
+    int endy = spec.y + spec.height;
+    yend     = std::min(endy, yend);
+    if (ybegin >= yend)
+        return true;
+
     int ychunkstart = spec.y
                       + round_down_to_multiple(ybegin - spec.y, scansperchunk);
+
+    // If the request is only part of a single chunk, go through the chunk
+    // cache: decoding a whole chunk to hand back a few of its scanlines is
+    // expensive, and a client that reads a scanline (or any other sub-chunk
+    // swath) at a time will ask for the rest of that chunk next.
+    if (scansperchunk > 1 && ybegin >= spec.y) {
+        int ychunkend = std::min(ychunkstart + scansperchunk, endy);
+        if (yend <= ychunkend && (ybegin > ychunkstart || yend < ychunkend))
+            return read_cached_chunk(subimage, miplevel, ybegin, yend, chbegin,
+                                     chend, ychunkstart, ychunkend,
+                                     scanlinebytes, data);
+    }
+
     std::atomic<bool> ok(true);
     parallel_for_chunked(
         ychunkstart, yend, scansperchunk,

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1053,6 +1053,19 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     for (const auto& p : spec.extra_attribs)
         put_parameter(p.name().string(), p.type(), p.data(), header);
 
+    // Now that the header's compression is settled, say how many scanlines
+    // are packed into each of the chunks we are about to write, so that
+    // ImageOutput::write_image can hand us whole chunks. A value carried in
+    // from some other file says nothing about this one, so erase it either
+    // way. This has to come after the loop above -- that is what would have
+    // written it into the file, and this is only a hint to our own caller.
+    spec.erase_attribute("oiio:RowsPerChunk");
+    if (spec.tile_width == 0) {
+        int scansperchunk = exr_scanlines_per_chunk(header.compression());
+        if (scansperchunk > 1)
+            spec.attribute("oiio:RowsPerChunk", scansperchunk);
+    }
+
     // Multi-part EXR files required to have a name. Make one up if not
     // supplied.
     if (m_nsubimages > 1 && !header.hasName()) {

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1317,6 +1317,8 @@ TIFFInput::readspec(bool read_meta)
         TIFFGetField(m_tif, TIFFTAG_ROWSPERSTRIP, &m_rowsperstrip);
         if (m_rowsperstrip > 0) {
             // Only set the attrib if a legit value was found in the file
+            if (m_rowsperstrip > 1)
+                m_spec.attribute("oiio:RowsPerChunk", m_rowsperstrip);
             m_spec.attribute("tiff:RowsPerStrip", m_rowsperstrip);
             m_rowsperstrip = std::min(m_rowsperstrip, m_spec.height);
         } else {

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -923,6 +923,16 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
     for (const auto& p : m_spec.extra_attribs)
         put_parameter(p);
 
+    // Now that m_rowsperstrip has stopped moving -- put_parameter above
+    // honors a "tiff:RowsPerStrip" request -- say how many scanlines are in
+    // each of the strips we are about to write, so that
+    // ImageOutput::write_image can hand us whole strips. A value carried in
+    // from some other file says nothing about this one, so erase it either
+    // way.
+    m_spec.erase_attribute("oiio:RowsPerChunk");
+    if (!m_spec.tile_width && m_rowsperstrip > 1)
+        m_spec.attribute("oiio:RowsPerChunk", m_rowsperstrip);
+
     if (m_spec.get_int_attribute("tiff:write_iptc")) {
         // Enable IPTC block writing only if "tiff_write_iptc" hint is explicitly
         // enabled. This was to avoid writing bad IPTC blocks, but I think that

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -6,6 +6,7 @@ out.exr              :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading out2.exr
@@ -17,6 +18,7 @@ out2.exr             :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "Aimg"
     oiio:subimages: 1
     openexr:chunkCount: 4

--- a/testsuite/iinfo/ref/out-fmt6.txt
+++ b/testsuite/iinfo/ref/out-fmt6.txt
@@ -147,6 +147,7 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+src/tiny-az.exr :     oiio:RowsPerChunk: 16
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     openexr:lineOrder: "increasingY"
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
@@ -174,6 +175,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000
@@ -360,6 +362,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -383,6 +386,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -406,6 +410,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/iinfo/ref/out.txt
+++ b/testsuite/iinfo/ref/out.txt
@@ -147,6 +147,7 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+src/tiny-az.exr :     oiio:RowsPerChunk: 16
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     openexr:lineOrder: "increasingY"
 src/tiny-az.exr :     Stats Min: 0.250000 0.500000 0.750000 (float)
@@ -174,6 +175,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Pixel (2, 2): 0.250000000 0.500000000 0.750000000
@@ -347,6 +349,7 @@ Reading tmp.tif
 <attrib name="tiff:PlanarConfiguration" type="int">1</attrib>
 <attrib name="planarconfig" type="string">contig</attrib>
 <attrib name="compression" type="string">zip</attrib>
+<attrib name="oiio:RowsPerChunk" type="int">32</attrib>
 <attrib name="tiff:RowsPerStrip" type="int">32</attrib>
 </ImageSpec>
 src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
@@ -360,6 +363,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -383,6 +387,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -406,6 +411,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/invalid-rps-metadata/ref/out.txt
+++ b/testsuite/invalid-rps-metadata/ref/out.txt
@@ -8,6 +8,7 @@ negrps.tif           :    1 x    1, 3 channel, float tiff
     planarconfig: "contig"
     Software: "OpenImageIO 3.2.0.2dev : 2C50DDDC920616B428C03D5F6786B396201DAF23"
     oiio:BitsPerSample: 32
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/maketx/ref/out-alt.txt
+++ b/testsuite/maketx/ref/out-alt.txt
@@ -378,6 +378,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/maketx/ref/out-macarm.txt
+++ b/testsuite/maketx/ref/out-macarm.txt
@@ -378,6 +378,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -378,6 +378,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/misnamed-file/ref/out.txt
+++ b/testsuite/misnamed-file/ref/out.txt
@@ -12,6 +12,7 @@ misnamed.exr         : 1000 x 1000, 4 channel, uint8 tiff
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 8
     tiff:Compression: 8
     tiff:PageNumber: 0, 1
     tiff:PhotometricInterpretation: 2

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -92,6 +92,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -105,6 +106,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -120,6 +122,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -132,6 +135,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -92,6 +92,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -105,6 +106,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -120,6 +122,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
     openexr:chunkCount: 4
@@ -132,6 +135,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
     openexr:chunkCount: 4

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -320,6 +320,7 @@ Meta native:  128 x   96, 3 channel, uint8 tiff
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -93,6 +93,7 @@ green.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-replace.exr
@@ -108,6 +109,7 @@ greenmeta-replace.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge.exr
@@ -123,6 +125,7 @@ greenmeta-merge.exr  :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge-override.exr
@@ -138,6 +141,7 @@ greenmeta-merge-override.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge-camera.exr
@@ -151,6 +155,7 @@ greenmeta-merge-camera.exr :   64 x   64, 3 channel, half openexr
     screenWindowWidth: 1
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading greenmeta-merge-2.exr
@@ -169,6 +174,7 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 3
     openexr:chunkCount: 4
@@ -186,6 +192,7 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 3
     openexr:chunkCount: 4
@@ -203,6 +210,7 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage02"
     oiio:subimages: 3
     openexr:chunkCount: 4
@@ -216,6 +224,7 @@ nometamerge.exr      :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading metamerge.exr
@@ -228,6 +237,7 @@ metamerge.exr        :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Testing -o with no image

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -9,6 +9,7 @@ src/bad.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -28,6 +29,7 @@ black.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -47,6 +49,7 @@ box3.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     Stats Min: 0.000000 0.000000 0.000000 (float)

--- a/testsuite/oiiotool-maketx/ref/out-macarm.txt
+++ b/testsuite/oiiotool-maketx/ref/out-macarm.txt
@@ -368,6 +368,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -321,6 +321,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/oiiotool-maketx/ref/out-win.txt
+++ b/testsuite/oiiotool-maketx/ref/out-win.txt
@@ -368,6 +368,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -368,6 +368,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/oiiotool-subimage/ref/out.txt
+++ b/testsuite/oiiotool-subimage/ref/out.txt
@@ -18,6 +18,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "layerA"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -31,6 +32,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "layerB"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -44,6 +46,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "layerC"
     oiio:subimages: 4
     openexr:chunkCount: 4
@@ -57,6 +60,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimagename: "layerD"
     oiio:subimages: 4
     openexr:chunkCount: 4

--- a/testsuite/oiiotool-thumbnail-set/ref/out.txt
+++ b/testsuite/oiiotool-thumbnail-set/ref/out.txt
@@ -22,6 +22,7 @@ no_thumb.tif         :  512 x  384, 3 channel, uint8 tiff
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -40,6 +40,7 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 dumpdata:

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -7,6 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Chromaticities/Rec709.exr" and "Rec709.exr"
@@ -21,6 +22,7 @@ Reading ../openexr-images/Chromaticities/XYZ.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Chromaticities/XYZ.exr" and "XYZ.exr"

--- a/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
@@ -7,6 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -22,6 +23,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -37,6 +39,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -51,6 +54,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -68,6 +72,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     thumbnail_height: 66
     thumbnail_nchannels: 4
     thumbnail_width: 100
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -85,6 +90,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     thumbnail_height: 80
     thumbnail_nchannels: 4
     thumbnail_width: 80
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1

--- a/testsuite/openexr-luminance-chroma/ref/out.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out.txt
@@ -7,6 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -22,6 +23,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -37,6 +39,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -51,6 +54,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -68,6 +72,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     thumbnail_height: 66
     thumbnail_nchannels: 4
     thumbnail_width: 100
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1
@@ -85,6 +90,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     thumbnail_height: 80
     thumbnail_nchannels: 4
     thumbnail_width: 80
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:luminancechroma: 1

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -246,6 +246,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesSphere.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"
@@ -263,6 +264,7 @@ Reading ../openexr-images/MultiView/Adjuster.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Adjuster.exr" and "Adjuster.exr"
@@ -279,6 +281,7 @@ Reading ../openexr-images/MultiView/Balls.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Balls.exr" and "Balls.exr"
@@ -299,6 +302,7 @@ Reading ../openexr-images/MultiView/Fog.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/Fog.exr" and "Fog.exr"
@@ -341,6 +345,7 @@ Reading ../openexr-images/MultiView/LosPadres.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/MultiView/LosPadres.exr" and "LosPadres.exr"

--- a/testsuite/openexr-scanlines/ref/out.txt
+++ b/testsuite/openexr-scanlines/ref/out.txt
@@ -1,0 +1,6 @@
+none.exr scanline reads match: PASS
+zips.exr scanline reads match: PASS
+zip.exr scanline reads match: PASS
+piz.exr scanline reads match: PASS
+dwab.exr scanline reads match: PASS
+offset.exr scanline reads match: PASS

--- a/testsuite/openexr-scanlines/run.py
+++ b/testsuite/openexr-scanlines/run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+############################################################################
+# Reading an EXR a few scanlines at a time must return the same pixels as
+# reading the whole image, no matter how the requested swaths line up with
+# the compressed chunks of the file (which hold 1, 16, 32, or 256 scanlines
+# depending on the compression).
+############################################################################
+
+redirect = " >> out.txt 2>&1 "
+
+# Test images: a few compressions with different scanlines per chunk, and
+# one with a data window that doesn't start at y=0.
+for comp in ["none", "zips", "zip", "piz", "dwab"]:
+    command += oiiotool("--pattern noise:type=uniform:seed=1 41x300 4 "
+                        + "--compression " + comp + " -d half -o " + comp + ".exr")
+command += oiiotool("--pattern noise:type=uniform:seed=1 41x300 4 --origin -7-13 "
+                    + "--compression zip -d half -o offset.exr")
+
+command += pythonbin + " src/test_scanlines.py >> out.txt 2>&1 ;"
+
+outputs = ["out.txt"]

--- a/testsuite/openexr-scanlines/src/test_scanlines.py
+++ b/testsuite/openexr-scanlines/src/test_scanlines.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+# Read each test file scanline by scanline, and in swaths of assorted sizes
+# and alignments, comparing everything against a single read of the whole
+# image.
+
+import OpenImageIO as oiio
+
+def scanline_reads_match(filename):
+    inp = oiio.ImageInput.open(filename)
+    if inp is None:
+        print("Could not open", filename, ":", oiio.geterror())
+        return False
+    spec = inp.spec()
+    y0, height, nchans = spec.y, spec.height, spec.nchannels
+    full = inp.read_image(oiio.HALF)
+    if full is None:
+        print("Could not read", filename, ":", inp.geterror())
+        return False
+    full = full.reshape(height, spec.width, nchans)
+    ok = True
+    for step in [1, 3, 7, 16, 17, 32, 64, 256]:
+        for start in [0, 1, 15, 31]:
+            y = y0 + start
+            while y < y0 + height:
+                yend = min(y + step, y0 + height)
+                pixels = inp.read_scanlines(0, 0, y, yend, 0, 0, nchans, oiio.HALF)
+                if pixels is None:
+                    print("read_scanlines({},{}) of {} failed: {}".format(
+                          y, yend, filename, inp.geterror()))
+                    return False
+                pixels = pixels.reshape(yend - y, spec.width, nchans)
+                if not (pixels == full[y - y0 : yend - y0]).all():
+                    print("{}: wrong pixels for scanlines {}-{} (step {})".format(
+                          filename, y, yend, step))
+                    ok = False
+                y = yend
+    # One scanline at a time, of channel subsets
+    for (chbegin, chend) in [(0, 1), (1, 3), (3, 4)]:
+        for y in range(y0, y0 + height):
+            pixels = inp.read_scanlines(0, 0, y, y + 1, 0, chbegin, chend, oiio.HALF)
+            pixels = pixels.reshape(spec.width, chend - chbegin)
+            if not (pixels == full[y - y0, :, chbegin:chend]).all():
+                print("{}: wrong pixels for scanline {}, channels {}-{}".format(
+                      filename, y, chbegin, chend))
+                ok = False
+                break
+    inp.close()
+    return ok
+
+
+for filename in ["none.exr", "zips.exr", "zip.exr", "piz.exr", "dwab.exr",
+                 "offset.exr"]:
+    print(filename, "scanline reads match:",
+          "PASS" if scanline_reads_match(filename) else "FAIL")

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -17,6 +17,7 @@ Reading ../openexr-images/ScanLines/Blobbies.exr
     thumbnail_width: 100
     utcOffset: 28800
     whiteLuminance: 50
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "decreasingY"
 Comparing "../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
@@ -34,6 +35,7 @@ Reading ../openexr-images/ScanLines/CandleGlass.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/CandleGlass.exr" and "CandleGlass.exr"
@@ -47,6 +49,7 @@ Reading ../openexr-images/ScanLines/Cannon.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
@@ -59,6 +62,7 @@ Reading ../openexr-images/ScanLines/Desk.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Desk.exr" and "Desk.exr"
@@ -81,6 +85,7 @@ Reading ../openexr-images/ScanLines/MtTamWest.exr
     thumbnail_nchannels: 4
     thumbnail_width: 100
     utcOffset: 25200
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/MtTamWest.exr" and "MtTamWest.exr"
@@ -98,6 +103,7 @@ Reading ../openexr-images/ScanLines/PrismsLenses.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/PrismsLenses.exr" and "PrismsLenses.exr"
@@ -116,6 +122,7 @@ Reading ../openexr-images/ScanLines/StillLife.exr
     thumbnail_nchannels: 4
     thumbnail_width: 100
     utcOffset: 25200
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/StillLife.exr" and "StillLife.exr"
@@ -137,6 +144,7 @@ Reading ../openexr-images/ScanLines/Tree.exr
     thumbnail_width: 100
     utcOffset: 25200
     whiteLuminance: 621
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/ScanLines/Tree.exr" and "Tree.exr"
@@ -149,6 +157,7 @@ Reading ../openexr-images/TestImages/AllHalfValues.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/AllHalfValues.exr" and "AllHalfValues.exr"
@@ -161,6 +170,7 @@ Reading ../openexr-images/TestImages/BrightRings.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/BrightRings.exr" and "BrightRings.exr"
@@ -173,6 +183,7 @@ Reading ../openexr-images/TestImages/BrightRingsNanInf.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/BrightRingsNanInf.exr" and "BrightRingsNanInf.exr"
@@ -185,6 +196,7 @@ Reading ../openexr-images/TestImages/GammaChart.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/GammaChart.exr" and "GammaChart.exr"
@@ -197,6 +209,7 @@ Reading ../openexr-images/TestImages/GrayRampsDiagonal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/GrayRampsDiagonal.exr" and "GrayRampsDiagonal.exr"
@@ -209,6 +222,7 @@ Reading ../openexr-images/TestImages/GrayRampsHorizontal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/GrayRampsHorizontal.exr" and "GrayRampsHorizontal.exr"
@@ -221,6 +235,7 @@ Reading ../openexr-images/TestImages/RgbRampsDiagonal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/RgbRampsDiagonal.exr" and "RgbRampsDiagonal.exr"
@@ -233,6 +248,7 @@ Reading ../openexr-images/TestImages/SquaresSwirls.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/SquaresSwirls.exr" and "SquaresSwirls.exr"
@@ -246,6 +262,7 @@ Reading ../openexr-images/TestImages/WideColorGamut.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/WideColorGamut.exr" and "WideColorGamut.exr"
@@ -258,6 +275,7 @@ Reading ../openexr-images/TestImages/WideFloatRange.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/TestImages/WideFloatRange.exr" and "WideFloatRange.exr"
@@ -360,6 +378,7 @@ negoverscan.exr      :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 acesImageContainerFlag for relaxed-out.exr is (1)
@@ -400,6 +419,7 @@ color_interop_id_scene_linear.exr :    4 x    4, 3 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_ap1_scene"
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading color_interop_id_linear_adobergb.exr
@@ -412,6 +432,7 @@ color_interop_id_linear_adobergb.exr :    4 x    4, 3 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_adobergb_scene"
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading color_interop_id_unknown.exr
@@ -422,5 +443,6 @@ color_interop_id_unknown.exr :    4 x    4, 3 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-window/ref/out.txt
+++ b/testsuite/openexr-window/ref/out.txt
@@ -6,6 +6,7 @@ Reading ../openexr-images/DisplayWindow/t01.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t01.exr" and "t01.exr"
@@ -20,6 +21,7 @@ Reading ../openexr-images/DisplayWindow/t02.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t02.exr" and "t02.exr"
@@ -34,6 +36,7 @@ Reading ../openexr-images/DisplayWindow/t03.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t03.exr" and "t03.exr"
@@ -48,6 +51,7 @@ Reading ../openexr-images/DisplayWindow/t04.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t04.exr" and "t04.exr"
@@ -62,6 +66,7 @@ Reading ../openexr-images/DisplayWindow/t05.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t05.exr" and "t05.exr"
@@ -76,6 +81,7 @@ Reading ../openexr-images/DisplayWindow/t06.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t06.exr" and "t06.exr"
@@ -90,6 +96,7 @@ Reading ../openexr-images/DisplayWindow/t07.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t07.exr" and "t07.exr"
@@ -105,6 +112,7 @@ Reading ../openexr-images/DisplayWindow/t08.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t08.exr" and "t08.exr"
@@ -119,6 +127,7 @@ Reading ../openexr-images/DisplayWindow/t09.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t09.exr" and "t09.exr"
@@ -133,6 +142,7 @@ Reading ../openexr-images/DisplayWindow/t10.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t10.exr" and "t10.exr"
@@ -147,6 +157,7 @@ Reading ../openexr-images/DisplayWindow/t11.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t11.exr" and "t11.exr"
@@ -161,6 +172,7 @@ Reading ../openexr-images/DisplayWindow/t12.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t12.exr" and "t12.exr"
@@ -175,6 +187,7 @@ Reading ../openexr-images/DisplayWindow/t13.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t13.exr" and "t13.exr"
@@ -189,6 +202,7 @@ Reading ../openexr-images/DisplayWindow/t14.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t14.exr" and "t14.exr"
@@ -203,6 +217,7 @@ Reading ../openexr-images/DisplayWindow/t15.exr
     PixelAspectRatio: 1.5
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t15.exr" and "t15.exr"
@@ -217,6 +232,7 @@ Reading ../openexr-images/DisplayWindow/t16.exr
     PixelAspectRatio: 0.666667
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/DisplayWindow/t16.exr" and "t16.exr"

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -77,5 +77,6 @@ rat2.exr             :   64 x   64, 3 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/tiff-depths/ref/out-linuxarm.txt
+++ b/testsuite/tiff-depths/ref/out-linuxarm.txt
@@ -12,6 +12,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -36,6 +37,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -60,6 +62,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-06.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 6
+    oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -84,6 +87,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -108,6 +112,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -132,6 +137,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -156,6 +162,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -180,6 +187,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -204,6 +212,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -228,6 +237,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -252,6 +262,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 431
     tiff:BitsPerSample: 2
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -278,6 +289,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 221
     tiff:BitsPerSample: 4
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -304,6 +316,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 3
@@ -329,6 +342,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 3
@@ -354,6 +368,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -378,6 +393,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -402,6 +418,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -426,6 +443,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:RowsPerChunk: 29
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -450,6 +468,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:RowsPerChunk: 24
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -474,6 +493,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:RowsPerChunk: 21
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -498,6 +518,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 18
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -522,6 +543,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:RowsPerChunk: 12
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -546,6 +568,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:RowsPerChunk: 9
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -570,6 +593,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -594,6 +618,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -618,6 +643,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -642,6 +668,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -666,6 +693,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -690,6 +718,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -714,6 +743,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -738,6 +768,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -762,6 +793,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -786,6 +818,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5
@@ -811,6 +844,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 14
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5
@@ -836,6 +870,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5
@@ -861,6 +896,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -12,6 +12,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -36,6 +37,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -60,6 +62,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-06.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 6
+    oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -84,6 +87,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -108,6 +112,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -132,6 +137,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -156,6 +162,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -180,6 +187,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -204,6 +212,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -228,6 +237,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
@@ -252,6 +262,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 431
     tiff:BitsPerSample: 2
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -278,6 +289,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 221
     tiff:BitsPerSample: 4
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -304,6 +316,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 3
@@ -329,6 +342,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 3
@@ -354,6 +368,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -378,6 +393,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -402,6 +418,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -426,6 +443,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:RowsPerChunk: 29
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -450,6 +468,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:RowsPerChunk: 24
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -474,6 +493,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:RowsPerChunk: 21
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -498,6 +518,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 18
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -522,6 +543,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:RowsPerChunk: 12
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -546,6 +568,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:RowsPerChunk: 9
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -570,6 +593,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -594,6 +618,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -618,6 +643,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -642,6 +668,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -666,6 +693,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -690,6 +718,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -714,6 +743,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -738,6 +768,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -762,6 +793,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -786,6 +818,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5
@@ -811,6 +844,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 14
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5
@@ -836,6 +870,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 112
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5
@@ -861,6 +896,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 56
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff403-b.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff403-b.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -35,6 +36,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -53,6 +55,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff403-c.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff403-c.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -35,6 +36,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -53,6 +55,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff403.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff403.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -35,6 +36,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -53,6 +55,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff409.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff409.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -35,6 +36,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -53,6 +55,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff410.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff410.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -35,6 +36,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -53,6 +55,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff430.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff430.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -50,6 +51,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -68,6 +70,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff470-b.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff470-b.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -50,6 +51,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -68,6 +70,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff470-c.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff470-c.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -50,6 +51,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -68,6 +70,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out-libtiff470.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff470.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -50,6 +51,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -68,6 +70,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-misc/ref/out.txt
+++ b/testsuite/tiff-misc/ref/out.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -35,6 +36,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -53,6 +55,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 5

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -22,6 +23,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -87,6 +89,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -105,6 +108,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 25
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -158,6 +162,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 3
@@ -177,6 +182,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32844
@@ -196,6 +202,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
     tiff:PhotometricInterpretation: 32845
@@ -215,6 +222,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32845
@@ -264,6 +272,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -291,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
     tiff:PhotometricInterpretation: 6
@@ -309,6 +319,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -326,6 +337,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 6
@@ -347,6 +359,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6

--- a/testsuite/tiff-suite/ref/out-alt2.txt
+++ b/testsuite/tiff-suite/ref/out-alt2.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -22,6 +23,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -87,6 +89,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -105,6 +108,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 120
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -158,6 +162,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 3
@@ -177,6 +182,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32844
@@ -196,6 +202,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
     tiff:PhotometricInterpretation: 32845
@@ -215,6 +222,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32845
@@ -264,6 +272,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -291,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
     tiff:PhotometricInterpretation: 6
@@ -309,6 +319,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -326,6 +337,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 6
@@ -347,6 +359,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -22,6 +23,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -87,6 +89,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -105,6 +108,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 25
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -158,6 +162,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 3
@@ -177,6 +182,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32844
@@ -196,6 +202,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
     tiff:PhotometricInterpretation: 32845
@@ -215,6 +222,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32845
@@ -264,6 +272,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -291,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
     tiff:PhotometricInterpretation: 6
@@ -309,6 +319,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -326,6 +337,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 6
@@ -347,6 +359,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6

--- a/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -22,6 +23,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -87,6 +89,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -105,6 +108,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 120
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -158,6 +162,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 3
@@ -177,6 +182,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32844
@@ -196,6 +202,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
     tiff:PhotometricInterpretation: 32845
@@ -215,6 +222,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32845
@@ -264,6 +272,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -291,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
     tiff:PhotometricInterpretation: 6
@@ -309,6 +319,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -326,6 +337,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 6
@@ -347,6 +359,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
@@ -22,6 +23,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -87,6 +89,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -105,6 +108,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 25
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 6
@@ -158,6 +162,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 3
@@ -177,6 +182,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32844
@@ -196,6 +202,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
     tiff:PhotometricInterpretation: 32845
@@ -215,6 +222,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
     tiff:PhotometricInterpretation: 32845
@@ -264,6 +272,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -291,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
     tiff:PhotometricInterpretation: 6
@@ -309,6 +319,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -326,6 +337,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 6
@@ -347,6 +359,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6


### PR DESCRIPTION
TL;DR: Issue #5379 alerted us to the fact that on certain versions of OpenEXR, performance was horrible when reading one scanline at a time, because entire chunks are reread and decoded each time. This PR solves this with a 1-chunk cache in OIIO's openexr readers.

Fixes #5379

Summary of before and after, using imagespeed_test on a 4k exr (on my MacBookPro M4):

| Method                            | time (s) | rate  |    | AFTER |       |
| --------------------------------- | -------- | ----- | -- | ----- | ----- |
| read_image                        |  0.03s   | 318.2 |    | 0.03s | 330.5 |
| **read_scanline (1 at a time)**   | 31.15s   |   0.3 |    | 0.12s |  71.7 |
| read_scanlines (64 at a time)     |  0.51s   |  17.5 |    | 0.12s |  71.6 |
| ImageBuf read                     |  0.03s   | 303.1 |    | 0.03s | 325.0 |
| ImageCache get_pixels             |  0.05s   | 183.2 |    | 0.14s |  64.9 |
| ImageCache get_pixels (autotile)  |  0.52s   |  17.1 |    | 0.13s |  66.5 |

Longer explanation:

EXR compression packs many scanlines into each chunk (16 for zip, 32 for piz and dwaa, 256 for dwab), and a chunk can only be decompressed whole. A client reading fewer scanlines than that at a time made us decode the same chunk again on every call. Reading a 4096x2160 zip file one scanline at a time was orders of magnitude slower, see table above.

Give both readers a one-chunk cache. A request lying strictly inside a single chunk is served from it, decoding the whole chunk first if we don't have it. Lookup and store are under a mutex, the decode is not. Chunks over 32 MB are decoded but not retained. The key is subimage, miplevel, chunk and channel range.  We cannot lean on the OpenEXR library here: the C core keeps no such stash, and the C++ layer's (OpenEXR PR 1899) is dropped by setFrameBuffer(), which we must call before every readPixels() because the destination moves.

One scanline at a time is now 100x faster, the same speed as reading 64 scanlines at a time, which is also made 4x faster by this patch. It's still most efficient to read the whole image, which is 4x faster still. (These are multithreaded benchmarks, so there is threading benefit to doing more chunk decodes in parallel, that's probably the remaining difference between 64 scanline reads and whole-image reads.)

Reading in whole chunks matters to more than EXR, so name the idea: "oiio:RowsPerChunk", set by any format storing scanlines in indivisible groups. TIFF has advertised "tiff:RowsPerStrip" for years, and read_image and the ImageCache both looked for that one name; they now consult the general one, and the TIFF and EXR readers and writers set it to describe the file at hand. It is a hint only, never written into a file.

That changes the ImageCache for untiled EXR files, which now get the treatment untiled TIFFs have had since 2020: always autotiled, in full-width tiles holding a whole number of chunks, even when autotile is 0. Treating such a file as one image-sized tile decompresses the whole image on every cache miss, which collapses once several of them no longer fit in the cache together. Tiles are capped at 16 MB, past which we stop aligning rather than let too few tiles fit.

You can see from the stats in the table, ImageCache with tiled files is still very efficient; reading via ImageCache is as fast as reading in 64 row blocks via raw ImageInput::read_scanlines. Though we will note that reading through the ImageCache without autotile has slowed down somewhat compared to before, but that's not a common use case for scanline files unless they are really big.

A new openexr-scanlines test reads assorted compressions in odd swaths and channel subsets and compares against a single whole-image read, for both readers.

Along the way, we noticed some latent bugs exposed by the new tests and decided to fix. Technically, they are OpenEXR bugs, fixed, but OIIO might build against OpenEXR versions that predate the fixes, so here we are.

Fix a buffer overrun on OpenEXR 3.3.2 through 3.4.2. Their classic ScanLineInputFile keeps one decoded ScanLineProcess across readPixels() calls but chooses the pixel-unpack routine only on the first, and the specialized routines write every channel through channels[0].decode_to_ptr. So a channel-subset read after a full-channel one overruns the caller's buffer, or writes through a null pointer if channel 0 was among those dropped. Introduced by OpenEXR's PR 1899, fixed in 3.4.3 by PR 2150, never fixed on the 3.3 branch. Work around it by reading all channels into scratch and copying out the requested range. The tiled and deep readers build their process objects per call, so they are unaffected. We can get rid of the extra work (which is guarded by `#if` on the OpenEXR version anyway) once our own minimum OpenEXR dependency is >= 3.4.3.

Further discussion / food for thought:

The one-chunk cache is simple and works perfectly when reading one scanline at a time, as long as they are read in order. In OIIO internals themselves (including oiiotool), we really only read scanline files in order, so not a problem for us. But if an app was using the OIIO ImageInput API to read single scanlines in random order, the 1-chunk cache would be ineffective and it would end up being back to the expensive case. Do we care? That seems unusual, and we strongly advise people with this access pattern to use ImageCache, or ImageBuf, or maintain a more sophisticated caching scheme on their end.

Assisted-by: Claude Code / Claude Opus 5

