### PR TITLE
cleanup: Raise ABI standard to latest patch release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,8 +358,8 @@ jobs:
             pybind11_ver: v3.0.0
             simd: "avx2,f16c"
             skip_tests: 1
-            # abi_check: v3.1.6.0
-            abi_check: fd8e13c48bb154a011ac1c37980fce3d405ec74e
+            # abi_check: v3.1.17.0
+            abi_check: 73bc189f7d8469a9760ce9c5099b686c77695074
             setenvs: export OIIO_CMAKE_FLAGS="-DOIIO_BUILD_TOOLS=0 -DOIIO_BUILD_TESTS=0 -DUSE_PYTHON=0"
                             USE_OPENCV=0 USE_FFMPEG=0 USE_PYTHON=0 USE_FREETYPE=0
             optional_deps_append: "openjph;Qt6"


### PR DESCRIPTION
Bump the "abi_check" commit to 3.1.17.0 to capture anything else we added to 3.1 after the last ABI sync point.

(Note: this is for merging into 3.1. We need more work for main/3.2 that will come separately.)