### PR TITLE
cleanup: Fix ABI issues, bump standard, allow exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,8 +255,8 @@ jobs:
             pybind11_ver: v3.0.0
             simd: "avx2,f16c"
             skip_tests: 1
-            # abi_check: v3.1.6.0
-            abi_check: d4c8024633dba8bb3c01d22b65ce9bc7a1ae215e
+            # abi_check: v3.1.17.0
+            abi_check: 73bc189f7d8469a9760ce9c5099b686c77695074
             setenvs: export OIIO_CMAKE_FLAGS="-DOIIO_BUILD_TOOLS=0 -DOIIO_BUILD_TESTS=0 -DUSE_PYTHON=0"
                             USE_OPENCV=0 USE_FFMPEG=0 USE_PYTHON=0 USE_FREETYPE=0
             optional_deps_append: "Qt6"

--- a/src/build-scripts/ci-abicheck.bash
+++ b/src/build-scripts/ci-abicheck.bash
@@ -32,10 +32,40 @@ done
 echo "Saved ABI dumps"
 
 #
+# Things to exclude from the comparison. Both are Perl regexes matched against
+# any part of a (demangled) type name / (mangled) symbol name, and both can be
+# set per-CI-job (e.g. via the job's `setenvs:`), since different ABI baselines
+# (vs 3.1, vs 3.2, ...) legitimately want to ignore different things:
+#
+#   ABI_SKIP_TYPES_RE    types whose internal changes should not be reported
+#   ABI_SKIP_SYMBOLS_RE  symbols whose changes/removals should not be reported
+#
+# `ABI_SKIP_TYPES_RE` defaults to the span family: `span<T>` (and hence
+# `cspan<T>`, which is just `span<const T>`) is always a pointer + size, by
+# design tracking std::span, so its layout will never change -- but abi-dumper
+# picks a representative among the layout-identical `span<...>` instantiations
+# that varies between builds, so acc periodically reports a spurious "base type
+# has been changed ... of different format" diff on it.
+#
+# (Use ${VAR-default} so a job can force "no skipping" with an explicit empty
+# value, e.g. `setenvs: export ABI_SKIP_TYPES_RE=`.)
+ABI_SKIP_TYPES_RE=${ABI_SKIP_TYPES_RE-'span<'}
+ABI_SKIP_SYMBOLS_RE=${ABI_SKIP_SYMBOLS_RE-}
+
+ABI_SKIP_ARGS=""
+if [[ -n $ABI_SKIP_TYPES_RE ]] ; then
+    ABI_SKIP_ARGS+=" -skip-internal-types $ABI_SKIP_TYPES_RE"
+fi
+if [[ -n $ABI_SKIP_SYMBOLS_RE ]] ; then
+    ABI_SKIP_ARGS+=" -skip-internal-symbols $ABI_SKIP_SYMBOLS_RE"
+fi
+echo "ABI_CHECK: skip args:${ABI_SKIP_ARGS:- none}"
+
+#
 # Run the ABI compliance checker, saving the outputs to files
 #
 for lib in $LIBS ; do
-    abi-compliance-checker -l $lib -old $BUILDDIR_OLD/abi-$lib.dump -new $BUILDDIR_NEW/abi-$lib.dump | tee ${lib}-abi-results.txt || true
+    abi-compliance-checker -l $lib -old $BUILDDIR_OLD/abi-$lib.dump -new $BUILDDIR_NEW/abi-$lib.dump $ABI_SKIP_ARGS | tee ${lib}-abi-results.txt || true
     echo -e "\x1b[33;1m"
     echo -e "$lib"
     fgrep "Binary compatibility:" ${lib}-abi-results.txt

--- a/src/include/OpenImageIO/detail/pugixml/pugiconfig.hpp
+++ b/src/include/OpenImageIO/detail/pugixml/pugiconfig.hpp
@@ -50,7 +50,9 @@
 // #define PUGIXML_XPATH_DEPTH_LIMIT 1024
 
 // Uncomment this to switch to header-only version
