### PR TITLE
build: be more flexible with nanobind versions

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -139,6 +139,7 @@ if (USE_PYTHON AND OIIO_BUILD_PYTHON_NANOBIND)
     discover_nanobind_cmake_dir()
     checked_find_package (nanobind CONFIG REQUIRED
                           VERSION_MIN 2.8.0 VERSION_MAX 3.9
+                          NO_FP_RANGE_CHECK
                           BUILD_LOCAL missing)
 endif ()
 


### PR DESCRIPTION
Some packages have cmake exported configs that are very inflexible with versions. In particular, it seems that nanobind's exported cmake doesn't like the range we are passing of 2.8.0..3.9 -- it was fine until trying the new nanobind 3.0, which is rejected, and the auto-build kicks in (making 2.13, as it turns out).

The solution is simple, since we already accounted for this in packages -- just use NO_FP_RANGE_CHECK in the call to checked_find_package, and that clears it right up.

The CMake inside TLDR is that a range does not really mean "any version between these is ok." It depends on logic in the exported config, and when SameMajorVersion is used for the check on the config side, no range that spans a major version boundary is ever going to be satisfied. Oops. The cmake way is that the dependency's config gets to adjudicate compatibility, which generally requires the whole range has to be compatible, and there is not a way for the client package to say "really, anything in this range is ok" -- except to not specify a range at all, and then just double check what it finds (that's what we do when we use NO_FP_RANGE_CHECK).
