### PR TITLE
fix(ImageBuf): IB::nmiplevels() returns 0 for non-IC ImageBuf

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -832,6 +832,8 @@ DDSInput::seek_subimage(int subimage, int miplevel)
             m_spec.attribute("compression", str);
     }
 
+    m_spec.attribute("oiio:miplevels", (int)m_dds.mipmaps);
+
     uint32_t bpp = 0;
     if (m_dds.fmt.bpp
         && (m_dds.fmt.flags

--- a/src/doc/builtinplugins.md
+++ b/src/doc/builtinplugins.md
@@ -184,6 +184,9 @@ red & green channels).
      - string
      - For environment maps, which cube faces are present (e.g., ``"+x -x
        +y -y"`` if *x* & *y* faces are present, but not *z*).
+   * - ``oiio:miplevels``
+     - int
+     - The number of MIP levels.
 
 ```
 
@@ -1649,6 +1652,9 @@ The official OpenEXR site is <http://www.openexr.com/>.
    * - ``oiio:subimages``
      - int
      - The number of "parts" (subimages) in the file.
+   * - ``oiio:miplevels``
+     - int
+     - The number of MIP levels of the part (subimage).
    * - ``smpte:TimeCode``
      - int[2]
      - SMPTE time code (vecsemantics will be marked as TIMECODE)
@@ -2234,6 +2240,9 @@ Ptex files at all.
    * - ``wrapmode``
      - string
      - the wrap mode as specified by the Ptex file.
+   * - ``oiio:miplevels``
+     - int
+     - The number of MIP levels of the face (subimage).
    * - *other*
      -
      - Any other arbitrary metadata in the Ptex file will be stored directly

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -333,6 +333,10 @@ public:
     void set_thumbnail(const ImageBuf& thumb, DoLock do_lock = DoLock(true));
     std::shared_ptr<ImageBuf> get_thumbnail(DoLock do_lock = DoLock(true)) const;
 
+    // Count the MIP levels of the current subimage by iterating with
+    // spec_dimensions(), storing the result in m_nmiplevels (0 on failure).
+    void count_nmiplevels(DoLock do_lock = DoLock(true));
+
 private:
     ImageBuf::IBStorage m_storage
         = ImageBuf::UNINITIALIZED;  // Pixel storage class
@@ -562,9 +566,11 @@ ImageBufImpl::ImageBufImpl(const ImageBufImpl& src)
         m_nsubimages       = 1;
         m_current_subimage = 0;
         m_current_miplevel = 0;
-        m_nmiplevels       = 0;
+        m_nmiplevels       = 1;
         m_spec.erase_attribute("oiio:subimages");
         m_nativespec.erase_attribute("oiio:subimages");
+        m_spec.erase_attribute("oiio:miplevels");
+        m_nativespec.erase_attribute("oiio:miplevels");
         m_pixels_read = true;
     }
     if (src.m_configspec)
@@ -871,6 +877,7 @@ ImageBufImpl::clear()
     m_name.clear();
     m_fileformat.clear();
     m_nsubimages       = 0;
+    m_nmiplevels       = 0;
     m_current_subimage = -1;
     m_current_miplevel = -1;
     m_spec             = ImageSpec();
@@ -1304,6 +1311,16 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
         m_current_subimage = subimage;
         m_current_miplevel = miplevel;
         m_pixelaspect = m_spec.get_float_attribute("pixelaspectratio", 1.0f);
+
+        // Set only for formats that don't support mipmaps or whose MIP level
+        // count is known up front. Otherwise, it stays 0, and nmiplevels()
+        // counts the levels lazily by iterating.
+        if (!input->supports("mipmap")) {
+            m_nmiplevels = 1;
+        } else {
+            m_nmiplevels = m_spec.get_int_attribute("oiio:miplevels");
+        }
+
         atomic_fetch_add(OIIO::pvt::IB_total_open_time, float(timer()));
         // Set last, after every field above is written -- see the comment
         // on m_spec_valid's declaration.
@@ -2106,10 +2123,48 @@ ImageBuf::miplevel() const
 }
 
 
+void
+ImageBufImpl::count_nmiplevels(DoLock do_lock)
+{
+    lock_t lock(m_mutex, std::defer_lock_t());
+    if (do_lock)
+        lock.lock();
+    if (!validate_spec(DoLock(false) /* we already hold the lock */)) {
+        m_nmiplevels = 0;
+        return;
+    }
+
+    auto input = ImageInput::open(m_name.string(), m_configspec.get(),
+                                  m_rioproxy);
+    if (!input) {
+        error("Could not open file: {}", OIIO::geterror());
+        m_nmiplevels = 0;
+        return;
+    }
+
+    // Count until spec_dimensions() returns a spec whose format is unknown.
+    int nmip = 0;
+    while (input->spec_dimensions(m_current_subimage, nmip).format
+           != TypeUnknown) {
+        ++nmip;
+    }
+    m_nmiplevels = nmip;
+}
+
+
 int
 ImageBuf::nmiplevels() const
 {
-    m_impl->validate_spec();
+    if (!m_impl->validate_spec()) {
+        m_impl->m_nmiplevels = 0;
+    } else if (m_impl->m_name.empty() || m_impl->m_fileformat.empty()) {
+        // No direct reference to a file, so 1 as documented.
+        m_impl->m_nmiplevels = 1;
+    } else if (m_impl->m_nmiplevels < 1) {
+        // Count MIP levels by iteration, only for files whose MIP level count
+        // was not known up front in init_spec().
+        m_impl->count_nmiplevels();
+    }
     return m_impl->m_nmiplevels;
 }
 
@@ -2389,9 +2444,11 @@ ImageBuf::copy_pixels(const ImageBuf& src)
     m_impl->m_nsubimages       = 1;
     m_impl->m_current_subimage = 0;
     m_impl->m_current_miplevel = 0;
-    m_impl->m_nmiplevels       = 0;
+    m_impl->m_nmiplevels       = 1;
     m_impl->m_spec.erase_attribute("oiio:subimages");
     m_impl->m_nativespec.erase_attribute("oiio:subimages");
+    m_impl->m_spec.erase_attribute("oiio:miplevels");
+    m_impl->m_nativespec.erase_attribute("oiio:miplevels");
 
     return ok;
 }

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -407,6 +407,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
     if (!query_channels(in, header))  // also sets format
         return false;
 
+    spec.attribute("oiio:miplevels", nmiplevels);
     spec.deep = Strutil::istarts_with(header->type(), "deep");
 
     if (levelmode != Imf::ONE_LEVEL)
@@ -1155,11 +1156,6 @@ OpenEXRInput::seek_subimage(int subimage, int miplevel)
 
     m_miplevel = miplevel;
     m_spec     = part.spec;
-
-    //! Add the number of miplevels as an attribute for the first miplevel.
-    //! TOFIX: adding the following attribute breaks unit tests
-    // if (m_miplevel == 0 && part.nmiplevels > 1)
-    //     m_spec.attribute("oiio:miplevels", part.nmiplevels);
 
     if (!check_open(m_spec, { 0, 1 << 30, 0, 1 << 30, 0, 1, 0, 1 << 12 }))
         return false;

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -541,6 +541,7 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
     if (!query_channels(in, ctxt, subimage))  // also sets format
         return false;
 
+    spec.attribute("oiio:miplevels", nmiplevels);
     spec.deep = (storage == EXR_STORAGE_DEEP_TILED
                  || storage == EXR_STORAGE_DEEP_SCANLINE);
 
@@ -1143,11 +1144,6 @@ OpenEXRCoreInput::seek_subimage(int subimage, int miplevel)
 
     m_miplevel = miplevel;
     m_spec     = part.spec;
-
-    //! Add the number of miplevels as an attribute for the first miplevel.
-    //! TOFIX: adding the following attribute breaks unit tests
-    // if (m_miplevel == 0 && part.nmiplevels > 1)
-    //     m_spec.attribute("oiio:miplevels", part.nmiplevels);
 
     if (!check_open(m_spec, { 0, 1 << 30, 0, 1 << 30, 0, 1, 0, 1 << 12 }))
         return false;

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -442,10 +442,7 @@ PtexInput::seek_subimage(int subimage, int miplevel)
         m_spec.attribute("oiio:subimages", m_numFaces);
     }
 
-    // Add the number of miplevels as an attribute for the first miplevel.
-    if (miplevel == 0 && nmiplevels > 1)
-        m_spec.attribute("oiio:miplevels", nmiplevels);
-
+    m_spec.attribute("oiio:miplevels", nmiplevels);
     facedata->release();
     return true;
 }

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1437,6 +1437,10 @@ TIFFInput::readspec(bool read_meta)
             m_spec.channelnames[c] = "z";
     }
 
+    // Set miplevels to 1 if no mipmap emulation.
+    if (!m_emulate_mipmap)
+        m_spec.attribute("oiio:miplevels", 1);
+
     /// read color profile
     unsigned int icc_datasize = 0;
     uint8_t* icc_buf          = NULL;

--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -4,6 +4,7 @@ Reading ../oiio-images/dds/dds_bc1.dds
     channel list: R, G, B, A
     compression: "DXT1"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc1_mips.dds
 ../oiio-images/dds/dds_bc1_mips.dds :   16 x    8, 4 channel, uint8 dds
     MIP-map levels: 16x8 8x4 4x2 2x1 1x1
@@ -11,30 +12,35 @@ Reading ../oiio-images/dds/dds_bc1_mips.dds
     channel list: R, G, B, A
     compression: "DXT1"
     textureformat: "Plain Texture"
+    oiio:miplevels: 5
 Reading ../oiio-images/dds/dds_bc2.dds
 ../oiio-images/dds/dds_bc2.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: B458B3BAA7F457E06D04D0FBF93C003FFA729C97
     channel list: R, G, B, A
     compression: "DXT3"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc3.dds
 ../oiio-images/dds/dds_bc3.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: B45BF28699FBA3CD6B52A9116FEAD7A08DD2B694
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc4.dds
 ../oiio-images/dds/dds_bc4.dds :   16 x    8, 1 channel, uint8 dds
     SHA-1: 3AB99C171DF5E3ADB494D2C09DE67C7FF53EA18C
     channel list: Y
     compression: "BC4"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc5.dds
 ../oiio-images/dds/dds_bc5.dds :   16 x    8, 2 channel, uint8 dds
     SHA-1: 460525BD9A4E3D295F0A9878204AA0912F3825BB
     channel list: R, G
     compression: "BC5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc6hu.dds
 ../oiio-images/dds/dds_bc6hu.dds :   16 x    8, 3 channel, half dds
     SHA-1: 11499B6B8451F0488366EB4E7C10BEEC39C2792A
@@ -42,6 +48,7 @@ Reading ../oiio-images/dds/dds_bc6hu.dds
     compression: "BC6HU"
     textureformat: "Plain Texture"
     oiio:ColorSpace: "lin_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc6hu_hdr.dds
 ../oiio-images/dds/dds_bc6hu_hdr.dds :  128 x   64, 3 channel, half dds
     SHA-1: 86FE86288649F5375DB51CDF19C91C3651992726
@@ -49,24 +56,28 @@ Reading ../oiio-images/dds/dds_bc6hu_hdr.dds
     compression: "BC6HU"
     textureformat: "Plain Texture"
     oiio:ColorSpace: "lin_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc7.dds
 ../oiio-images/dds/dds_bc7.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 18D1977AD74C3C19E5B30459D212EBC8C7F8BC54
     channel list: R, G, B, A
     compression: "BC7"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bgr8.dds
 ../oiio-images/dds/dds_bgr8.dds :   16 x    8, 3 channel, uint8 dds
     SHA-1: 6BF57CCCCF14021926285CE97D25AEC150324476
     channel list: R, G, B
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_npot_bc3.dds
 ../oiio-images/dds/dds_npot_bc3.dds :   13 x    7, 4 channel, uint8 dds
     SHA-1: 06063F63E99837BDCDA2F8864ECD55738778C1A5
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_npot_bc3_mips.dds
 ../oiio-images/dds/dds_npot_bc3_mips.dds :   13 x    7, 4 channel, uint8 dds
     MIP-map levels: 13x7 6x3 3x1 1x1
@@ -74,12 +85,14 @@ Reading ../oiio-images/dds/dds_npot_bc3_mips.dds
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 4
 Reading ../oiio-images/dds/dds_npot_rgba8.dds
 ../oiio-images/dds/dds_npot_rgba8.dds :   13 x    7, 4 channel, uint8 dds
     SHA-1: 6CBA3E2782498E2E92F5E4B08376A2E948FE3BAF
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_npot_rgba8_mips.dds
 ../oiio-images/dds/dds_npot_rgba8_mips.dds :   13 x    7, 4 channel, uint8 dds
     MIP-map levels: 13x7 6x3 3x1 1x1
@@ -87,30 +100,35 @@ Reading ../oiio-images/dds/dds_npot_rgba8_mips.dds
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
+    oiio:miplevels: 4
 Reading ../oiio-images/dds/dds_r5g6b5.dds
 ../oiio-images/dds/dds_r5g6b5.dds :   16 x    8, 3 channel, uint8 dds
     SHA-1: 37A3BFD2B8A52006B4F07065A90BE774F276B751
     channel list: R, G, B
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_rgb8.dds
 ../oiio-images/dds/dds_rgb8.dds :   16 x    8, 3 channel, uint8 dds
     SHA-1: 6BF57CCCCF14021926285CE97D25AEC150324476
     channel list: R, G, B
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_rgba4.dds
 ../oiio-images/dds/dds_rgba4.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: E49AB2BCE799274DE4E12DCDF1B93363F34E0FA1
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_rgba8.dds
 ../oiio-images/dds/dds_rgba8.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 61986C7E2D4F402B4A268AE5187AAFAF1647C0E6
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_rgba8_mips.dds
 ../oiio-images/dds/dds_rgba8_mips.dds :   16 x    8, 4 channel, uint8 dds
     MIP-map levels: 16x8 8x4 4x2 2x1 1x1
@@ -118,66 +136,77 @@ Reading ../oiio-images/dds/dds_rgba8_mips.dds
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
+    oiio:miplevels: 5
 Reading ../oiio-images/dds/dds_a8.dds
 ../oiio-images/dds/dds_a8.dds :   24 x   20, 1 channel, uint8 dds
     SHA-1: 497ACCA96FAAC89AE74BDE8CA7B69B37CA9C5F20
     channel list: Y
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_abgr8.dds
 ../oiio-images/dds/dds_abgr8.dds :   24 x   20, 4 channel, uint8 dds
     SHA-1: B84A369C1CB71B102DA57D04635B7F42116F9B16
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc3nm.dds
 ../oiio-images/dds/dds_bc3nm.dds :   24 x   20, 3 channel, uint8 dds
     SHA-1: 04C252DA402FBF35E7D39605231356CBCA6AF006
     channel list: R, G, B
     compression: "DXT5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc3rxgb.dds
 ../oiio-images/dds/dds_bc3rxgb.dds :   24 x   20, 4 channel, uint8 dds
     SHA-1: 460EAC801AA68743CC3D3FC01E9BF067CD9CB67F
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_bc3ycocg.dds
 ../oiio-images/dds/dds_bc3ycocg.dds :   24 x   20, 4 channel, uint8 dds
     SHA-1: 485B74D1E9BEF25D8CA06880A6CAD260430CBE30
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_l8.dds
 ../oiio-images/dds/dds_l8.dds :   24 x   20, 1 channel, uint8 dds
     SHA-1: 2E40B849905A3F67F22F86188540DD21DB3C29C5
     channel list: Y
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_l8a8.dds
 ../oiio-images/dds/dds_l8a8.dds :   24 x   20, 2 channel, uint8 dds
     SHA-1: D6B33AA4813B6D181399AF0E9658D173BD505E2D
     channel list: Y, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_rgb10a2.dds
 ../oiio-images/dds/dds_rgb10a2.dds :   24 x   20, 4 channel, uint8 dds
     SHA-1: D7599C62CA35D7C4478341471A54526CB546CF0C
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_rgb332.dds
 ../oiio-images/dds/dds_rgb332.dds :   24 x   20, 3 channel, uint8 dds
     SHA-1: 777DB8FC8240CA6FADF6B58870B07D83EEA84372
     channel list: R, G, B
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_rgb5a1.dds
 ../oiio-images/dds/dds_rgb5a1.dds :   24 x   20, 4 channel, uint8 dds
     SHA-1: C6EE5529AB29827FFF4AD941D7714EF30F3DAA75
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_bc1_srgb.dds
 ../oiio-images/dds/dds_dxgi_bc1_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 02BFD2FEE553D00AEFEEEE22BB5119724D588F6A
@@ -185,6 +214,7 @@ Reading ../oiio-images/dds/dds_dxgi_bc1_srgb.dds
     compression: "DXT1"
     textureformat: "Plain Texture"
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_bc2_srgb.dds
 ../oiio-images/dds/dds_dxgi_bc2_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: D99494018941ADCA11EAE469D8C6E598DA37A8BF
@@ -192,6 +222,7 @@ Reading ../oiio-images/dds/dds_dxgi_bc2_srgb.dds
     compression: "DXT3"
     textureformat: "Plain Texture"
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_bc3_srgb.dds
 ../oiio-images/dds/dds_dxgi_bc3_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 75F9FCD1920A00966F2FE13DF40F4FB0A6CD8DED
@@ -199,6 +230,7 @@ Reading ../oiio-images/dds/dds_dxgi_bc3_srgb.dds
     compression: "DXT5"
     textureformat: "Plain Texture"
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_bc7_srgb.dds
 ../oiio-images/dds/dds_dxgi_bc7_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 91DBAC0E5ED54D5BBEECA4C48AB704FA9F7FE317
@@ -206,6 +238,7 @@ Reading ../oiio-images/dds/dds_dxgi_bc7_srgb.dds
     compression: "BC7"
     textureformat: "Plain Texture"
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_rgba8_srgb.dds
 ../oiio-images/dds/dds_dxgi_rgba8_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 61986C7E2D4F402B4A268AE5187AAFAF1647C0E6
@@ -213,6 +246,7 @@ Reading ../oiio-images/dds/dds_dxgi_rgba8_srgb.dds
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_bgra8_srgb.dds
 ../oiio-images/dds/dds_dxgi_bgra8_srgb.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: 61986C7E2D4F402B4A268AE5187AAFAF1647C0E6
@@ -220,6 +254,7 @@ Reading ../oiio-images/dds/dds_dxgi_bgra8_srgb.dds
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_bgrx8_srgb.dds
 ../oiio-images/dds/dds_dxgi_bgrx8_srgb.dds :   16 x    8, 3 channel, uint8 dds
     SHA-1: 6BF57CCCCF14021926285CE97D25AEC150324476
@@ -227,18 +262,21 @@ Reading ../oiio-images/dds/dds_dxgi_bgrx8_srgb.dds
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_rgb10a2.dds
 ../oiio-images/dds/dds_dxgi_rgb10a2.dds :   16 x    8, 4 channel, uint8 dds
     SHA-1: F38B31F89991752DAB792DC9FF29F7F7DE0E7911
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/dds_dxgi_r16.dds
 ../oiio-images/dds/dds_dxgi_r16.dds :   16 x    8, 1 channel, uint8 dds
     SHA-1: 016B31C71C2BFEAB9E1CCE1649EC22EE27D97D3F
     channel list: Y
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/broken/dds_bc3_just_header.dds
 oiiotool ERROR: -info : SHA-1: Read error: hit end of file in dds reader
 Full command line was:
@@ -247,6 +285,7 @@ Full command line was:
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 oiiotool ERROR: read : "../oiio-images/dds/broken/dds_bc3_no_full_header.dds": Read error: hit end of file in dds reader
 Full command line was:
 > oiiotool --info -v -a --hash ../oiio-images/dds/broken/dds_bc3_no_full_header.dds
@@ -258,6 +297,7 @@ Full command line was:
     channel list: R, G, B, A
     compression: "BC7"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading ../oiio-images/dds/broken/dds_bc7_not_enough_data.dds
 oiiotool ERROR: -info : SHA-1: Read error: hit end of file in dds reader
 Full command line was:
@@ -266,6 +306,7 @@ Full command line was:
     channel list: R, G, B, A
     compression: "BC7"
     textureformat: "Plain Texture"
+    oiio:miplevels: 1
 Reading src/crash-1634.dds
 oiiotool ERROR: -info : SHA-1: Read error: hit end of file in dds reader
 Full command line was:
@@ -274,6 +315,7 @@ src/crash-1634.dds   :   16 x    8, 1 channel, uint8 dds
     channel list: Y
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
 oiiotool ERROR: read : "src/crash-1635.dds": Invalid DDS bytes-per-pixel (131072). Possible corrupt input?
 Full command line was:
 > oiiotool --info -v -a --hash src/crash-1635.dds
@@ -283,6 +325,7 @@ src/crash-3950.dds   :   16 x    1, 4 channel, uint8 dds
     channel list: R, G, B, A
     compression: "DXT4"
     textureformat: "Plain Texture"
+    oiio:miplevels: 6
 oiiotool ERROR: read : "src/crash-bpp.dds": Invalid DDS bytes-per-pixel (322122548). Possible corrupt input?
 Full command line was:
 > oiiotool --info -v -a --hash src/crash-bpp.dds

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -6,6 +6,7 @@ out.exr              :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -18,6 +19,7 @@ out2.exr             :   64 x   64, 6 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "Aimg"
     oiio:subimages: 1

--- a/testsuite/heif/ref/out-reorient.txt
+++ b/testsuite/heif/ref/out-reorient.txt
@@ -12,6 +12,7 @@ reorient0.tif        :  160 x  240, 3 channel, uint8 tiff
     Exif:ColorSpace: 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2

--- a/testsuite/iinfo/ref/out-fmt6.txt
+++ b/testsuite/iinfo/ref/out-fmt6.txt
@@ -147,6 +147,7 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+src/tiny-az.exr :     oiio:miplevels: 1
 src/tiny-az.exr :     oiio:RowsPerChunk: 16
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     openexr:lineOrder: "increasingY"
@@ -175,6 +176,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -215,6 +217,7 @@ src/tinydeep.exr :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
     openexr:lineOrder: "increasingY"
@@ -250,6 +253,7 @@ src/tinydeep.exr     :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
     openexr:lineOrder: "increasingY"
@@ -350,6 +354,7 @@ Reading tmp.tif
 <attrib name="planarconfig" type="string">contig</attrib>
 <attrib name="compression" type="string">zip</attrib>
 <attrib name="tiff:RowsPerStrip" type="int">32</attrib>
+<attrib name="oiio:miplevels" type="int">1</attrib>
 </ImageSpec>
 src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     3 subimages: 2x2 [u8,u8,u8], 2x2 [u8,u8,u8], 2x2 [u8,u8,u8]
@@ -362,6 +367,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -386,6 +392,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -410,6 +417,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2

--- a/testsuite/iinfo/ref/out.txt
+++ b/testsuite/iinfo/ref/out.txt
@@ -147,6 +147,7 @@ src/tiny-az.exr :     screenWindowCenter: 0, 0
 src/tiny-az.exr :     screenWindowWidth: 1
 src/tiny-az.exr :     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
 src/tiny-az.exr :     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+src/tiny-az.exr :     oiio:miplevels: 1
 src/tiny-az.exr :     oiio:RowsPerChunk: 16
 src/tiny-az.exr :     oiio:subimages: 1
 src/tiny-az.exr :     openexr:lineOrder: "increasingY"
@@ -175,6 +176,7 @@ src/tiny-az.exr      :    4 x    4, 3 channel, float openexr
     screenWindowWidth: 1
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
     Exif:ImageHistory: "oiiotool -pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -215,6 +217,7 @@ src/tinydeep.exr :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
     openexr:lineOrder: "increasingY"
@@ -250,6 +253,7 @@ src/tinydeep.exr     :    4 x    4, 2 channel, deep float openexr
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
     version: 1
     Exif:ImageHistory: "oiiotool -pattern constant:color=1e38,0 4x4 2 --chnames Z,A --point:color=10.0,1.0 2,2 --deepen -o tinydeep.exr"
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
     openexr:lineOrder: "increasingY"
@@ -351,6 +355,7 @@ Reading tmp.tif
 <attrib name="compression" type="string">zip</attrib>
 <attrib name="oiio:RowsPerChunk" type="int">32</attrib>
 <attrib name="tiff:RowsPerStrip" type="int">32</attrib>
+<attrib name="oiio:miplevels" type="int">1</attrib>
 </ImageSpec>
 src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     3 subimages: 2x2 [u8,u8,u8], 2x2 [u8,u8,u8], 2x2 [u8,u8,u8]
@@ -363,6 +368,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -387,6 +393,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -411,6 +418,7 @@ src/subimage.tif :    2 x    2, 3 channel, uint8 tiff
     planarconfig: "contig"
     Software: "OpenImageIO 2.5.0.0spi : oiiotool -pattern constant:color=0.25,0.5,0.75 2x2 3 -dup -dup --siappendall -d uint8 -o subimage.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2

--- a/testsuite/maketx/ref/out-alt.txt
+++ b/testsuite/maketx/ref/out-alt.txt
@@ -337,6 +337,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:miplevels: 1
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -365,6 +366,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:miplevels: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -378,6 +380,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -458,6 +461,7 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -548,6 +552,7 @@ bumpslope-central.exr :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00487623,0.00476811,-1.36547e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "E332A489C2BCDE63C2DB6A68E847CF396642F0A6"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -642,6 +647,7 @@ bumpslope-normal.exr :  128 x  128, 6 channel, half openexr
     version: 1
     wrapmodes: "black,black"
     oiio:AverageColor: "-1,-5.0059e-05,5.46902e-05,0.00489737,0.00494693,4.87366e-05"
+    oiio:miplevels: 8
     oiio:SHA-1: "BC210B60E71DDBBA147EAD3C638ACC908C11CF6C"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -744,6 +750,7 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779"
+    oiio:miplevels: 7
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -776,6 +783,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/maketx/ref/out-macarm.txt
+++ b/testsuite/maketx/ref/out-macarm.txt
@@ -337,6 +337,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:miplevels: 1
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -365,6 +366,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:miplevels: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -378,6 +380,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -458,6 +461,7 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -548,6 +552,7 @@ bumpslope-central.exr :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00487623,0.00476811,-1.36547e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "E332A489C2BCDE63C2DB6A68E847CF396642F0A6"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -642,6 +647,7 @@ bumpslope-normal.exr :  128 x  128, 6 channel, half openexr
     version: 1
     wrapmodes: "black,black"
     oiio:AverageColor: "-1,-5.0059e-05,5.46902e-05,0.00489737,0.00494693,4.87366e-05"
+    oiio:miplevels: 8
     oiio:SHA-1: "BC210B60E71DDBBA147EAD3C638ACC908C11CF6C"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -744,6 +750,7 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779"
+    oiio:miplevels: 7
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -776,6 +783,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -337,6 +337,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:miplevels: 1
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -365,6 +366,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:miplevels: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -378,6 +380,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -458,6 +461,7 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -548,6 +552,7 @@ bumpslope-central.exr :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00487623,0.00476811,-1.36547e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "E332A489C2BCDE63C2DB6A68E847CF396642F0A6"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -642,6 +647,7 @@ bumpslope-normal.exr :  128 x  128, 6 channel, half openexr
     version: 1
     wrapmodes: "black,black"
     oiio:AverageColor: "-1,-5.0059e-05,5.46902e-05,0.00489737,0.00494693,4.87366e-05"
+    oiio:miplevels: 8
     oiio:SHA-1: "BC210B60E71DDBBA147EAD3C638ACC908C11CF6C"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -744,6 +750,7 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779"
+    oiio:miplevels: 7
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -776,6 +783,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/misnamed-file/ref/out.txt
+++ b/testsuite/misnamed-file/ref/out.txt
@@ -12,6 +12,7 @@ misnamed.exr         : 1000 x 1000, 4 channel, uint8 tiff
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:Compression: 8
     tiff:PageNumber: 0, 1

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -92,6 +92,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
@@ -106,6 +107,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
@@ -122,6 +124,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
@@ -135,6 +138,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -92,6 +92,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
@@ -106,6 +107,7 @@ attrib2.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2
@@ -122,6 +124,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 2
@@ -135,6 +138,7 @@ attrib0.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 2

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -320,6 +320,7 @@ Meta native:  128 x   96, 3 channel, uint8 tiff
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -14,6 +14,7 @@ allhalf.exr          :   38 x   38, 5 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading rgbahalf-zfloat.exr
@@ -27,6 +28,7 @@ rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading sub-formats.exr
@@ -82,6 +84,7 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Reading green.exr
@@ -93,6 +96,7 @@ green.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -109,6 +113,7 @@ greenmeta-replace.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -125,6 +130,7 @@ greenmeta-merge.exr  :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -141,6 +147,7 @@ greenmeta-merge-override.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -155,6 +162,7 @@ greenmeta-merge-camera.exr :   64 x   64, 3 channel, half openexr
     screenWindowWidth: 1
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -174,6 +182,7 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage00"
     oiio:subimages: 3
@@ -192,6 +201,7 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage01"
     oiio:subimages: 3
@@ -210,6 +220,7 @@ greenmeta-merge-2.exr :   64 x   64, 3 channel, half openexr
     weight: 20.5
     camera:lens: "AX30"
     camera:shutter: 0.0125
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "subimage02"
     oiio:subimages: 3
@@ -224,6 +235,7 @@ nometamerge.exr      :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -237,6 +249,7 @@ metamerge.exr        :   64 x   64, 6 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-deep/ref/out-fmt6.txt
+++ b/testsuite/oiiotool-deep/ref/out-fmt6.txt
@@ -12,6 +12,7 @@ allhalf.exr          :  160 x  120, 2 channel, deep half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 6
     openexr:lineOrder: "randomY"
@@ -56,6 +57,7 @@ swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 6
     openexr:lineOrder: "randomY"
@@ -95,6 +97,7 @@ tinydeep.exr         :    4 x    4, 2 channel, deep float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     version: 1
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-deep/ref/out.txt
+++ b/testsuite/oiiotool-deep/ref/out.txt
@@ -12,6 +12,7 @@ allhalf.exr          :  160 x  120, 2 channel, deep half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 6
     openexr:lineOrder: "randomY"
@@ -56,6 +57,7 @@ swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
     version: 1
     worldToCamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1.5, 0, 4, 1
     worldToNDC: 2.41421, 0, 0, 0, 0, 3.21895, 0, 0, 0, 0, -1.00671, -1, 3.62132, 0, 3.92617, 4
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 6
     openexr:lineOrder: "randomY"
@@ -95,6 +97,7 @@ tinydeep.exr         :    4 x    4, 2 channel, deep float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     version: 1
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 4
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -9,6 +9,7 @@ src/bad.exr          :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -29,6 +30,7 @@ black.exr            :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -49,6 +51,7 @@ box3.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-maketx/ref/out-macarm.txt
+++ b/testsuite/oiiotool-maketx/ref/out-macarm.txt
@@ -277,6 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:miplevels: 1
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -307,6 +308,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
+    oiio:miplevels: 2
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -349,6 +351,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:miplevels: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -368,6 +371,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -599,6 +603,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -277,6 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:miplevels: 1
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -304,6 +305,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:miplevels: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     openexr:roundingmode: 0
 Reading grid.tx
@@ -321,6 +323,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -552,6 +555,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-maketx/ref/out-win.txt
+++ b/testsuite/oiiotool-maketx/ref/out-win.txt
@@ -277,6 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:miplevels: 1
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -307,6 +308,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
+    oiio:miplevels: 2
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -349,6 +351,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:miplevels: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -368,6 +371,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -599,6 +603,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -277,6 +277,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:miplevels: 1
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     oiio:subimages: 1
     openexr:levelmode: 0
@@ -307,6 +308,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
     oiio:ConstantColor: "1e+06,1e+06,1e+06"
+    oiio:miplevels: 2
     oiio:SHA-1: "E3D97EED7EE68F1885685F312DDD7D8773C29862"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -349,6 +351,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:miplevels: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -368,6 +371,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -599,6 +603,7 @@ bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
     uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:miplevels: 7
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/oiiotool-subimage/ref/out.txt
+++ b/testsuite/oiiotool-subimage/ref/out.txt
@@ -18,6 +18,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "layerA"
     oiio:subimages: 4
@@ -32,6 +33,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "layerB"
     oiio:subimages: 4
@@ -46,6 +48,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "layerC"
     oiio:subimages: 4
@@ -60,6 +63,7 @@ jpgr.exr             :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimagename: "layerD"
     oiio:subimages: 4
@@ -81,6 +85,7 @@ mip4.tif             :   64 x   64, 4 channel, uint8 tiff
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1

--- a/testsuite/oiiotool-thumbnail-set/ref/out.txt
+++ b/testsuite/oiiotool-thumbnail-set/ref/out.txt
@@ -22,6 +22,7 @@ no_thumb.tif         :  512 x  384, 3 channel, uint8 tiff
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -40,6 +40,7 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -7,6 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -22,6 +23,7 @@ Reading ../openexr-images/Chromaticities/XYZ.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -40,6 +42,7 @@ Reading ../openexr-images/LuminanceChroma/Garden.exr
     thumbnail_height: 56
     thumbnail_nchannels: 4
     thumbnail_width: 100
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/LuminanceChroma/Garden.exr" and "Garden.exr"

--- a/testsuite/openexr-idmanifest/ref/out.txt
+++ b/testsuite/openexr-idmanifest/ref/out.txt
@@ -7,6 +7,7 @@ src/manifest.exr     :   16 x   16, 8 channel, deep half/half/half/half/half/uin
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     version: 1
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 16
     openexr:compressedIDManifest: 55, 1, 0, 0, 0, 0, 0, 0, 120, 94, 99, 0, 2, 110, 32, 230, ... [250 x uint8]
@@ -21,6 +22,7 @@ manifest.exr         :   16 x   16, 8 channel, deep half/half/half/half/half/uin
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     version: 1
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:chunkCount: 16
     openexr:compressedIDManifest: 55, 1, 0, 0, 0, 0, 0, 0, 120, 94, 99, 0, 2, 110, 32, 230, ... [250 x uint8]

--- a/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out-macarm.txt
@@ -7,6 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -23,6 +24,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -39,6 +41,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -54,6 +57,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -72,6 +76,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     thumbnail_height: 66
     thumbnail_nchannels: 4
     thumbnail_width: 100
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -90,6 +95,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     thumbnail_height: 80
     thumbnail_nchannels: 4
     thumbnail_width: 80
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-luminance-chroma/ref/out.txt
+++ b/testsuite/openexr-luminance-chroma/ref/out.txt
@@ -7,6 +7,7 @@ Reading ../openexr-images/Chromaticities/Rec709_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -23,6 +24,7 @@ Reading ../openexr-images/Chromaticities/XYZ_YC.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -39,6 +41,7 @@ Reading ../openexr-images/LuminanceChroma/CrissyField.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -54,6 +57,7 @@ Reading ../openexr-images/LuminanceChroma/Flowers.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -72,6 +76,7 @@ Reading ../openexr-images/LuminanceChroma/MtTamNorth.exr
     thumbnail_height: 66
     thumbnail_nchannels: 4
     thumbnail_width: 100
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -90,6 +95,7 @@ Reading ../openexr-images/LuminanceChroma/StarField.exr
     thumbnail_height: 80
     thumbnail_nchannels: 4
     thumbnail_width: 80
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -15,6 +15,7 @@ Reading ../openexr-images/MultiResolution/Bonita.exr
     thumbnail_nchannels: 4
     thumbnail_width: 100
     wrapmodes: "clamp,clamp"
+    oiio:miplevels: 10
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -34,6 +35,7 @@ Reading ../openexr-images/MultiResolution/ColorCodedLevels.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
+    oiio:miplevels: 10
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -53,6 +55,7 @@ Reading ../openexr-images/MultiResolution/KernerEnvCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
+    oiio:miplevels: 11
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -71,6 +74,7 @@ Reading ../openexr-images/MultiResolution/KernerEnvLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
+    oiio:miplevels: 11
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -91,6 +95,7 @@ Reading ../openexr-images/MultiResolution/MirrorPattern.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "mirror,mirror"
+    oiio:miplevels: 10
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -110,6 +115,7 @@ Reading ../openexr-images/MultiResolution/OrientationCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
+    oiio:miplevels: 12
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -128,6 +134,7 @@ Reading ../openexr-images/MultiResolution/OrientationLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
+    oiio:miplevels: 11
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -148,6 +155,7 @@ Reading ../openexr-images/MultiResolution/PeriodicPattern.exr
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
+    oiio:miplevels: 10
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -170,6 +178,7 @@ Reading ../openexr-images/MultiResolution/StageEnvCube.exr
     thumbnail_height: 180
     thumbnail_nchannels: 4
     thumbnail_width: 30
+    oiio:miplevels: 11
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -191,6 +200,7 @@ Reading ../openexr-images/MultiResolution/StageEnvLatLong.exr
     thumbnail_height: 50
     thumbnail_nchannels: 4
     thumbnail_width: 100
+    oiio:miplevels: 11
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -212,6 +222,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesCube.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
+    oiio:miplevels: 11
     oiio:sampleborder: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -230,6 +241,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesLatLong.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
+    oiio:miplevels: 11
     oiio:sampleborder: 1
     oiio:subimages: 1
     oiio:updirection: "y"
@@ -246,6 +258,7 @@ Reading ../openexr-images/MultiResolution/WavyLinesSphere.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -264,6 +277,7 @@ Reading ../openexr-images/MultiView/Adjuster.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -281,6 +295,7 @@ Reading ../openexr-images/MultiView/Balls.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -302,6 +317,7 @@ Reading ../openexr-images/MultiView/Fog.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -325,6 +341,7 @@ Reading ../openexr-images/MultiView/Impact.exr
     wrapmodes: "clamp,clamp"
     XResolution: 100
     YResolution: 100
+    oiio:miplevels: 10
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     openexr:roundingmode: 0
@@ -345,6 +362,7 @@ Reading ../openexr-images/MultiView/LosPadres.exr
     screenWindowWidth: 1
     XResolution: 100
     YResolution: 100
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -17,6 +17,7 @@ Reading ../openexr-images/ScanLines/Blobbies.exr
     thumbnail_width: 100
     utcOffset: 28800
     whiteLuminance: 50
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "decreasingY"
@@ -35,6 +36,7 @@ Reading ../openexr-images/ScanLines/CandleGlass.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -49,6 +51,7 @@ Reading ../openexr-images/ScanLines/Cannon.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -62,6 +65,7 @@ Reading ../openexr-images/ScanLines/Desk.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -85,6 +89,7 @@ Reading ../openexr-images/ScanLines/MtTamWest.exr
     thumbnail_nchannels: 4
     thumbnail_width: 100
     utcOffset: 25200
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -103,6 +108,7 @@ Reading ../openexr-images/ScanLines/PrismsLenses.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -122,6 +128,7 @@ Reading ../openexr-images/ScanLines/StillLife.exr
     thumbnail_nchannels: 4
     thumbnail_width: 100
     utcOffset: 25200
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -144,6 +151,7 @@ Reading ../openexr-images/ScanLines/Tree.exr
     thumbnail_width: 100
     utcOffset: 25200
     whiteLuminance: 621
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -157,6 +165,7 @@ Reading ../openexr-images/TestImages/AllHalfValues.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -170,6 +179,7 @@ Reading ../openexr-images/TestImages/BrightRings.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -183,6 +193,7 @@ Reading ../openexr-images/TestImages/BrightRingsNanInf.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -196,6 +207,7 @@ Reading ../openexr-images/TestImages/GammaChart.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -209,6 +221,7 @@ Reading ../openexr-images/TestImages/GrayRampsDiagonal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -222,6 +235,7 @@ Reading ../openexr-images/TestImages/GrayRampsHorizontal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -235,6 +249,7 @@ Reading ../openexr-images/TestImages/RgbRampsDiagonal.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -248,6 +263,7 @@ Reading ../openexr-images/TestImages/SquaresSwirls.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -262,6 +278,7 @@ Reading ../openexr-images/TestImages/WideColorGamut.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -275,6 +292,7 @@ Reading ../openexr-images/TestImages/WideFloatRange.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -303,6 +321,7 @@ Reading ../openexr-images/Tiles/GoldenGate.exr
     thumbnail_nchannels: 4
     thumbnail_width: 100
     utcOffset: 28800
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/GoldenGate.exr" and "GoldenGate.exr"
@@ -321,6 +340,7 @@ Reading ../openexr-images/Tiles/Ocean.exr
     thumbnail_height: 70
     thumbnail_nchannels: 4
     thumbnail_width: 100
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
@@ -345,6 +365,7 @@ Reading ../openexr-images/Tiles/Spirals.exr
     thumbnail_width: 100
     utcOffset: 28800
     whiteLuminance: 90
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
 Comparing "../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
@@ -362,6 +383,7 @@ Reading ../openexr-images/Beachball/singlepart.0001.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:subimagename: "rgba"
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -378,6 +400,7 @@ negoverscan.exr      :   64 x   64, 3 channel, half openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -397,6 +420,7 @@ strict-out.exr       :    4 x    4, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_ap0_scene"
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:ACESContainerPolicy: "strict"
     openexr:lineOrder: "increasingY"
@@ -419,6 +443,7 @@ color_interop_id_scene_linear.exr :    4 x    4, 3 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_ap1_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -432,6 +457,7 @@ color_interop_id_linear_adobergb.exr :    4 x    4, 3 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "lin_adobergb_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -443,6 +469,7 @@ color_interop_id_unknown.exr :    4 x    4, 3 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -15,6 +15,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba.left"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -32,6 +33,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "depth.left"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -49,6 +51,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba.right"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -66,6 +69,7 @@ Reading ../openexr-images/v2/Stereo/composited.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "depth.right"
     oiio:subimages: 4
     openexr:chunkCount: 1078
@@ -99,6 +103,7 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     screenWindowWidth: 1
     version: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 761
@@ -117,6 +122,7 @@ Reading ../openexr-images/v2/Stereo/Balls.exr
     screenWindowWidth: 1
     version: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 761
@@ -158,6 +164,7 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     screenWindowWidth: 1
     version: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 1080
@@ -173,6 +180,7 @@ Reading ../openexr-images/v2/Stereo/Leaves.exr
     screenWindowWidth: 1
     version: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 1080
@@ -215,6 +223,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -231,6 +240,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "depth_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -247,6 +257,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "forward_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -263,6 +274,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "whitebarmask_left"
     oiio:subimages: 10
     openexr:chunkCount: 769
@@ -279,6 +291,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
+    oiio:miplevels: 1
     oiio:subimagename: "rgba_left"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -295,6 +308,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "depth_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -311,6 +325,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "forward_right"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -326,6 +341,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:subimagename: "disparityL"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -341,6 +357,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:subimagename: "disparityR"
     oiio:subimages: 10
     openexr:chunkCount: 876
@@ -357,6 +374,7 @@ Reading ../openexr-images/Beachball/multipart.0001.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
+    oiio:miplevels: 1
     oiio:subimagename: "whitebarmask_right"
     oiio:subimages: 10
     openexr:chunkCount: 769

--- a/testsuite/openexr-window/ref/out.txt
+++ b/testsuite/openexr-window/ref/out.txt
@@ -6,6 +6,7 @@ Reading ../openexr-images/DisplayWindow/t01.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -21,6 +22,7 @@ Reading ../openexr-images/DisplayWindow/t02.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -36,6 +38,7 @@ Reading ../openexr-images/DisplayWindow/t03.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -51,6 +54,7 @@ Reading ../openexr-images/DisplayWindow/t04.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -66,6 +70,7 @@ Reading ../openexr-images/DisplayWindow/t05.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -81,6 +86,7 @@ Reading ../openexr-images/DisplayWindow/t06.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -96,6 +102,7 @@ Reading ../openexr-images/DisplayWindow/t07.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -112,6 +119,7 @@ Reading ../openexr-images/DisplayWindow/t08.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -127,6 +135,7 @@ Reading ../openexr-images/DisplayWindow/t09.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -142,6 +151,7 @@ Reading ../openexr-images/DisplayWindow/t10.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -157,6 +167,7 @@ Reading ../openexr-images/DisplayWindow/t11.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -172,6 +183,7 @@ Reading ../openexr-images/DisplayWindow/t12.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -187,6 +199,7 @@ Reading ../openexr-images/DisplayWindow/t13.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -202,6 +215,7 @@ Reading ../openexr-images/DisplayWindow/t14.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -217,6 +231,7 @@ Reading ../openexr-images/DisplayWindow/t15.exr
     PixelAspectRatio: 1.5
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
@@ -232,6 +247,7 @@ Reading ../openexr-images/DisplayWindow/t16.exr
     PixelAspectRatio: 0.666667
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -250,6 +250,12 @@ Testing error handling for out-of-range subimage, miplevel
   tahoe-tiny.tif subimage 0 mip 0: True 
   tahoe-tiny.tif subimage 0 mip 1: False Could not seek to subimage=0 miplevel=1
 
+Testing the number of miplevels
+  ../common/bayer.png nmiplevels: 1
+  ../common/grid-small.exr nmiplevels: 1
+  ../common/textures/grid.tx nmiplevels: 11
+  ../common/tahoe-tiny.tif nmiplevels: 1
+
 Done.
 Comparing "out.tif" and "ref/out.tif"
 PASS

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -222,6 +222,14 @@ def test_outofrange_subimage_miplevel() :
         print(" ", f, "subimage 0 mip 1:", ok, buf.geterror())
 
 
+# Test for the number of MIP levels.
+def test_nmiplevels():
+    print("\nTesting the number of miplevels")
+    for f in ["../common/bayer.png", "../common/grid-small.exr",
+              "../common/textures/grid.tx", "../common/tahoe-tiny.tif"]:
+        buf = oiio.ImageBuf(f, 0, 0)
+        print(" ", f, "nmiplevels:", buf.nmiplevels)
+
 
 ######################################################################
 # main test starts here
@@ -279,7 +287,7 @@ try:
     b.read ()
     if b.nsubimages != 0:
         print ("subimage:", b.subimage, " / ", b.nsubimages)
-    if b.nmiplevels != 0:
+    if b.nmiplevels != 11:
         print ("miplevel:", b.miplevel, " / ", b.nmiplevels)
     print ("channels:", b.nchannels)
     print ("name:", b.name)
@@ -349,6 +357,7 @@ try:
     test_copy_metadata ()
     test_repr_png ()
     test_outofrange_subimage_miplevel ()
+    test_nmiplevels()
 
     print ("\nDone.")
 except Exception as detail:

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -63,6 +63,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     timecodeRate: 24
     Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     oiio:ColorSpace: "lin_ap0_scene"
+    oiio:miplevels: 1
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"
     smpte:TimeCode: 01:18:19:06
@@ -77,6 +78,7 @@ rat2.exr             :   64 x   64, 3 channel, float openexr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     oiio:subimages: 1
     openexr:lineOrder: "increasingY"

--- a/testsuite/tiff-depths/ref/out-linuxarm.txt
+++ b/testsuite/tiff-depths/ref/out-linuxarm.txt
@@ -12,6 +12,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -37,6 +38,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -62,6 +64,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-06.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 6
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -87,6 +90,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -112,6 +116,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -137,6 +142,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -162,6 +168,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -187,6 +194,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -212,6 +220,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -237,6 +246,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -262,6 +272,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 431
     tiff:BitsPerSample: 2
     tiff:ColorSpace: "palette"
@@ -289,6 +300,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 221
     tiff:BitsPerSample: 4
     tiff:ColorSpace: "palette"
@@ -316,6 +328,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -342,6 +355,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -368,6 +382,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -393,6 +408,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -418,6 +434,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -443,6 +460,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 29
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -468,6 +486,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 24
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -493,6 +512,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 21
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -518,6 +538,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 18
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -543,6 +564,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 12
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -568,6 +590,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 9
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -593,6 +616,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -618,6 +642,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -643,6 +668,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -668,6 +694,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -693,6 +720,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -718,6 +746,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -743,6 +772,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -768,6 +798,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -793,6 +824,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -818,6 +850,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
@@ -844,6 +877,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 14
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
@@ -870,6 +904,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
@@ -896,6 +931,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -12,6 +12,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -37,6 +38,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -62,6 +64,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-06.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 6
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -87,6 +90,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -112,6 +116,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -137,6 +142,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -162,6 +168,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -187,6 +194,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -212,6 +220,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -237,6 +246,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-minisblack-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
@@ -262,6 +272,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 431
     tiff:BitsPerSample: 2
     tiff:ColorSpace: "palette"
@@ -289,6 +300,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 221
     tiff:BitsPerSample: 4
     tiff:ColorSpace: "palette"
@@ -316,6 +328,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -342,6 +355,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-palette-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:ColorSpace: "palette"
     tiff:Compression: 1
@@ -368,6 +382,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 148
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -393,6 +408,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -418,6 +434,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -443,6 +460,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 29
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -468,6 +486,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 24
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -493,6 +512,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 21
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -518,6 +538,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 18
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -543,6 +564,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 12
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -568,6 +590,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 9
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -593,6 +616,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 2
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 431
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -618,6 +642,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 4
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 221
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -643,6 +668,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -668,6 +694,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 10
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 89
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -693,6 +720,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 12
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 74
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -718,6 +746,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 14
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 64
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -743,6 +772,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -768,6 +798,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 24
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 37
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -793,6 +824,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 32
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -818,6 +850,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
@@ -844,6 +877,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 14
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
@@ -870,6 +904,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 112
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1
@@ -896,6 +931,7 @@ Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 56
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff403-b.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff403-b.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -36,6 +37,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -55,6 +57,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff403-c.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff403-c.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -36,6 +37,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -55,6 +57,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff403.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff403.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -36,6 +37,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -55,6 +57,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff409.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff409.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -36,6 +37,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -55,6 +57,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff410.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff410.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -36,6 +37,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -55,6 +57,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff430.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff430.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -51,6 +52,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -70,6 +72,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff470-b.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff470-b.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -51,6 +52,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -70,6 +72,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff470-c.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff470-c.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -51,6 +52,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -70,6 +72,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out-libtiff470.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff470.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -51,6 +52,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     GPS:TrackRef: "T" (true north)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -70,6 +72,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-misc/ref/out.txt
+++ b/testsuite/tiff-misc/ref/out.txt
@@ -8,6 +8,7 @@ src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "separate"
     Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 7
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -36,6 +37,7 @@ gps.tif              :   64 x   64, 3 channel, uint8 tiff
     Exif:SubjectDistance: 0 (0 m)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
@@ -55,6 +57,7 @@ src/crash-cmyk-1bit.tif :   73 x   43, 3 channel, uint1 tiff
     XResolution: 0
     YResolution: 72
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 28
     tiff:ColorSpace: "CMYK"
     tiff:Compression: 1

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
@@ -23,6 +24,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
@@ -39,6 +41,7 @@ Reading ../oiio-images/libtiffpic/cramps-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -89,6 +92,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -108,6 +112,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 25
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -129,6 +134,7 @@ Reading ../oiio-images/libtiffpic/fax2d.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -148,6 +154,7 @@ Reading ../oiio-images/libtiffpic/g3test.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -162,6 +169,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
@@ -182,6 +190,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
@@ -202,6 +211,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
@@ -222,6 +232,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
@@ -272,6 +283,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -288,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -300,6 +313,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
@@ -319,6 +333,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
@@ -337,6 +352,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
@@ -359,6 +375,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
@@ -379,6 +396,7 @@ Reading ../oiio-images/libtiffpic/zackthecat.tif
     YResolution: 75
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6
@@ -390,6 +408,7 @@ Reading ../oiio-images/libtiffpic/oxford.tif
     compression: "lzw"
     planarconfig: "separate"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2

--- a/testsuite/tiff-suite/ref/out-alt2.txt
+++ b/testsuite/tiff-suite/ref/out-alt2.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
@@ -23,6 +24,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
@@ -39,6 +41,7 @@ Reading ../oiio-images/libtiffpic/cramps-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -89,6 +92,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -108,6 +112,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 120
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -129,6 +134,7 @@ Reading ../oiio-images/libtiffpic/fax2d.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -148,6 +154,7 @@ Reading ../oiio-images/libtiffpic/g3test.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -162,6 +169,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
@@ -182,6 +190,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
@@ -202,6 +211,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
@@ -222,6 +232,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
@@ -272,6 +283,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -288,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -300,6 +313,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
@@ -319,6 +333,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
@@ -337,6 +352,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
@@ -359,6 +375,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
@@ -379,6 +396,7 @@ Reading ../oiio-images/libtiffpic/zackthecat.tif
     YResolution: 75
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6
@@ -390,6 +408,7 @@ Reading ../oiio-images/libtiffpic/oxford.tif
     compression: "lzw"
     planarconfig: "separate"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
@@ -23,6 +24,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
@@ -39,6 +41,7 @@ Reading ../oiio-images/libtiffpic/cramps-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -89,6 +92,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -108,6 +112,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 25
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -129,6 +134,7 @@ Reading ../oiio-images/libtiffpic/fax2d.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -148,6 +154,7 @@ Reading ../oiio-images/libtiffpic/g3test.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -162,6 +169,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
@@ -182,6 +190,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
@@ -202,6 +211,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
@@ -222,6 +232,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
@@ -272,6 +283,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -288,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -300,6 +313,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
@@ -319,6 +333,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
@@ -337,6 +352,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
@@ -359,6 +375,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
@@ -379,6 +396,7 @@ Reading ../oiio-images/libtiffpic/zackthecat.tif
     YResolution: 75
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6
@@ -390,6 +408,7 @@ Reading ../oiio-images/libtiffpic/oxford.tif
     compression: "lzw"
     planarconfig: "separate"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2

--- a/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
@@ -23,6 +24,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
@@ -39,6 +41,7 @@ Reading ../oiio-images/libtiffpic/cramps-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -89,6 +92,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -108,6 +112,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 120
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -129,6 +134,7 @@ Reading ../oiio-images/libtiffpic/fax2d.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -148,6 +154,7 @@ Reading ../oiio-images/libtiffpic/g3test.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -162,6 +169,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
@@ -182,6 +190,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
@@ -202,6 +211,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
@@ -222,6 +232,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
@@ -272,6 +283,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -288,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -300,6 +313,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
@@ -319,6 +333,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
@@ -337,6 +352,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
@@ -359,6 +375,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
@@ -379,6 +396,7 @@ Reading ../oiio-images/libtiffpic/zackthecat.tif
     YResolution: 75
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6
@@ -390,6 +408,7 @@ Reading ../oiio-images/libtiffpic/oxford.tif
     compression: "lzw"
     planarconfig: "separate"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -5,6 +5,7 @@ Reading ../oiio-images/libtiffpic/caspian.tif
     compression: "zip"
     planarconfig: "separate"
     oiio:BitsPerSample: 64
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 3
     tiff:Compression: 32946
     tiff:PhotometricInterpretation: 2
@@ -23,6 +24,7 @@ Reading ../oiio-images/libtiffpic/cramps.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 12
     tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
@@ -39,6 +41,7 @@ Reading ../oiio-images/libtiffpic/cramps-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
@@ -89,6 +92,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 15
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -108,6 +112,7 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:YCbCrPositioning: 2
     Exif:YCbCrSubsampling: 2, 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 25
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 1
@@ -129,6 +134,7 @@ Reading ../oiio-images/libtiffpic/fax2d.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -148,6 +154,7 @@ Reading ../oiio-images/libtiffpic/g3test.tif
     XResolution: 204
     YResolution: 98
     oiio:BitsPerSample: 1
+    oiio:miplevels: 1
     tiff:Compression: 3
     tiff:PageNumber: 1, 1
     tiff:PhotometricInterpretation: 0
@@ -162,6 +169,7 @@ Reading ../oiio-images/libtiffpic/jello.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:ColorSpace: "palette"
     tiff:Compression: 32773
@@ -182,6 +190,7 @@ Reading ../oiio-images/libtiffpic/off_l16.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGL"
     tiff:Compression: 34676
@@ -202,6 +211,7 @@ Reading ../oiio-images/libtiffpic/off_luv24.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34677
@@ -222,6 +232,7 @@ Reading ../oiio-images/libtiffpic/off_luv32.tif
     XResolution: 72
     YResolution: 72
     oiio:BitsPerSample: 16
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:ColorSpace: "LOGLUV"
     tiff:Compression: 34676
@@ -272,6 +283,7 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:WhiteBalance: 0 (auto)
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 32
     tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
@@ -288,6 +300,7 @@ Reading ../oiio-images/libtiffpic/quad-tile.tif
     Orientation: 1 (normal)
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -300,6 +313,7 @@ Reading ../oiio-images/libtiffpic/quad-jpeg.tif
     compression: "jpeg"
     planarconfig: "contig"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 16
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 7
@@ -319,6 +333,7 @@ Reading ../oiio-images/libtiffpic/strike.tif
     XResolution: 1
     YResolution: 1
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 8
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
@@ -337,6 +352,7 @@ Reading ../oiio-images/libtiffpic/ycbcr-cat.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 10
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
@@ -359,6 +375,7 @@ Reading ../oiio-images/libtiffpic/smallliz.tif
     Exif:YCbCrPositioning: 1
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     oiio:RowsPerChunk: 160
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
@@ -379,6 +396,7 @@ Reading ../oiio-images/libtiffpic/zackthecat.tif
     YResolution: 75
     Exif:YCbCrSubsampling: 2, 2
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:ColorSpace: "YCbCr"
     tiff:Compression: 6
     tiff:PhotometricInterpretation: 6
@@ -390,6 +408,7 @@ Reading ../oiio-images/libtiffpic/oxford.tif
     compression: "lzw"
     planarconfig: "separate"
     oiio:BitsPerSample: 8
+    oiio:miplevels: 1
     tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2


### PR DESCRIPTION
The ImageBuf constructor path without an ImageCache ends in `init_spec()`. There, the non-IC branch only reset `m_nmiplevels = 0` and never assigned a real value, so `nmiplevels()` always returned 0.

Now `init_spec()` sets `m_nmiplevels = 1` if the format doesn't support mipmaps, or assigns the number of MIP levels if it can be known up front. If a format does support mipmaps but the count requires walking through the levels, then it's counted by iteration, lazily on the `nmiplevels()` call. The iteration calls `spec_dimensions()` repeatedly until it returns an empty ImageSpec.

This improves EXR, DDS, and Ptex to set the "oiio:miplevels" attribute when read (Ptex previously set it only for MIP-mapped files), so that `init_spec()` can get the attribute's value and save it to `ImageBufImpl::m_nmiplevels`. For TIFF, it only sets the attribute to 1 when a file has no texture format tag, because an iteration would be needed to get the number of MIP levels otherwise. Setting the attribute to 1 up front avoids an unnecessary open for non-mipmapped TIFF files.

Additionally, an ImageBuf that doesn't have a direct reference to a file returns 1 as documented.

A test for `IB::nmiplevels()` is added to the python-imagebuf testsuite. Also test reference files affected by the new "oiio:miplevels" attribute are all updated accordingly.

Fixes #5409