-// #define PUGIXML_HEADER_ONLY
+// OIIO: we build the vendored pugixml header-only so its symbols stay inline
+// and hidden, never exported into libOpenImageIO's ABI.
+#define PUGIXML_HEADER_ONLY
 
 // Uncomment this to enable long long support (usually enabled automatically)
 // #define PUGIXML_HAS_LONG_LONG

--- a/src/include/OpenImageIO/nsversions.h
+++ b/src/include/OpenImageIO/nsversions.h
@@ -155,6 +155,10 @@
 #define OIIO_NAMESPACE_3_2_BEGIN OIIO_NS_BEGIN(v3_2)
 #define OIIO_NAMESPACE_3_2_END OIIO_NS_END
 
+// Specialty macro: Make something ABI compatible with 3.3
+#define OIIO_NAMESPACE_3_3_BEGIN OIIO_NS_BEGIN(v3_3)
+#define OIIO_NAMESPACE_3_3_END OIIO_NS_END
+
 
 
 // Forward declarations of important classes

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -197,33 +197,6 @@ parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
                      paropt opt = paropt(0, paropt::SplitDir::Y, 1));
 
 
-#ifndef OIIO_DOXYGEN
-// DEPRECATED(3.2) -- old version makes a copy of task instead of &&, ick
-OIIO_UTIL_API void parallel_for(int32_t begin, int32_t end,
-                                function_view<void(int32_t)> task,
-                                paropt opt = 0);
-
-// DEPRECATED(3.2) -- old version makes a copy of task instead of &&, ick
-OIIO_UTIL_API void parallel_for(int64_t begin, int64_t end,
-                                function_view<void(int64_t)> task,
-                                paropt opt = 0);
-
-// DEPRECATED(3.2) -- old version makes a copy of task instead of &&, ick
-OIIO_UTIL_API void parallel_for(uint32_t begin, uint32_t end,
-                                function_view<void(uint32_t)> task,
-                                paropt opt = 0);
-
-// DEPRECATED(3.2) -- old version makes a copy of task instead of &&, ick
-OIIO_UTIL_API void parallel_for(uint64_t begin, uint64_t end,
-                                function_view<void(uint64_t)> task,
-                                paropt opt = 0);
-#endif
-
-OIIO_NAMESPACE_3_1_END
-
-
-OIIO_NAMESPACE_BEGIN
-
 /// Parallel "for" loop, for a task that takes a single integer index, run
 /// it on all indices on the range [begin,end):
 ///
@@ -252,10 +225,7 @@ OIIO_UTIL_API void parallel_for(uint64_t begin, uint64_t end,
                                 function_view<void(uint64_t)>&& task,
                                 paropt opt = 0);
 
-OIIO_NAMESPACE_END
 
-
-OIIO_NAMESPACE_3_1_BEGIN
 
 /// Parallel "for" loop, for a task that takes an integer range, run it
 /// on all indices on the range [begin,end):
@@ -332,6 +302,7 @@ OIIO_NAMESPACE_3_1_END
 // Compatibility
 OIIO_NAMESPACE_BEGIN
 #ifndef OIIO_DOXYGEN
+using v3_1::parallel_for;
 using v3_1::parallel_for_2D;
 using v3_1::parallel_for_chunked;
 using v3_1::parallel_for_chunked_2D;

--- a/src/libOpenImageIO/imagebufalgo_flip.cpp
+++ b/src/libOpenImageIO/imagebufalgo_flip.cpp
@@ -1237,4 +1237,25 @@ ImageBufAlgo::FLIP_diff(const ImageBuf& ref, const ImageBuf& test,
     return dst;
 }
 
