### PR TITLE
deps: Bump DCMTK minimum to 3.6.2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        1.17 required for monochrome HEIC support; tested through 1.23.1)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.
  * If you want support for DICOM medical image files:
-     * DCMTK >= 3.6.1 (tested through 3.7.0)
+     * **DCMTK >= 3.6.2** (tested through 3.7.0)
  * If you want support for WebP images:
      * WebP >= 1.1 (tested through 1.6)
  * If you want support for Ptex:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -178,7 +178,7 @@ checked_find_package (TBB 2017
                       PREFER_CONFIG)
 
 # DCMTK is used to read DICOM images
-checked_find_package (DCMTK CONFIG VERSION_MIN 3.6.1)
+checked_find_package (DCMTK CONFIG VERSION_MIN 3.6.2)
 
 checked_find_package (FFmpeg VERSION_MIN 4.0)
 

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -295,11 +295,7 @@ DICOMInput::read_metadata()
                 float val;
                 if (dataset->findAndGetFloat32(tag, val).good())
                     m_spec.attribute(name, val);
-            } else if (evr == EVR_FD
-#if PACKAGE_VERSION_NUMBER >= 362
-                       || evr == EVR_OD
-#endif
-            ) {
+            } else if (evr == EVR_FD || evr == EVR_OD) {
                 double val;
                 if (dataset->findAndGetFloat64(tag, val).good())
                     m_spec.attribute(name, (float)val);
@@ -320,10 +316,7 @@ DICOMInput::read_metadata()
                        || evr == EVR_DT || evr == EVR_LT || evr == EVR_PN
                        || evr == EVR_ST || evr == EVR_TM || evr == EVR_UI
                        || evr == EVR_UT || evr == EVR_LO || evr == EVR_SH
-#if PACKAGE_VERSION_NUMBER >= 362
-                       || evr == EVR_UC || evr == EVR_UR
-#endif
-            ) {
+                       || evr == EVR_UC || evr == EVR_UR) {
                 OFString val;
                 if (dataset->findAndGetOFString(tag, val).good())
                     m_spec.attribute(name, val.c_str());


### PR DESCRIPTION
This is still many many years old, but it's the only jump (from 3.6.1) that gives us any code simplification on our side, to there's no benefit to us of insisting on an even newer minimum version.