+
+// These are just for link compatibility with 3.1 and 3.2 "main" before
+// release, when these were in the experimental namespace.
+namespace ImageBufAlgo {
+namespace experimental {
+    bool OIIO_API FLIP_diff(ImageBuf& dst, const ImageBuf& ref,
+                            const ImageBuf& test, KWArgs options, ROI roi,
+                            int nthreads)
+    {
+        return ImageBufAlgo::FLIP_diff(dst, ref, test, options, roi, nthreads);
+    }
+
+
+    ImageBuf OIIO_API FLIP_diff(const ImageBuf& ref, const ImageBuf& test,
+                                KWArgs options, ROI roi, int nthreads)
+    {
+        return ImageBufAlgo::FLIP_diff(ref, test, options, roi, nthreads);
+    }
+}  // namespace experimental
+}  // namespace ImageBufAlgo
+
 OIIO_NAMESPACE_3_1_END

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -690,16 +690,16 @@ parallel_for_impl(Index begin, Index end, function_view<void(Index)>&& task,
 
 
 
-// DEPRECATED
-void
+// DEPRECATED(3.2) -- no longer declared in header, just for link compat
+OIIO_UTIL_API void
 parallel_for(int begin, int end, function_view<void(int)> task, paropt opt)
 {
     parallel_for_impl(begin, end, std::move(task), opt);
 }
 
 
-// DEPRECATED
-void
+// DEPRECATED(3.2) -- no longer declared in header, just for link compat
+OIIO_UTIL_API void
 parallel_for(uint32_t begin, uint32_t end, function_view<void(uint32_t)> task,
              paropt opt)
 {
@@ -707,8 +707,8 @@ parallel_for(uint32_t begin, uint32_t end, function_view<void(uint32_t)> task,
 }
 
 
-// DEPRECATED
-void
+// DEPRECATED(3.2) -- no longer declared in header, just for link compat
+OIIO_UTIL_API void
 parallel_for(int64_t begin, int64_t end, function_view<void(int64_t)> task,
              paropt opt)
 {
@@ -716,18 +716,15 @@ parallel_for(int64_t begin, int64_t end, function_view<void(int64_t)> task,
 }
 
 
-// DEPRECATED
-void
+// DEPRECATED(3.2) -- no longer declared in header, just for link compat
+OIIO_UTIL_API void
 parallel_for(uint64_t begin, uint64_t end, function_view<void(uint64_t)> task,
              paropt opt)
 {
     parallel_for_impl(begin, end, std::move(task), opt);
 }
 
-OIIO_NAMESPACE_3_1_END
 
-
-OIIO_NAMESPACE_BEGIN
 
 void
 parallel_for(int begin, int end, function_view<void(int)>&& task, paropt opt)
@@ -759,10 +756,7 @@ parallel_for(uint64_t begin, uint64_t end, function_view<void(uint64_t)>&& task,
     parallel_for_impl(begin, end, std::move(task), opt);
 }
 
-OIIO_NAMESPACE_END
 
-
-OIIO_NAMESPACE_3_1_BEGIN
 
 template<typename Index>
 inline void


### PR DESCRIPTION
Careful inspection of the ABI check reports reveals a couple issues I want to fix up before tagging a 3.2 beta. I actually made a couple mistakes with ABI -- but only in main, so it's ok to break (i.e. fix) in this minor way before branching the beta.

First, a while back, we changed the call signatures of the parallel_for functions in parallel.h. The old, to-be-deprecated ones were in the 3_1 namespace, and I unwisely put the new ones in the "current" namespace, which after renaming main to be 3.2, became the 3_2 namespace.

This was wrong. Because the functions were overloadable but looked the same in a source call, I should have just added the new ones in the 3_1 namespace, and commented out the deprecated in the header so they would never be chosen when compiling new modules (but still have both sets in thread.cpp, so old code would continue to link).

Switching now to the scheme I should have used all along.

Second, when we recently upgraded the vendored PugiXML, I forgot to preserve a customization I made before that turned on the PUGIXML_HEADER_ONLY. Not doing so after the upgrade incorrectly allowed all the PugiXML symbols to be visible exports of our library. Fix that mistake now (also only was ever in main).

These changes will be fine for the supported 3.2 release. It will break ABI versus the 3.2 main branch, as it was before 3.2 release. So what -- we explicitly do not guarantee ABI compatibility at all for pre-release code.

Bump the "abi_check" commit to 3.1.17.0 to capture anything else we added to 3.1 after the last ABI sync point.

Allow skipping false positives via env variable, where the ABI CI jobs can specify to skip certain issues known not to be harmful.

Assisted-by: Claude Code / sonnet-5  (for some analysis of what was going wrong, and advice on how to make the abi checker skip the false positives)
