### PR TITLE
feat(webp): add experimental OpenMeta (Apache 2.0) metadata decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,13 @@ include_directories (
 # Tell CMake to process the sub-directories
 add_subdirectory (src/libutil)
 
+set (OIIO_OPENMETA_BRIDGE_ENABLED OFF)
+if (OpenMeta_FOUND AND TARGET OpenMeta::openmeta
+        AND NOT BUILD_OIIOUTIL_ONLY)
+    set (OIIO_OPENMETA_BRIDGE_ENABLED ON)
+    add_subdirectory (src/openmeta.bridge)
+endif ()
+
 # Add IO plugin directories -- if we are embedding plugins, we need to visit
 # these directories BEFORE the OpenImageIO target is established (in
 # src/libOpenImageIO). For each plugin, we append to the lists of source

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,6 +76,9 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * DCMTK >= 3.6.2 (tested through 3.7.0)
  * If you want support for WebP images:
      * WebP >= 1.1 (tested through 1.6)
+     * OpenMeta >= 0.4.118 is an experimental optional metadata decoder,
+       enabled with `USE_OPENMETA=ON`. OpenMeta and its bridge are compiled as
+       C++20, while OpenImageIO and the bridge facade retain C++17 interfaces.
  * If you want support for Ptex:
      * Ptex >= 2.3.1 (probably works for older; tested through 2.5)
  * If you want to be able to do font rendering into images:

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -17,6 +17,13 @@ if (NOT @fmt_LOCAL_BUILD@ AND (NOT @OIIO_INTERNALIZE_FMT@ OR @OIIO_USE_COMPILED_
 endif ()
 
 if (NOT @BUILD_SHARED_LIBS@)
+    if (@OIIO_USE_HWY@)
+        # OpenMeta dependencies may otherwise create a partial Highway import.
+        find_dependency(hwy CONFIG)
+    endif ()
+    if (@OIIO_OPENMETA_BRIDGE_ENABLED@ AND @EMBEDPLUGINS@)
+        find_dependency(OpenMeta CONFIG)
+    endif ()
     # This is required in static library builds, as e.g. PNG::PNG appears among
     # INTERFACE_LINK_LIBRARIES. If the project does not know about PNG target, it will cause
     # configuration error about unknown targets being linked in.

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -221,6 +221,21 @@ endif ()
 
 checked_find_package (WebP VERSION_MIN 1.1)
 
+# Import the complete Highway target set before OpenMeta dependencies.
+if (OIIO_USE_HWY)
+    checked_find_package (hwy)
+endif ()
+
+option (USE_OPENMETA "Enable experimental OpenMeta metadata decoding" OFF)
+checked_find_package (OpenMeta CONFIG
+                      VERSION_MIN 0.4.118)
+if (OpenMeta_FOUND AND NOT TARGET OpenMeta::openmeta)
+    message (WARNING
+             "OpenMeta was found without an OpenMeta::openmeta target; "
+             "disabling it")
+    set (OpenMeta_FOUND FALSE)
+endif ()
+
 option (USE_R3DSDK "Enable R3DSDK (RED camera) support" OFF)
 checked_find_package (R3DSDK NO_RECORD_NOTFOUND)  # RED camera
 
@@ -249,11 +264,6 @@ if (USE_QT AND OPENGL_FOUND)
     endif ()
 endif ()
 
-
-# Google Highway for SIMD (optional optimization)
-if (OIIO_USE_HWY)
-    checked_find_package (hwy)
-endif ()
 
 # Tessil/robin-map. Use its own exported CMake config (target tsl::robin_map)
 # rather than a bespoke Find module. This also means that when the nanobind

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -548,6 +548,10 @@ macro (oiio_add_all_tests)
     oiio_add_tests (webp
                     FOUNDVAR WebP_FOUND ENABLEVAR ENABLE_WebP
                     IMAGEDIR oiio-images/webp)
+    if (TARGET OpenImageIO_OpenMeta)
+        oiio_add_tests (webp-openmeta
+                        FOUNDVAR WebP_FOUND ENABLEVAR ENABLE_WebP)
+    endif ()
     oiio_add_tests (zfile ENABLEVAR ENABLE_ZFILE
                     IMAGEDIR oiio-images)
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -3193,6 +3193,11 @@ Webp
 WebP is an image file format developed by Google that is intended to be an
 open standard for lossy-compressed images for use on the web.
 
+When OpenImageIO is built with the experimental ``USE_OPENMETA=ON`` option,
+the WebP reader uses OpenMeta to decode EXIF and XMP into typed ImageSpec
+attributes, including structured XMP properties. Without OpenMeta, the WebP
+reader retains its legacy EXIF metadata handling.
+
 **Attributes**
 
 .. list-table::
@@ -3320,4 +3325,3 @@ of the z-buffer. Zfile files use the file extension :file:`.zfile`.
    * - ``worldtoscreen``
      - matrix
      - Nl
-

--- a/src/openmeta.bridge/CMakeLists.txt
+++ b/src/openmeta.bridge/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+if (BUILD_SHARED_LIBS)
+    add_library (OpenImageIO_OpenMetaBridge SHARED openmeta_bridge.cpp)
+    target_compile_definitions (OpenImageIO_OpenMetaBridge
+                                PRIVATE OIIO_OPENMETA_BRIDGE_EXPORTS=1)
+else ()
+    add_library (OpenImageIO_OpenMetaBridge STATIC openmeta_bridge.cpp)
+    target_compile_definitions (OpenImageIO_OpenMetaBridge
+                                PUBLIC OIIO_OPENMETA_BRIDGE_STATIC=1)
+endif ()
+target_compile_features (OpenImageIO_OpenMetaBridge PRIVATE cxx_std_20)
+target_include_directories (OpenImageIO_OpenMetaBridge
+                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries (OpenImageIO_OpenMetaBridge PRIVATE OpenMeta::openmeta)
+set (OpenImageIO_OpenMetaBridge_LINK_FLAGS "")
+if (BUILD_SHARED_LIBS)
+    set (OpenImageIO_OpenMetaBridge_LINK_FLAGS "${EXTRA_DSO_LINK_ARGS}")
+    if (UNIX AND NOT APPLE)
+        # OpenMeta is commonly static; do not export its symbols from the bridge.
+        string (APPEND OpenImageIO_OpenMetaBridge_LINK_FLAGS
+                " -Wl,--exclude-libs,ALL")
+    endif ()
+    if ((CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD")
+            OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
+        set (_openmeta_bridge_map
+             "${CMAKE_CURRENT_SOURCE_DIR}/openmeta_bridge.map")
+        string (APPEND OpenImageIO_OpenMetaBridge_LINK_FLAGS
+                " -Wl,--version-script=${_openmeta_bridge_map}")
+    elseif (APPLE)
+        set (_openmeta_bridge_exports
+             "${CMAKE_CURRENT_SOURCE_DIR}/openmeta_bridge.exports")
+        string (APPEND OpenImageIO_OpenMetaBridge_LINK_FLAGS
+                " -Wl,-exported_symbols_list," "${_openmeta_bridge_exports}")
+    endif ()
+endif ()
+set_target_properties (OpenImageIO_OpenMetaBridge PROPERTIES
+                       CXX_STANDARD 20
+                       CXX_STANDARD_REQUIRED ON
+                       CXX_EXTENSIONS OFF
+                       POSITION_INDEPENDENT_CODE ON
+                       LINK_FLAGS "${OpenImageIO_OpenMetaBridge_LINK_FLAGS}"
+                       FOLDER "Support")
+
+add_library (OpenImageIO_OpenMeta STATIC openmeta_oiio.cpp)
+target_compile_features (OpenImageIO_OpenMeta PRIVATE cxx_std_17)
+target_include_directories (OpenImageIO_OpenMeta
+                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_link_libraries (OpenImageIO_OpenMeta
+                       PRIVATE OpenImageIO_Util OpenImageIO_OpenMetaBridge)
+set_target_properties (OpenImageIO_OpenMeta PROPERTIES
+                       CXX_STANDARD 17
+                       CXX_STANDARD_REQUIRED ON
+                       CXX_EXTENSIONS OFF
+                       POSITION_INDEPENDENT_CODE ON
+                       FOLDER "Support")
+
+if (BUILD_SHARED_LIBS)
+    install (TARGETS OpenImageIO_OpenMetaBridge
+             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT user
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT user
+             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT developer)
+elseif (EMBEDPLUGINS)
+    install_targets (OpenImageIO_OpenMetaBridge OpenImageIO_OpenMeta)
+endif ()
+
+if (OIIO_BUILD_TESTS AND BUILD_TESTING)
+    fancy_add_executable (NAME openmeta_bridge_test
+                          SRC openmeta_bridge_test.cpp
+                          NO_INSTALL
+                          FOLDER "Unit Tests"
+                          LINK_LIBRARIES OpenImageIO_OpenMeta OpenImageIO_Util)
+    set_target_properties (openmeta_bridge_test PROPERTIES
+                           CXX_STANDARD 17
+                           CXX_STANDARD_REQUIRED ON
+                           CXX_EXTENSIONS OFF)
+    add_test (unit_openmeta_bridge
+              ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openmeta_bridge_test)
+endif ()

--- a/src/openmeta.bridge/openmeta_bridge.cpp
+++ b/src/openmeta.bridge/openmeta_bridge.cpp
@@ -305,8 +305,7 @@ namespace {
     struct ExportState final {
         std::span<const openmeta::Entry> entries;
         std::vector<uint8_t> entry_states;
-        std::unordered_set<std::string, TransparentStringHash,
-                           std::equal_to<>>
+        std::unordered_set<std::string, TransparentStringHash, std::equal_to<>>
             names;
     };
 
@@ -331,9 +330,8 @@ namespace {
             try {
                 if (m_state->entries.empty()
                     || item.entry < m_state->entries.data()
-                    || item.entry
-                           >= m_state->entries.data()
-                                  + m_state->entries.size()) {
+                    || item.entry >= m_state->entries.data()
+                                         + m_state->entries.size()) {
                     m_failed = true;
                     return;
                 }
@@ -342,9 +340,8 @@ namespace {
                 if (m_state->entry_states[entry_index] != 0)
                     return;
 
-                const bool is_xmp
-                    = item.entry->key.kind
-                      == openmeta::MetaKeyKind::XmpProperty;
+                const bool is_xmp = item.entry->key.kind
+                                    == openmeta::MetaKeyKind::XmpProperty;
                 if ((m_pass == ExportPass::NativeFlatHost && is_xmp)
                     || (m_pass == ExportPass::XmpFlatHost && !is_xmp)) {
                     return;
@@ -366,8 +363,7 @@ namespace {
                     return;
                 }
 
-                const auto inserted
-                    = m_state->names.emplace(item.name).second;
+                const auto inserted = m_state->names.emplace(item.name).second;
                 if (!inserted) {
                     // Retry flat-name collisions with canonical names.
                     if (m_pass == ExportPass::CanonicalFallback) {
@@ -639,8 +635,8 @@ decode_impl(const Source* source, Format format, const DecodeOptions* options,
                 openmeta::ExportOptions export_options;
                 export_options.style       = style;
                 export_options.name_policy = openmeta::ExportNamePolicy::Spec;
-                export_options.include_makernotes
-                    = requested.decode_makernote != 0;
+                export_options.include_makernotes = requested.decode_makernote
+                                                    != 0;
                 ExportSink sink(read.snapshot.store, attribute_callback,
                                 attribute_context, pass, &export_state);
                 openmeta::visit_metadata(read.snapshot.store, export_options,

--- a/src/openmeta.bridge/openmeta_bridge.cpp
+++ b/src/openmeta.bridge/openmeta_bridge.cpp
@@ -1,0 +1,721 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+#include "openmeta_bridge.h"
+
+#include <algorithm>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <new>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+#include <openmeta/host_adoption.h>
+#include <openmeta/interop_export.h>
+#include <openmeta/metadata_transfer.h>
+
+namespace oiio_openmeta {
+namespace {
+
+    openmeta::ContainerFormat to_openmeta_format(Format format) noexcept
+    {
+        switch (format) {
+        case Format::Jpeg: return openmeta::ContainerFormat::Jpeg;
+        case Format::Png: return openmeta::ContainerFormat::Png;
+        case Format::Webp: return openmeta::ContainerFormat::Webp;
+        case Format::Gif: return openmeta::ContainerFormat::Gif;
+        case Format::Tiff: return openmeta::ContainerFormat::Tiff;
+        case Format::Crw: return openmeta::ContainerFormat::Crw;
+        case Format::Raf: return openmeta::ContainerFormat::Raf;
+        case Format::X3f: return openmeta::ContainerFormat::X3f;
+        case Format::Jp2: return openmeta::ContainerFormat::Jp2;
+        case Format::Jxl: return openmeta::ContainerFormat::Jxl;
+        case Format::Heif: return openmeta::ContainerFormat::Heif;
+        case Format::Avif: return openmeta::ContainerFormat::Avif;
+        case Format::Cr3: return openmeta::ContainerFormat::Cr3;
+        case Format::Exr: return openmeta::ContainerFormat::Exr;
+        case Format::Unknown: break;
+        }
+        return openmeta::ContainerFormat::Unknown;
+    }
+
+    Format from_openmeta_format(openmeta::ContainerFormat format) noexcept
+    {
+        switch (format) {
+        case openmeta::ContainerFormat::Jpeg: return Format::Jpeg;
+        case openmeta::ContainerFormat::Png: return Format::Png;
+        case openmeta::ContainerFormat::Webp: return Format::Webp;
+        case openmeta::ContainerFormat::Gif: return Format::Gif;
+        case openmeta::ContainerFormat::Tiff: return Format::Tiff;
+        case openmeta::ContainerFormat::Crw: return Format::Crw;
+        case openmeta::ContainerFormat::Raf: return Format::Raf;
+        case openmeta::ContainerFormat::X3f: return Format::X3f;
+        case openmeta::ContainerFormat::Jp2: return Format::Jp2;
+        case openmeta::ContainerFormat::Jxl: return Format::Jxl;
+        case openmeta::ContainerFormat::Heif: return Format::Heif;
+        case openmeta::ContainerFormat::Avif: return Format::Avif;
+        case openmeta::ContainerFormat::Cr3: return Format::Cr3;
+        case openmeta::ContainerFormat::Exr: return Format::Exr;
+        case openmeta::ContainerFormat::Unknown: break;
+        }
+        return Format::Unknown;
+    }
+
+    openmeta::RandomAccessIoCode
+    to_openmeta_read_code(SourceReadCode code) noexcept
+    {
+        switch (code) {
+        case SourceReadCode::Ok: return openmeta::RandomAccessIoCode::Ok;
+        case SourceReadCode::IoError:
+            return openmeta::RandomAccessIoCode::IoError;
+        case SourceReadCode::SourceChanged:
+            return openmeta::RandomAccessIoCode::SourceChanged;
+        case SourceReadCode::Cancelled:
+            return openmeta::RandomAccessIoCode::Cancelled;
+        }
+        return openmeta::RandomAccessIoCode::IoError;
+    }
+
+    struct ReadContext final {
+        const Source* source = nullptr;
+    };
+
+    openmeta::RandomAccessIoResult
+    read_at(void* context, uint64_t offset,
+            std::span<std::byte> destination) noexcept
+    {
+        const auto* read_context = static_cast<const ReadContext*>(context);
+        if (!read_context || !read_context->source
+            || !read_context->source->read_at) {
+            return { openmeta::RandomAccessIoCode::IoError, 0 };
+        }
+
+        const SourceReadResult result
+            = read_context->source->read_at(read_context->source->context,
+                                            offset, destination.data(),
+                                            destination.size());
+        if (result.bytes_read > destination.size())
+            return { openmeta::RandomAccessIoCode::IoError, 0 };
+        return { to_openmeta_read_code(result.code), result.bytes_read };
+    }
+
+    bool to_size(uint64_t value, size_t* out) noexcept
+    {
+        if (!out || value > std::numeric_limits<size_t>::max())
+            return false;
+        *out = static_cast<size_t>(value);
+        return true;
+    }
+
+    ElementType
+    from_openmeta_element_type(openmeta::MetaElementType type) noexcept
+    {
+        switch (type) {
+        case openmeta::MetaElementType::U8: return ElementType::U8;
+        case openmeta::MetaElementType::I8: return ElementType::I8;
+        case openmeta::MetaElementType::U16: return ElementType::U16;
+        case openmeta::MetaElementType::I16: return ElementType::I16;
+        case openmeta::MetaElementType::U32: return ElementType::U32;
+        case openmeta::MetaElementType::I32: return ElementType::I32;
+        case openmeta::MetaElementType::U64: return ElementType::U64;
+        case openmeta::MetaElementType::I64: return ElementType::I64;
+        case openmeta::MetaElementType::F32: return ElementType::F32;
+        case openmeta::MetaElementType::F64: return ElementType::F64;
+        case openmeta::MetaElementType::URational:
+            return ElementType::URational;
+        case openmeta::MetaElementType::SRational:
+            return ElementType::SRational;
+        }
+        return ElementType::U8;
+    }
+
+    TextEncoding
+    from_openmeta_text_encoding(openmeta::TextEncoding encoding) noexcept
+    {
+        switch (encoding) {
+        case openmeta::TextEncoding::Unknown: return TextEncoding::Unknown;
+        case openmeta::TextEncoding::Ascii: return TextEncoding::Ascii;
+        case openmeta::TextEncoding::Utf8: return TextEncoding::Utf8;
+        case openmeta::TextEncoding::Utf16LE: return TextEncoding::Utf16LE;
+        case openmeta::TextEncoding::Utf16BE: return TextEncoding::Utf16BE;
+        }
+        return TextEncoding::Unknown;
+    }
+
+    uint64_t element_size(openmeta::MetaElementType type) noexcept
+    {
+        switch (type) {
+        case openmeta::MetaElementType::U8:
+        case openmeta::MetaElementType::I8: return 1;
+        case openmeta::MetaElementType::U16:
+        case openmeta::MetaElementType::I16: return 2;
+        case openmeta::MetaElementType::U32:
+        case openmeta::MetaElementType::I32:
+        case openmeta::MetaElementType::F32: return 4;
+        case openmeta::MetaElementType::U64:
+        case openmeta::MetaElementType::I64:
+        case openmeta::MetaElementType::F64:
+        case openmeta::MetaElementType::URational:
+        case openmeta::MetaElementType::SRational: return 8;
+        }
+        return 0;
+    }
+
+    struct ScalarStorage final {
+        uint8_t u8   = 0;
+        int8_t i8    = 0;
+        uint16_t u16 = 0;
+        int16_t i16  = 0;
+        uint32_t u32 = 0;
+        int32_t i32  = 0;
+        uint64_t u64 = 0;
+        int64_t i64  = 0;
+        float f32    = 0.0f;
+        double f64   = 0.0;
+        URational ur;
+        SRational sr;
+    };
+
+    bool make_value_view(const openmeta::MetaStore& store,
+                         const openmeta::MetaValue& value, ValueView* out,
+                         ScalarStorage* scalar) noexcept
+    {
+        if (!out || !scalar)
+            return false;
+
+        out->element_type = from_openmeta_element_type(value.elem_type);
+        out->encoding     = from_openmeta_text_encoding(value.text_encoding);
+        out->count        = value.count;
+
+        switch (value.kind) {
+        case openmeta::MetaValueKind::Empty:
+            out->kind = ValueKind::Empty;
+            return true;
+        case openmeta::MetaValueKind::Scalar:
+            out->kind  = ValueKind::Scalar;
+            out->count = 1;
+            out->size  = element_size(value.elem_type);
+            switch (value.elem_type) {
+            case openmeta::MetaElementType::U8:
+                scalar->u8 = static_cast<uint8_t>(value.data.u64);
+                out->data  = &scalar->u8;
+                break;
+            case openmeta::MetaElementType::U16:
+                scalar->u16 = static_cast<uint16_t>(value.data.u64);
+                out->data   = &scalar->u16;
+                break;
+            case openmeta::MetaElementType::U32:
+                scalar->u32 = static_cast<uint32_t>(value.data.u64);
+                out->data   = &scalar->u32;
+                break;
+            case openmeta::MetaElementType::U64:
+                scalar->u64 = value.data.u64;
+                out->data   = &scalar->u64;
+                break;
+            case openmeta::MetaElementType::I8:
+                scalar->i8 = static_cast<int8_t>(value.data.i64);
+                out->data  = &scalar->i8;
+                break;
+            case openmeta::MetaElementType::I16:
+                scalar->i16 = static_cast<int16_t>(value.data.i64);
+                out->data   = &scalar->i16;
+                break;
+            case openmeta::MetaElementType::I32:
+                scalar->i32 = static_cast<int32_t>(value.data.i64);
+                out->data   = &scalar->i32;
+                break;
+            case openmeta::MetaElementType::I64:
+                scalar->i64 = value.data.i64;
+                out->data   = &scalar->i64;
+                break;
+            case openmeta::MetaElementType::F32:
+                std::memcpy(&scalar->f32, &value.data.f32_bits,
+                            sizeof(scalar->f32));
+                out->data = &scalar->f32;
+                break;
+            case openmeta::MetaElementType::F64:
+                std::memcpy(&scalar->f64, &value.data.f64_bits,
+                            sizeof(scalar->f64));
+                out->data = &scalar->f64;
+                break;
+            case openmeta::MetaElementType::URational:
+                scalar->ur = { value.data.ur.numer, value.data.ur.denom };
+                out->data  = &scalar->ur;
+                break;
+            case openmeta::MetaElementType::SRational:
+                scalar->sr = { value.data.sr.numer, value.data.sr.denom };
+                out->data  = &scalar->sr;
+                break;
+            }
+            return out->data && out->size != 0;
+        case openmeta::MetaValueKind::Array:
+        case openmeta::MetaValueKind::Bytes:
+        case openmeta::MetaValueKind::Text: {
+            const std::span<const std::byte> bytes = store.arena().span(
+                value.data.span);
+            uint64_t expected = value.count;
+            if (value.kind == openmeta::MetaValueKind::Array) {
+                const uint64_t size = element_size(value.elem_type);
+                if (size == 0
+                    || value.count
+                           > std::numeric_limits<uint64_t>::max() / size)
+                    return false;
+                expected  = size * value.count;
+                out->kind = ValueKind::Array;
+            } else if (value.kind == openmeta::MetaValueKind::Bytes) {
+                out->kind = ValueKind::Bytes;
+            } else {
+                out->kind = ValueKind::Text;
+            }
+            if (bytes.size() != expected)
+                return false;
+            out->data = bytes.data();
+            out->size = bytes.size();
+            return expected == 0 || out->data;
+        }
+        }
+        return false;
+    }
+
+    enum class ExportPass : uint8_t {
+        NativeFlatHost,
+        XmpFlatHost,
+        CanonicalFallback,
+    };
+
+    struct TransparentStringHash final {
+        using is_transparent = void;
+
+        size_t operator()(std::string_view value) const noexcept
+        {
+            return std::hash<std::string_view> {}(value);
+        }
+
+        size_t operator()(const std::string& value) const noexcept
+        {
+            return (*this)(std::string_view(value));
+        }
+    };
+
+    struct ExportState final {
+        std::span<const openmeta::Entry> entries;
+        std::vector<uint8_t> entry_states;
+        std::unordered_set<std::string, TransparentStringHash,
+                           std::equal_to<>>
+            names;
+    };
+
+    class ExportSink final : public openmeta::MetadataSink {
+    public:
+        ExportSink(const openmeta::MetaStore& store, AttributeCallback callback,
+                   void* context, ExportPass pass, ExportState* state) noexcept
+            : m_store(store)
+            , m_callback(callback)
+            , m_context(context)
+            , m_pass(pass)
+            , m_state(state)
+        {
+        }
+
+        void on_item(const openmeta::ExportItem& item) noexcept override
+        {
+            if (m_rejected || m_out_of_memory || m_failed || !m_state
+                || !item.entry)
+                return;
+
+            try {
+                if (m_state->entries.empty()
+                    || item.entry < m_state->entries.data()
+                    || item.entry
+                           >= m_state->entries.data()
+                                  + m_state->entries.size()) {
+                    m_failed = true;
+                    return;
+                }
+                const size_t entry_index = static_cast<size_t>(
+                    item.entry - m_state->entries.data());
+                if (m_state->entry_states[entry_index] != 0)
+                    return;
+
+                const bool is_xmp
+                    = item.entry->key.kind
+                      == openmeta::MetaKeyKind::XmpProperty;
+                if ((m_pass == ExportPass::NativeFlatHost && is_xmp)
+                    || (m_pass == ExportPass::XmpFlatHost && !is_xmp)) {
+                    return;
+                }
+
+                AttributeView view;
+                view.name            = item.name.data();
+                view.name_size       = item.name.size();
+                view.source_entry_id = static_cast<uint32_t>(entry_index);
+                view.source_block_id = item.entry->origin.block;
+                view.source_order    = item.entry->origin.order_in_block;
+                view.flags           = static_cast<uint8_t>(item.flags);
+
+                ScalarStorage scalar;
+                if (!make_value_view(m_store, item.entry->value, &view.value,
+                                     &scalar)) {
+                    m_state->entry_states[entry_index] = 2;
+                    ++m_skipped;
+                    return;
+                }
+
+                const auto inserted
+                    = m_state->names.emplace(item.name).second;
+                if (!inserted) {
+                    // Retry flat-name collisions with canonical names.
+                    if (m_pass == ExportPass::CanonicalFallback) {
+                        m_state->entry_states[entry_index] = 2;
+                        ++m_skipped;
+                    }
+                    return;
+                }
+
+                if (m_callback && !m_callback(m_context, &view)) {
+                    m_rejected = true;
+                    return;
+                }
+                m_state->entry_states[entry_index] = 1;
+                ++m_emitted;
+            } catch (const std::bad_alloc&) {
+                m_out_of_memory = true;
+            } catch (...) {
+                m_failed = true;
+            }
+        }
+
+        uint32_t emitted() const noexcept { return m_emitted; }
+        uint32_t skipped() const noexcept { return m_skipped; }
+        bool rejected() const noexcept { return m_rejected; }
+        bool out_of_memory() const noexcept { return m_out_of_memory; }
+        bool failed() const noexcept { return m_failed; }
+
+    private:
+        const openmeta::MetaStore& m_store;
+        AttributeCallback m_callback = nullptr;
+        void* m_context              = nullptr;
+        ExportPass m_pass            = ExportPass::NativeFlatHost;
+        ExportState* m_state         = nullptr;
+        uint32_t m_emitted           = 0;
+        uint32_t m_skipped           = 0;
+        bool m_rejected              = false;
+        bool m_out_of_memory         = false;
+        bool m_failed                = false;
+    };
+
+    DecodeCode
+    decode_code(const openmeta::ReadTransferSourceSnapshotRandomAccessResult&
+                    read) noexcept
+    {
+        if (read.complete())
+            return DecodeCode::Ok;
+        if (read.code
+            == openmeta::ReadTransferSourceSnapshotRandomAccessCode::
+                UnsupportedFormat)
+            return DecodeCode::UnsupportedFormat;
+        if (read.code
+            == openmeta::ReadTransferSourceSnapshotRandomAccessCode::
+                ScratchTooSmall)
+            return DecodeCode::ScratchTooSmall;
+        if (read.code
+            == openmeta::ReadTransferSourceSnapshotRandomAccessCode::
+                ResidualMetadataPaths)
+            return DecodeCode::Incomplete;
+        if (!read.input.ok()) {
+            using Code = openmeta::RandomAccessReadCode;
+            if (read.input.code == Code::RequestTooLarge
+                || read.input.code == Code::RequestLimitExceeded
+                || read.input.code == Code::ByteLimitExceeded)
+                return DecodeCode::ResourceLimit;
+            return DecodeCode::InputFailure;
+        }
+        if (read.status == openmeta::TransferStatus::LimitExceeded)
+            return DecodeCode::ResourceLimit;
+        if (read.status == openmeta::TransferStatus::Unsupported)
+            return DecodeCode::UnsupportedFormat;
+        return DecodeCode::DecodeFailure;
+    }
+
+    DiagnosticSeverity from_openmeta_severity(
+        openmeta::ReadTransferSourceDiagnosticSeverity severity) noexcept
+    {
+        switch (severity) {
+        case openmeta::ReadTransferSourceDiagnosticSeverity::Info:
+            return DiagnosticSeverity::Info;
+        case openmeta::ReadTransferSourceDiagnosticSeverity::Warning:
+            return DiagnosticSeverity::Warning;
+        case openmeta::ReadTransferSourceDiagnosticSeverity::Error:
+            return DiagnosticSeverity::Error;
+        }
+        return DiagnosticSeverity::Error;
+    }
+
+}  // namespace
+
+static BridgeContract
+bridge_contract_impl() noexcept
+{
+    const openmeta::HostAdoptionProfile profile
+        = openmeta::host_adoption_profile();
+    BridgeContract result;
+    result.bridge_version               = BridgeContractVersion;
+    result.host_profile_version         = profile.profile_version;
+    result.random_access_source_version = profile.random_access_source_version;
+    result.positional_snapshot_version  = profile.positional_snapshot_version;
+    result.snapshot_object_version      = profile.snapshot_object_version;
+    result.snapshot_serialization_version
+        = profile.snapshot_serialization_version;
+    result.flat_host_export_version = profile.flat_host_export_version;
+    result.flat_host_import_version = profile.flat_host_import_version;
+    result.read_diagnostics_version = profile.read_diagnostics_version;
+    result.prepared_adapter_schema_version
+        = profile.prepared_adapter_schema_version;
+    result.compatible = openmeta::host_adoption_profile_matches(
+                            openmeta::kHostAdoptionProfileV1)
+                            ? 1
+                            : 0;
+    return result;
+}
+
+extern "C" void
+oiio_openmeta_bridge_contract(BridgeContract* contract) noexcept
+{
+    if (contract)
+        *contract = bridge_contract_impl();
+}
+
+static DecodeResult
+decode_impl(const Source* source, Format format, const DecodeOptions* options,
+            AttributeCallback attribute_callback, void* attribute_context,
+            DiagnosticCallback diagnostic_callback, void* diagnostic_context,
+            BlobCallback snapshot_callback, void* snapshot_context) noexcept
+{
+    DecodeResult summary;
+    try {
+        const DecodeOptions defaults;
+        const DecodeOptions& requested = options ? *options : defaults;
+        if (!source || source->contract_version != BridgeContractVersion
+            || source->struct_size < sizeof(Source) || source->size == 0
+            || !source->read_at
+            || requested.contract_version != BridgeContractVersion
+            || requested.struct_size < sizeof(DecodeOptions)
+            || format == Format::Unknown || requested.max_blocks == 0
+            || requested.max_ifds == 0 || requested.max_payload_parts == 0
+            || requested.read_window_bytes == 0
+            || requested.payload_scratch_bytes == 0
+            || requested.compressed_scratch_bytes == 0
+            || requested.value_scratch_bytes == 0
+            || requested.max_read_requests == 0
+            || requested.max_total_read_bytes == 0
+            || requested.max_single_read_bytes == 0
+            || (snapshot_callback && requested.max_serialized_snapshot == 0)) {
+            summary.code = DecodeCode::InvalidArgument;
+            return summary;
+        }
+        if (!openmeta::host_adoption_profile_matches(
+                openmeta::kHostAdoptionProfileV1)) {
+            summary.code = DecodeCode::IncompatibleLibrary;
+            return summary;
+        }
+
+        size_t read_window_size = 0;
+        size_t payload_size     = 0;
+        size_t compressed_size  = 0;
+        size_t value_size       = 0;
+        if (!to_size(requested.read_window_bytes, &read_window_size)
+            || !to_size(requested.payload_scratch_bytes, &payload_size)
+            || !to_size(requested.compressed_scratch_bytes, &compressed_size)
+            || !to_size(requested.value_scratch_bytes, &value_size)) {
+            summary.code = DecodeCode::InvalidArgument;
+            return summary;
+        }
+
+        std::vector<openmeta::ContainerBlockRef> blocks(requested.max_blocks);
+        std::vector<openmeta::ExifIfdRef> ifds(requested.max_ifds);
+        std::vector<uint32_t> payload_indices(requested.max_payload_parts);
+        std::vector<std::byte> read_window(read_window_size);
+        std::vector<std::byte> payload(payload_size);
+        std::vector<std::byte> compressed(compressed_size);
+        std::vector<std::byte> value(value_size);
+
+        ReadContext read_context { source };
+        const openmeta::RandomAccessSource random_source
+            = openmeta::make_callback_random_access_source(
+                source->size, &read_context, read_at,
+                source->concurrent_reads != 0);
+
+        openmeta::ReadTransferSourceSnapshotRandomAccessScratch scratch;
+        scratch.blocks                            = blocks;
+        scratch.ifds                              = ifds;
+        scratch.payload_indices                   = payload_indices;
+        scratch.read_window                       = read_window;
+        scratch.payload                           = payload;
+        scratch.compressed_payload                = compressed;
+        scratch.value                             = value;
+        scratch.window_options.minimum_read_bytes = read_window.size();
+
+        openmeta::ReadTransferSourceSnapshotRandomAccessOptions read_options;
+        read_options.include_pointer_tags = requested.include_pointer_tags != 0;
+        read_options.decode_makernote     = requested.decode_makernote != 0;
+        read_options.decode_embedded_containers
+            = requested.decode_embedded_containers != 0;
+        read_options.decompress            = requested.decompress != 0;
+        read_options.preserve_raw_carriers = false;
+
+        openmeta::RandomAccessReadLimits read_limits;
+        read_limits.max_requests          = requested.max_read_requests;
+        read_limits.max_total_bytes       = requested.max_total_read_bytes;
+        read_limits.max_single_read_bytes = requested.max_single_read_bytes;
+
+        openmeta::ReadTransferSourceSnapshotRandomAccessResult read
+            = openmeta::read_transfer_source_snapshot_random_access(
+                openmeta::make_random_access_source_range(random_source),
+                to_openmeta_format(format), scratch, read_options, read_limits);
+
+        summary.code                      = decode_code(read);
+        summary.complete                  = read.complete() ? 1 : 0;
+        summary.read_requests             = read.input.requests_issued;
+        summary.bytes_requested           = read.input.bytes_requested;
+        summary.bytes_completed           = read.input.bytes_completed;
+        summary.payload_scratch_needed    = read.payload_scratch_needed;
+        summary.compressed_scratch_needed = read.compressed_scratch_needed;
+        summary.value_scratch_needed      = read.value_scratch_needed;
+
+        const openmeta::ReadTransferSourceDiagnosticOptions diag_options {
+            requested.decode_makernote != 0,
+            requested.decode_embedded_containers != 0,
+        };
+        const openmeta::ReadTransferSourceDiagnosticsResult measured
+            = openmeta::collect_read_transfer_source_diagnostics(
+                read, std::span<openmeta::ReadTransferSourceDiagnostic> {},
+                diag_options);
+        summary.diagnostics_needed = measured.needed;
+        const uint32_t diagnostic_capacity
+            = std::min(measured.needed, requested.max_diagnostics);
+        std::vector<openmeta::ReadTransferSourceDiagnostic> diagnostics(
+            diagnostic_capacity);
+        const openmeta::ReadTransferSourceDiagnosticsResult collected
+            = openmeta::collect_read_transfer_source_diagnostics(read,
+                                                                 diagnostics,
+                                                                 diag_options);
+        for (uint32_t i = 0; i < collected.written; ++i) {
+            const auto& diagnostic = diagnostics[i];
+            DiagnosticView view;
+            view.severity       = from_openmeta_severity(diagnostic.severity);
+            view.domain         = static_cast<uint8_t>(diagnostic.domain);
+            view.code           = static_cast<uint16_t>(diagnostic.code);
+            view.format         = from_openmeta_format(diagnostic.format);
+            view.offset         = diagnostic.offset;
+            view.required_bytes = diagnostic.required_bytes;
+            view.count          = diagnostic.count;
+            view.tag            = diagnostic.tag;
+            view.input_code     = static_cast<uint8_t>(diagnostic.input_code);
+            view.message = openmeta::read_transfer_source_diagnostic_message(
+                diagnostic.code);
+            if (diagnostic_callback
+                && !diagnostic_callback(diagnostic_context, &view)) {
+                summary.code = DecodeCode::DiagnosticSinkRejected;
+                return summary;
+            }
+            ++summary.diagnostics_emitted;
+        }
+
+        if (read.snapshot.store.is_finalized()) {
+            const std::span<const openmeta::Entry> entries
+                = read.snapshot.store.entries();
+            ExportState export_state { entries,
+                                       std::vector<uint8_t>(entries.size(), 0),
+                                       {} };
+            export_state.names.reserve(entries.size());
+
+            auto export_pass = [&](openmeta::ExportNameStyle style,
+                                   ExportPass pass) -> bool {
+                openmeta::ExportOptions export_options;
+                export_options.style       = style;
+                export_options.name_policy = openmeta::ExportNamePolicy::Spec;
+                export_options.include_makernotes
+                    = requested.decode_makernote != 0;
+                ExportSink sink(read.snapshot.store, attribute_callback,
+                                attribute_context, pass, &export_state);
+                openmeta::visit_metadata(read.snapshot.store, export_options,
+                                         sink);
+                summary.attributes_emitted += sink.emitted();
+                summary.attributes_skipped += sink.skipped();
+                if (sink.rejected()) {
+                    summary.code = DecodeCode::AttributeSinkRejected;
+                    return false;
+                }
+                if (sink.out_of_memory()) {
+                    summary.code = DecodeCode::OutOfMemory;
+                    return false;
+                }
+                if (sink.failed()) {
+                    summary.code = DecodeCode::InternalError;
+                    return false;
+                }
+                return true;
+            };
+
+            // Prefer typed native names and retain XMP collisions canonically.
+            if (!export_pass(openmeta::ExportNameStyle::FlatHost,
+                             ExportPass::NativeFlatHost)
+                || !export_pass(openmeta::ExportNameStyle::FlatHost,
+                                ExportPass::XmpFlatHost)
+                || !export_pass(openmeta::ExportNameStyle::Canonical,
+                                ExportPass::CanonicalFallback)) {
+                return summary;
+            }
+        }
+
+        if (snapshot_callback && read.snapshot.store.is_finalized()) {
+            openmeta::TransferSourceSnapshotIoOptions io_options;
+            io_options.max_serialized_bytes = requested.max_serialized_snapshot;
+            std::vector<std::byte> serialized;
+            const openmeta::TransferSourceSnapshotIoResult serialized_result
+                = openmeta::serialize_transfer_source_snapshot(read.snapshot,
+                                                               &serialized,
+                                                               io_options);
+            if (serialized_result.status != openmeta::TransferStatus::Ok) {
+                summary.code = DecodeCode::SnapshotFailure;
+                return summary;
+            }
+            summary.snapshot_bytes = serialized.size();
+            if (!snapshot_callback(snapshot_context, serialized.data(),
+                                   serialized.size())) {
+                summary.code = DecodeCode::SnapshotSinkRejected;
+                return summary;
+            }
+            summary.snapshot_serialized = 1;
+        }
+        return summary;
+    } catch (const std::bad_alloc&) {
+        summary.code = DecodeCode::OutOfMemory;
+    } catch (...) {
+        summary.code = DecodeCode::InternalError;
+    }
+    return summary;
+}
+
+extern "C" void
+oiio_openmeta_decode(const Source* source, Format format,
+                     const DecodeOptions* options,
+                     AttributeCallback attribute_callback,
+                     void* attribute_context,
+                     DiagnosticCallback diagnostic_callback,
+                     void* diagnostic_context, BlobCallback snapshot_callback,
+                     void* snapshot_context, DecodeResult* result) noexcept
+{
+    if (result)
+        *result = decode_impl(source, format, options, attribute_callback,
+                              attribute_context, diagnostic_callback,
+                              diagnostic_context, snapshot_callback,
+                              snapshot_context);
+}
+
+}  // namespace oiio_openmeta

--- a/src/openmeta.bridge/openmeta_bridge.exports
+++ b/src/openmeta.bridge/openmeta_bridge.exports
@@ -1,0 +1,2 @@
+_oiio_openmeta_bridge_contract
+_oiio_openmeta_decode

--- a/src/openmeta.bridge/openmeta_bridge.h
+++ b/src/openmeta.bridge/openmeta_bridge.h
@@ -1,0 +1,244 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(OIIO_OPENMETA_BRIDGE_STATIC)
+#    define OIIO_OPENMETA_BRIDGE_API
+#elif defined(_WIN32)
+#    if defined(OIIO_OPENMETA_BRIDGE_EXPORTS)
+#        define OIIO_OPENMETA_BRIDGE_API __declspec(dllexport)
+#    else
+#        define OIIO_OPENMETA_BRIDGE_API __declspec(dllimport)
+#    endif
+#elif defined(__GNUC__) || defined(__clang__)
+#    define OIIO_OPENMETA_BRIDGE_API __attribute__((visibility("default")))
+#else
+#    define OIIO_OPENMETA_BRIDGE_API
+#endif
+
+namespace oiio_openmeta {
+
+inline constexpr uint32_t BridgeContractVersion = 1;
+
+enum class Format : uint8_t {
+    Unknown,
+    Jpeg,
+    Png,
+    Webp,
+    Gif,
+    Tiff,
+    Crw,
+    Raf,
+    X3f,
+    Jp2,
+    Jxl,
+    Heif,
+    Avif,
+    Cr3,
+    Exr,
+};
+
+enum class SourceReadCode : uint8_t {
+    Ok,
+    IoError,
+    SourceChanged,
+    Cancelled,
+};
+
+struct SourceReadResult final {
+    SourceReadCode code = SourceReadCode::Ok;
+    uint64_t bytes_read = 0;
+};
+
+using ReadAtCallback = SourceReadResult (*)(void* context, uint64_t offset,
+                                            void* destination,
+                                            uint64_t size) noexcept;
+
+struct Source final {
+    uint32_t contract_version = BridgeContractVersion;
+    uint32_t struct_size      = sizeof(Source);
+    uint64_t size             = 0;
+    void* context             = nullptr;
+    ReadAtCallback read_at    = nullptr;
+    uint8_t concurrent_reads  = 0;
+};
+
+enum class ValueKind : uint8_t {
+    Empty,
+    Scalar,
+    Array,
+    Bytes,
+    Text,
+};
+
+enum class ElementType : uint8_t {
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    U64,
+    I64,
+    F32,
+    F64,
+    URational,
+    SRational,
+};
+
+enum class TextEncoding : uint8_t {
+    Unknown,
+    Ascii,
+    Utf8,
+    Utf16LE,
+    Utf16BE,
+};
+
+struct URational final {
+    uint32_t numerator   = 0;
+    uint32_t denominator = 1;
+};
+
+struct SRational final {
+    int32_t numerator   = 0;
+    int32_t denominator = 1;
+};
+
+struct ValueView final {
+    ValueKind kind           = ValueKind::Empty;
+    ElementType element_type = ElementType::U8;
+    TextEncoding encoding    = TextEncoding::Unknown;
+    uint32_t count           = 0;
+    const void* data         = nullptr;
+    uint64_t size            = 0;
+};
+
+struct AttributeView final {
+    const char* name         = nullptr;
+    uint64_t name_size       = 0;
+    uint32_t source_entry_id = 0xffffffffU;
+    uint32_t source_block_id = 0xffffffffU;
+    uint32_t source_order    = 0;
+    uint8_t flags            = 0;
+    ValueView value;
+};
+
+using AttributeCallback = bool (*)(void* context,
+                                   const AttributeView* attribute) noexcept;
+
+enum class DiagnosticSeverity : uint8_t {
+    Info,
+    Warning,
+    Error,
+};
+
+struct DiagnosticView final {
+    DiagnosticSeverity severity = DiagnosticSeverity::Error;
+    uint8_t domain              = 0;
+    uint16_t code               = 0;
+    Format format               = Format::Unknown;
+    uint64_t offset             = 0;
+    uint64_t required_bytes     = 0;
+    uint32_t count              = 0;
+    uint16_t tag                = 0;
+    uint8_t input_code          = 0;
+    const char* message         = nullptr;
+};
+
+using DiagnosticCallback = bool (*)(void* context,
+                                    const DiagnosticView* diagnostic) noexcept;
+using BlobCallback       = bool (*)(void* context, const void* data,
+                              uint64_t size) noexcept;
+
+struct DecodeOptions final {
+    uint32_t contract_version = BridgeContractVersion;
+    uint32_t struct_size      = sizeof(DecodeOptions);
+
+    uint32_t max_blocks        = 256;
+    uint32_t max_ifds          = 512;
+    uint32_t max_payload_parts = 1024;
+    uint32_t max_diagnostics   = 64;
+
+    uint64_t read_window_bytes        = 4ULL * 1024ULL;
+    uint64_t payload_scratch_bytes    = 2ULL * 1024ULL * 1024ULL;
+    uint64_t compressed_scratch_bytes = 2ULL * 1024ULL * 1024ULL;
+    uint64_t value_scratch_bytes      = 1ULL * 1024ULL * 1024ULL;
+
+    uint32_t max_read_requests       = 65536;
+    uint64_t max_total_read_bytes    = 64ULL * 1024ULL * 1024ULL;
+    uint64_t max_single_read_bytes   = 16ULL * 1024ULL * 1024ULL;
+    uint64_t max_serialized_snapshot = 64ULL * 1024ULL * 1024ULL;
+
+    uint8_t include_pointer_tags       = 1;
+    uint8_t decode_makernote           = 0;
+    uint8_t decode_embedded_containers = 0;
+    uint8_t decompress                 = 1;
+};
+
+enum class DecodeCode : uint16_t {
+    Ok,
+    InvalidArgument,
+    IncompatibleLibrary,
+    UnsupportedFormat,
+    InputFailure,
+    ScratchTooSmall,
+    ResourceLimit,
+    DecodeFailure,
+    Incomplete,
+    AttributeSinkRejected,
+    DiagnosticSinkRejected,
+    SnapshotFailure,
+    SnapshotSinkRejected,
+    OutOfMemory,
+    InternalError,
+};
+
+struct DecodeResult final {
+    DecodeCode code                    = DecodeCode::InvalidArgument;
+    uint8_t complete                   = 0;
+    uint8_t snapshot_serialized        = 0;
+    uint32_t attributes_emitted        = 0;
+    uint32_t attributes_skipped        = 0;
+    uint32_t diagnostics_emitted       = 0;
+    uint32_t diagnostics_needed        = 0;
+    uint64_t read_requests             = 0;
+    uint64_t bytes_requested           = 0;
+    uint64_t bytes_completed           = 0;
+    uint64_t payload_scratch_needed    = 0;
+    uint64_t compressed_scratch_needed = 0;
+    uint64_t value_scratch_needed      = 0;
+    uint64_t snapshot_bytes            = 0;
+
+    bool ok() const noexcept { return code == DecodeCode::Ok; }
+};
+
+struct BridgeContract final {
+    uint32_t bridge_version                  = 0;
+    uint32_t host_profile_version            = 0;
+    uint32_t random_access_source_version    = 0;
+    uint32_t positional_snapshot_version     = 0;
+    uint32_t snapshot_object_version         = 0;
+    uint32_t snapshot_serialization_version  = 0;
+    uint32_t flat_host_export_version        = 0;
+    uint32_t flat_host_import_version        = 0;
+    uint32_t read_diagnostics_version        = 0;
+    uint32_t prepared_adapter_schema_version = 0;
+    uint8_t compatible                       = 0;
+};
+
+extern "C" OIIO_OPENMETA_BRIDGE_API void
+oiio_openmeta_bridge_contract(BridgeContract* contract) noexcept;
+
+extern "C" OIIO_OPENMETA_BRIDGE_API void oiio_openmeta_decode(
+    const Source* source, Format format, const DecodeOptions* options,
+    AttributeCallback attribute_callback, void* attribute_context,
+    DiagnosticCallback diagnostic_callback, void* diagnostic_context,
+    BlobCallback snapshot_callback, void* snapshot_context,
+    DecodeResult* result) noexcept;
+
+}  // namespace oiio_openmeta

--- a/src/openmeta.bridge/openmeta_bridge.h
+++ b/src/openmeta.bridge/openmeta_bridge.h
@@ -153,7 +153,7 @@ struct DiagnosticView final {
 using DiagnosticCallback = bool (*)(void* context,
                                     const DiagnosticView* diagnostic) noexcept;
 using BlobCallback       = bool (*)(void* context, const void* data,
-                              uint64_t size) noexcept;
+                                    uint64_t size) noexcept;
 
 struct DecodeOptions final {
     uint32_t contract_version = BridgeContractVersion;

--- a/src/openmeta.bridge/openmeta_bridge.map
+++ b/src/openmeta.bridge/openmeta_bridge.map
@@ -1,0 +1,7 @@
+{
+    global:
+        oiio_openmeta_bridge_contract;
+        oiio_openmeta_decode;
+    local:
+        *;
+};

--- a/src/openmeta.bridge/openmeta_bridge_test.cpp
+++ b/src/openmeta.bridge/openmeta_bridge_test.cpp
@@ -1,0 +1,191 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+#include "openmeta_oiio.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <vector>
+
+#include <OpenImageIO/unittest.h>
+
+OIIO_NAMESPACE_USING
+
+namespace {
+
+void
+append_ascii(std::vector<uint8_t>& bytes, std::string_view text)
+{
+    bytes.insert(bytes.end(), text.begin(), text.end());
+}
+
+void
+append_u16le(std::vector<uint8_t>& bytes, uint16_t value)
+{
+    bytes.push_back(static_cast<uint8_t>(value));
+    bytes.push_back(static_cast<uint8_t>(value >> 8));
+}
+
+void
+append_u32le(std::vector<uint8_t>& bytes, uint32_t value)
+{
+    bytes.push_back(static_cast<uint8_t>(value));
+    bytes.push_back(static_cast<uint8_t>(value >> 8));
+    bytes.push_back(static_cast<uint8_t>(value >> 16));
+    bytes.push_back(static_cast<uint8_t>(value >> 24));
+}
+
+void
+write_u32le(std::vector<uint8_t>& bytes, size_t offset, uint32_t value)
+{
+    bytes[offset]     = static_cast<uint8_t>(value);
+    bytes[offset + 1] = static_cast<uint8_t>(value >> 8);
+    bytes[offset + 2] = static_cast<uint8_t>(value >> 16);
+    bytes[offset + 3] = static_cast<uint8_t>(value >> 24);
+}
+
+void
+append_webp_chunk(std::vector<uint8_t>& bytes, std::string_view type,
+                  const std::vector<uint8_t>& payload)
+{
+    append_ascii(bytes, type);
+    append_u32le(bytes, static_cast<uint32_t>(payload.size()));
+    bytes.insert(bytes.end(), payload.begin(), payload.end());
+    if (payload.size() & 1U)
+        bytes.push_back(0);
+}
+
+std::vector<uint8_t>
+make_tiff()
+{
+    std::vector<uint8_t> bytes;
+    append_ascii(bytes, "II");
+    append_u16le(bytes, 42);
+    append_u32le(bytes, 8);
+    append_u16le(bytes, 2);
+
+    append_u16le(bytes, 0x010f);  // Make
+    append_u16le(bytes, 2);       // ASCII
+    append_u32le(bytes, 6);
+    append_u32le(bytes, 38);
+
+    append_u16le(bytes, 0x0112);  // Orientation
+    append_u16le(bytes, 3);       // SHORT
+    append_u32le(bytes, 1);
+    append_u16le(bytes, 6);
+    append_u16le(bytes, 0);
+
+    append_u32le(bytes, 0);
+    append_ascii(bytes, "Nikon");
+    bytes.push_back(0);
+    return bytes;
+}
+
+std::vector<uint8_t>
+make_webp()
+{
+    std::vector<uint8_t> bytes;
+    append_ascii(bytes, "RIFF");
+    append_u32le(bytes, 0);
+    append_ascii(bytes, "WEBP");
+    append_webp_chunk(bytes, "VP8X", std::vector<uint8_t>(10, 0));
+    append_webp_chunk(bytes, "EXIF", make_tiff());
+    append_webp_chunk(bytes, "VP8 ", std::vector<uint8_t>(1, 0));
+    write_u32le(bytes, 4, static_cast<uint32_t>(bytes.size() - 8));
+    return bytes;
+}
+
+class CountingProxy final : public Filesystem::IOProxy {
+public:
+    explicit CountingProxy(std::vector<uint8_t> bytes)
+        : IOProxy("openmeta-test", Read)
+        , m_bytes(std::move(bytes))
+    {
+    }
+
+    const char* proxytype() const override { return "openmeta-test"; }
+    size_t size() const override { return m_bytes.size(); }
+
+    size_t pread(void* buffer, size_t size, int64_t offset) override
+    {
+        read_requests.fetch_add(1, std::memory_order_relaxed);
+        if (!buffer || offset < 0
+            || static_cast<uint64_t>(offset) >= m_bytes.size())
+            return 0;
+        const size_t available = m_bytes.size() - static_cast<size_t>(offset);
+        const size_t count     = std::min(size, available);
+        std::memcpy(buffer, m_bytes.data() + static_cast<size_t>(offset),
+                    count);
+        return count;
+    }
+
+    std::atomic<uint32_t> read_requests { 0 };
+
+private:
+    std::vector<uint8_t> m_bytes;
+};
+
+void
+test_contract()
+{
+    const oiio_openmeta::BridgeContract contract
+        = pvt::openmeta::bridge_contract();
+    OIIO_CHECK_EQUAL(contract.bridge_version,
+                     oiio_openmeta::BridgeContractVersion);
+    OIIO_CHECK_EQUAL(contract.host_profile_version, 1U);
+    OIIO_CHECK_EQUAL(contract.compatible, 1U);
+}
+
+void
+test_decode()
+{
+    CountingProxy proxy(make_webp());
+    pvt::openmeta::DecodeRequest request;
+    request.serialize_snapshot = true;
+    const pvt::openmeta::DecodeResult result
+        = pvt::openmeta::decode(proxy, pvt::openmeta::Format::Webp, request);
+
+    OIIO_CHECK_ASSERT(result.ok());
+    OIIO_CHECK_EQUAL(result.bridge.complete, 1U);
+    OIIO_CHECK_EQUAL(result.bridge.diagnostics_needed, 0U);
+    OIIO_CHECK_EQUAL(result.diagnostics.size(), 0U);
+    OIIO_CHECK_EQUAL(result.attributes.get_string("Make"), "Nikon");
+    OIIO_CHECK_EQUAL(result.attributes.get_int("Orientation"), 6);
+    OIIO_CHECK_ASSERT(result.attributes.contains("Make"));
+    OIIO_CHECK_ASSERT(!result.sources.empty());
+    OIIO_CHECK_ASSERT(!result.serialized_snapshot.empty());
+    OIIO_CHECK_EQUAL(result.bridge.snapshot_serialized, 1U);
+    OIIO_CHECK_ASSERT(proxy.read_requests.load(std::memory_order_relaxed) > 0);
+}
+
+void
+test_read_limit_diagnostic()
+{
+    CountingProxy proxy(make_webp());
+    pvt::openmeta::DecodeRequest request;
+    request.options.max_total_read_bytes = 8;
+    const pvt::openmeta::DecodeResult result
+        = pvt::openmeta::decode(proxy, pvt::openmeta::Format::Webp, request);
+
+    OIIO_CHECK_FALSE(result.ok());
+    OIIO_CHECK_EQUAL(result.bridge.complete, 0U);
+    OIIO_CHECK_ASSERT(result.bridge.code
+                      == pvt::openmeta::DecodeCode::ResourceLimit);
+    OIIO_CHECK_ASSERT(result.bridge.diagnostics_needed > 0);
+    OIIO_CHECK_ASSERT(!result.diagnostics.empty());
+}
+
+}  // namespace
+
+int
+main()
+{
+    test_contract();
+    test_decode();
+    test_read_limit_diagnostic();
+    return unit_test_failures;
+}

--- a/src/openmeta.bridge/openmeta_oiio.cpp
+++ b/src/openmeta.bridge/openmeta_oiio.cpp
@@ -1,0 +1,332 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+#include "openmeta_oiio.h"
+
+#include <algorithm>
+#include <limits>
+#include <string_view>
+#include <utility>
+
+#include <OpenImageIO/strutil.h>
+
+OIIO_NAMESPACE_BEGIN
+namespace pvt::openmeta {
+namespace {
+
+    oiio_openmeta::SourceReadResult ioproxy_read_at(void* context,
+                                                    uint64_t offset,
+                                                    void* destination,
+                                                    uint64_t size) noexcept
+    {
+        auto* ioproxy = static_cast<Filesystem::IOProxy*>(context);
+        if (!ioproxy || !destination
+            || offset
+                   > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())
+            || size > std::numeric_limits<size_t>::max()) {
+            return { oiio_openmeta::SourceReadCode::IoError, 0 };
+        }
+        try {
+            const size_t bytes_read
+                = ioproxy->pread(destination, static_cast<size_t>(size),
+                                 static_cast<int64_t>(offset));
+            if (bytes_read > size)
+                return { oiio_openmeta::SourceReadCode::IoError, 0 };
+            return { oiio_openmeta::SourceReadCode::Ok, bytes_read };
+        } catch (...) {
+            return { oiio_openmeta::SourceReadCode::IoError, 0 };
+        }
+    }
+
+    bool element_type(oiio_openmeta::ElementType element,
+                      TypeDesc* type) noexcept
+    {
+        if (!type)
+            return false;
+        switch (element) {
+        case oiio_openmeta::ElementType::U8: *type = TypeUInt8; break;
+        case oiio_openmeta::ElementType::I8: *type = TypeInt8; break;
+        case oiio_openmeta::ElementType::U16: *type = TypeUInt16; break;
+        case oiio_openmeta::ElementType::I16: *type = TypeInt16; break;
+        case oiio_openmeta::ElementType::U32: *type = TypeUInt; break;
+        case oiio_openmeta::ElementType::I32: *type = TypeInt; break;
+        case oiio_openmeta::ElementType::U64: *type = TypeUInt64; break;
+        case oiio_openmeta::ElementType::I64: *type = TypeInt64; break;
+        case oiio_openmeta::ElementType::F32: *type = TypeFloat; break;
+        case oiio_openmeta::ElementType::F64:
+            *type = TypeDesc(TypeDesc::DOUBLE);
+            break;
+        case oiio_openmeta::ElementType::URational:
+            *type = TypeURational;
+            break;
+        case oiio_openmeta::ElementType::SRational: *type = TypeRational; break;
+        }
+        return type->basetype != TypeDesc::UNKNOWN;
+    }
+
+    bool text_value(const oiio_openmeta::ValueView& value, std::string* text)
+    {
+        if (!text || (!value.data && value.size != 0)
+            || value.size > std::numeric_limits<size_t>::max())
+            return false;
+
+        const auto* bytes = static_cast<const uint8_t*>(value.data);
+        const size_t size = static_cast<size_t>(value.size);
+        if (size == 0) {
+            text->clear();
+            return true;
+        }
+        if (value.encoding == oiio_openmeta::TextEncoding::Ascii
+            || value.encoding == oiio_openmeta::TextEncoding::Utf8) {
+            size_t length = size;
+            while (length && bytes[length - 1] == 0)
+                --length;
+            if (std::find(bytes, bytes + length, uint8_t(0)) != bytes + length)
+                return false;
+            text->assign(reinterpret_cast<const char*>(bytes), length);
+            return true;
+        }
+        if (value.encoding != oiio_openmeta::TextEncoding::Utf16LE
+            && value.encoding != oiio_openmeta::TextEncoding::Utf16BE)
+            return false;
+        if ((size & 1U) != 0)
+            return false;
+
+        std::u16string utf16;
+        utf16.reserve(size / 2);
+        for (size_t i = 0; i < size; i += 2) {
+            uint16_t code_unit = 0;
+            if (value.encoding == oiio_openmeta::TextEncoding::Utf16LE)
+                code_unit = uint16_t(bytes[i]) | (uint16_t(bytes[i + 1]) << 8);
+            else
+                code_unit = (uint16_t(bytes[i]) << 8) | uint16_t(bytes[i + 1]);
+            utf16.push_back(static_cast<char16_t>(code_unit));
+        }
+        while (!utf16.empty() && utf16.back() == 0)
+            utf16.pop_back();
+        if (std::find(utf16.begin(), utf16.end(), char16_t(0)) != utf16.end())
+            return false;
+        *text = Strutil::utf16_to_utf8(utf16);
+        return true;
+    }
+
+    bool add_raw_value(ParamValueList* attributes, string_view name,
+                       TypeDesc base_type, uint32_t count, const void* data,
+                       uint64_t size)
+    {
+        if (!attributes || name.empty() || count == 0 || !data
+            || count > static_cast<uint32_t>(std::numeric_limits<int>::max()))
+            return false;
+
+        TypeDesc type = base_type;
+        if (count > 1) {
+            type = TypeDesc(
+                static_cast<TypeDesc::BASETYPE>(base_type.basetype),
+                static_cast<TypeDesc::AGGREGATE>(base_type.aggregate),
+                static_cast<TypeDesc::VECSEMANTICS>(base_type.vecsemantics),
+                static_cast<int>(count));
+        }
+        if (size != type.size())
+            return false;
+        attributes->add_or_replace(
+            ParamValue(name, type, 1, data, ParamValue::Copy(true)));
+        return true;
+    }
+
+    struct AttributeCollector final {
+        DecodeResult* result = nullptr;
+        bool failed          = false;
+    };
+
+    bool
+    collect_attribute(void* context,
+                      const oiio_openmeta::AttributeView* attribute) noexcept
+    {
+        auto* collector = static_cast<AttributeCollector*>(context);
+        if (!collector || !collector->result || !attribute
+            || !attribute->name) {
+            if (collector)
+                collector->failed = true;
+            return false;
+        }
+        try {
+            if (attribute->name_size > std::numeric_limits<size_t>::max()) {
+                collector->failed = true;
+                return false;
+            }
+            const string_view name(attribute->name, attribute->name_size);
+            bool mapped = false;
+            if (attribute->value.kind == oiio_openmeta::ValueKind::Text) {
+                if (attribute->value.encoding
+                    == oiio_openmeta::TextEncoding::Unknown)
+                    mapped = add_raw_value(&collector->result->attributes, name,
+                                           TypeUInt8, attribute->value.count,
+                                           attribute->value.data,
+                                           attribute->value.size);
+                else {
+                    std::string text;
+                    if (text_value(attribute->value, &text)) {
+                        collector->result->attributes.attribute(name, text);
+                        mapped = true;
+                    }
+                }
+            } else if (attribute->value.kind
+                       == oiio_openmeta::ValueKind::Bytes) {
+                mapped = add_raw_value(&collector->result->attributes, name,
+                                       TypeUInt8, attribute->value.count,
+                                       attribute->value.data,
+                                       attribute->value.size);
+            } else if (attribute->value.kind == oiio_openmeta::ValueKind::Scalar
+                       || attribute->value.kind
+                              == oiio_openmeta::ValueKind::Array) {
+                TypeDesc type;
+                mapped = element_type(attribute->value.element_type, &type)
+                         && add_raw_value(&collector->result->attributes, name,
+                                          type, attribute->value.count,
+                                          attribute->value.data,
+                                          attribute->value.size);
+            }
+
+            if (!mapped) {
+                ++collector->result->mapping_failures;
+                return true;
+            }
+
+            SourceIdentity identity;
+            identity.name     = name;
+            identity.entry_id = attribute->source_entry_id;
+            identity.block_id = attribute->source_block_id;
+            identity.order    = attribute->source_order;
+            identity.flags    = attribute->flags;
+            auto found        = std::find_if(collector->result->sources.begin(),
+                                             collector->result->sources.end(),
+                                             [&](const SourceIdentity& item) {
+                                          return item.name == identity.name;
+                                      });
+            if (found == collector->result->sources.end())
+                collector->result->sources.emplace_back(std::move(identity));
+            else
+                *found = std::move(identity);
+            return true;
+        } catch (...) {
+            collector->failed = true;
+            return false;
+        }
+    }
+
+    struct DiagnosticCollector final {
+        DecodeResult* result = nullptr;
+        bool failed          = false;
+    };
+
+    bool
+    collect_diagnostic(void* context,
+                       const oiio_openmeta::DiagnosticView* diagnostic) noexcept
+    {
+        auto* collector = static_cast<DiagnosticCollector*>(context);
+        if (!collector || !collector->result || !diagnostic) {
+            if (collector)
+                collector->failed = true;
+            return false;
+        }
+        try {
+            Diagnostic copy;
+            copy.severity       = diagnostic->severity;
+            copy.domain         = diagnostic->domain;
+            copy.code           = diagnostic->code;
+            copy.format         = diagnostic->format;
+            copy.offset         = diagnostic->offset;
+            copy.required_bytes = diagnostic->required_bytes;
+            copy.count          = diagnostic->count;
+            copy.tag            = diagnostic->tag;
+            copy.input_code     = diagnostic->input_code;
+            if (diagnostic->message)
+                copy.message = diagnostic->message;
+            collector->result->diagnostics.emplace_back(std::move(copy));
+            return true;
+        } catch (...) {
+            collector->failed = true;
+            return false;
+        }
+    }
+
+    struct SnapshotCollector final {
+        DecodeResult* result = nullptr;
+        bool failed          = false;
+    };
+
+    bool collect_snapshot(void* context, const void* data,
+                          uint64_t size) noexcept
+    {
+        auto* collector = static_cast<SnapshotCollector*>(context);
+        if (!collector || !collector->result || (!data && size != 0)
+            || size > std::numeric_limits<size_t>::max()) {
+            if (collector)
+                collector->failed = true;
+            return false;
+        }
+        try {
+            if (size == 0) {
+                collector->result->serialized_snapshot.clear();
+                return true;
+            }
+            const auto* begin = static_cast<const uint8_t*>(data);
+            collector->result->serialized_snapshot.assign(
+                begin, begin + static_cast<size_t>(size));
+            return true;
+        } catch (...) {
+            collector->failed = true;
+            return false;
+        }
+    }
+
+}  // namespace
+
+oiio_openmeta::BridgeContract
+bridge_contract() noexcept
+{
+    oiio_openmeta::BridgeContract result;
+    oiio_openmeta::oiio_openmeta_bridge_contract(&result);
+    return result;
+}
+
+DecodeResult
+decode(Filesystem::IOProxy& ioproxy, Format format,
+       const DecodeRequest& request) noexcept
+{
+    DecodeResult result;
+    try {
+        const size_t source_size = ioproxy.size();
+        if (ioproxy.mode() != Filesystem::IOProxy::Read
+            || source_size == size_t(-1) || source_size == 0) {
+            result.bridge.code = DecodeCode::InvalidArgument;
+            return result;
+        }
+
+        oiio_openmeta::Source source;
+        source.size             = source_size;
+        source.context          = &ioproxy;
+        source.read_at          = ioproxy_read_at;
+        source.concurrent_reads = 1;
+
+        AttributeCollector attributes { &result };
+        DiagnosticCollector diagnostics { &result };
+        SnapshotCollector snapshot { &result };
+        oiio_openmeta::oiio_openmeta_decode(
+            &source, format, &request.options, collect_attribute, &attributes,
+            collect_diagnostic, &diagnostics,
+            request.serialize_snapshot ? collect_snapshot : nullptr,
+            request.serialize_snapshot ? &snapshot : nullptr, &result.bridge);
+        if (attributes.failed || diagnostics.failed || snapshot.failed) {
+            if (result.bridge.code == DecodeCode::Ok)
+                result.bridge.code = DecodeCode::InternalError;
+        }
+    } catch (...) {
+        result.bridge.code = DecodeCode::InternalError;
+    }
+    return result;
+}
+
+}  // namespace pvt::openmeta
+OIIO_NAMESPACE_END

--- a/src/openmeta.bridge/openmeta_oiio.cpp
+++ b/src/openmeta.bridge/openmeta_oiio.cpp
@@ -203,7 +203,7 @@ namespace {
                                              collector->result->sources.end(),
                                              [&](const SourceIdentity& item) {
                                           return item.name == identity.name;
-                                      });
+                                             });
             if (found == collector->result->sources.end())
                 collector->result->sources.emplace_back(std::move(identity));
             else

--- a/src/openmeta.bridge/openmeta_oiio.h
+++ b/src/openmeta.bridge/openmeta_oiio.h
@@ -1,0 +1,67 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+#pragma once
+
+#include "openmeta_bridge.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/paramlist.h>
+
+OIIO_NAMESPACE_BEGIN
+namespace pvt::openmeta {
+
+using Format        = oiio_openmeta::Format;
+using DecodeCode    = oiio_openmeta::DecodeCode;
+using DecodeOptions = oiio_openmeta::DecodeOptions;
+
+struct DecodeRequest final {
+    DecodeOptions options;
+    bool serialize_snapshot = false;
+};
+
+struct SourceIdentity final {
+    std::string name;
+    uint32_t entry_id = 0xffffffffU;
+    uint32_t block_id = 0xffffffffU;
+    uint32_t order    = 0;
+    uint8_t flags     = 0;
+};
+
+struct Diagnostic final {
+    oiio_openmeta::DiagnosticSeverity severity
+        = oiio_openmeta::DiagnosticSeverity::Error;
+    uint8_t domain          = 0;
+    uint16_t code           = 0;
+    Format format           = Format::Unknown;
+    uint64_t offset         = 0;
+    uint64_t required_bytes = 0;
+    uint32_t count          = 0;
+    uint16_t tag            = 0;
+    uint8_t input_code      = 0;
+    std::string message;
+};
+
+struct DecodeResult final {
+    oiio_openmeta::DecodeResult bridge;
+    ParamValueList attributes;
+    std::vector<SourceIdentity> sources;
+    std::vector<Diagnostic> diagnostics;
+    std::vector<uint8_t> serialized_snapshot;
+    uint32_t mapping_failures = 0;
+
+    bool ok() const noexcept { return bridge.ok() && mapping_failures == 0; }
+};
+
+oiio_openmeta::BridgeContract bridge_contract() noexcept;
+
+DecodeResult decode(Filesystem::IOProxy& ioproxy, Format format,
+                    const DecodeRequest& request = DecodeRequest {}) noexcept;
+
+}  // namespace pvt::openmeta
+OIIO_NAMESPACE_END

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -3,9 +3,16 @@
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 if (WebP_FOUND)
+    set (webp_optional_libraries)
+    set (webp_optional_definitions)
+    if (TARGET OpenImageIO_OpenMeta)
+        list (APPEND webp_optional_libraries OpenImageIO_OpenMeta)
+        list (APPEND webp_optional_definitions OIIO_USE_OPENMETA=1)
+    endif ()
     add_oiio_plugin (webpinput.cpp webpoutput.cpp
                      LINK_LIBRARIES WebP::webp WebP::webpdemux WebP::libwebpmux
-                     DEFINITIONS "USE_WEBP=1")
+                                    ${webp_optional_libraries}
+                     DEFINITIONS "USE_WEBP=1" ${webp_optional_definitions})
 else ()
     message (STATUS "WebP plugin will not be built")
 endif()

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -7,6 +7,10 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/tiffutils.h>
 
+#ifdef OIIO_USE_OPENMETA
+#    include "openmeta_oiio.h"
+#endif
+
 #include <webp/decode.h>
 #include <webp/demux.h>
 
@@ -24,6 +28,7 @@ struct WebpHead {
 
 
 
+#ifndef OIIO_USE_OPENMETA
 static bool
 webp_exif_payload_has_tiff_header(cspan<uint8_t> exif)
 {
@@ -35,6 +40,28 @@ webp_exif_payload_has_tiff_header(cspan<uint8_t> exif)
     const size_t tiff_header_offset = has_exif_header ? exif_header_size : 0;
     return exif.size() >= tiff_header_offset + sizeof(TIFFHeader);
 }
+#endif
+
+
+#ifdef OIIO_USE_OPENMETA
+static bool
+decode_openmeta_metadata(Filesystem::IOProxy& io, ImageSpec& spec)
+{
+    OIIO::pvt::openmeta::DecodeRequest request;
+    request.serialize_snapshot = false;
+    OIIO::pvt::openmeta::DecodeResult decoded
+        = OIIO::pvt::openmeta::decode(io, OIIO::pvt::openmeta::Format::Webp,
+                                      request);
+    if (!decoded.ok() || !decoded.bridge.complete)
+        return false;
+
+    for (const ParamValue& attribute : decoded.attributes) {
+        if (!spec.extra_attribs.contains(attribute.name()))
+            spec.extra_attribs.add_or_replace(attribute);
+    }
+    return true;
+}
+#endif
 
 
 class WebpInput final : public ImageInput {
@@ -205,6 +232,14 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
     }
 
     WebPChunkIterator chunk_iter;
+#ifdef OIIO_USE_OPENMETA
+    if (!decode_openmeta_metadata(*io, m_spec)
+        && OIIO::get_int_attribute("imageinput:strict")) {
+        errorfmt("Could not decode metadata with OpenMeta");
+        close();
+        return false;
+    }
+#else
     if (m_demux_flags & EXIF_FLAG
         && WebPDemuxGetChunk(m_demux, "EXIF", 1, &chunk_iter)) {
         cspan<uint8_t> exif_span(chunk_iter.chunk.bytes, chunk_iter.chunk.size);
@@ -225,6 +260,7 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
         // test case, otherwise I'm just guessing.
         WebPDemuxReleaseChunkIterator(&chunk_iter);
     }
+#endif
     if (m_demux_flags & ICCP_FLAG
         && WebPDemuxGetChunk(m_demux, "ICCP", 1, &chunk_iter)) {
         cspan<uint8_t> icc_span(chunk_iter.chunk.bytes, chunk_iter.chunk.size);

--- a/testsuite/webp-openmeta/ref/out.txt
+++ b/testsuite/webp-openmeta/ref/out.txt
@@ -1,0 +1,16 @@
+TIFF Make=OpenMetaCamera
+TIFF Orientation=6
+TIFF aperture=12/5
+TIFF XMP rating=4
+TIFF XMP aperture=99/10
+TIFF document=test:document
+TIFF history=saved
+TIFF ColorSpace=srgb_rec709_scene
+Prefixed Make=OpenMetaCamera
+Prefixed Orientation=6
+Prefixed aperture=12/5
+Prefixed XMP rating=4
+Prefixed XMP aperture=99/10
+Prefixed document=test:document
+Prefixed history=saved
+Prefixed ColorSpace=srgb_rec709_scene

--- a/testsuite/webp-openmeta/run.py
+++ b/testsuite/webp-openmeta/run.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+redirect = " >> out.txt 2>&1 "
+
+command += oiiotool("--create 1x1 3 -d uint8 -o base.webp")
+command += run_app(pythonbin + " src/make-openmeta-webp.py", silent=True)
+command += oiiotool(
+    'openmeta-metadata.webp '
+    '--echo "TIFF Make={TOP.Make}" '
+    '--echo "TIFF Orientation={TOP.Orientation}" '
+    '--echo "TIFF aperture={TOP.\'Exif:ApertureValue\'}" '
+    '--echo "TIFF XMP rating={TOP.\'XMP:Rating\'}" '
+    '--echo "TIFF XMP aperture={TOP.\'xmp:http://ns.adobe.com/exif/1.0/:ApertureValue\'}" '
+    '--echo "TIFF document={TOP.\'xmp:http://ns.adobe.com/xap/1.0/mm/:DocumentID\'}" '
+    '--echo "TIFF history={TOP.\'xmp:http://ns.adobe.com/xap/1.0/mm/:History[1]/stEvt:action\'}" '
+    '--echo "TIFF ColorSpace={TOP.\'oiio:ColorSpace\'}"'
+)
+command += oiiotool(
+    'openmeta-prefixed-metadata.webp '
+    '--echo "Prefixed Make={TOP.Make}" '
+    '--echo "Prefixed Orientation={TOP.Orientation}" '
+    '--echo "Prefixed aperture={TOP.\'Exif:ApertureValue\'}" '
+    '--echo "Prefixed XMP rating={TOP.\'XMP:Rating\'}" '
+    '--echo "Prefixed XMP aperture={TOP.\'xmp:http://ns.adobe.com/exif/1.0/:ApertureValue\'}" '
+    '--echo "Prefixed document={TOP.\'xmp:http://ns.adobe.com/xap/1.0/mm/:DocumentID\'}" '
+    '--echo "Prefixed history={TOP.\'xmp:http://ns.adobe.com/xap/1.0/mm/:History[1]/stEvt:action\'}" '
+    '--echo "Prefixed ColorSpace={TOP.\'oiio:ColorSpace\'}"'
+)

--- a/testsuite/webp-openmeta/src/make-openmeta-webp.py
+++ b/testsuite/webp-openmeta/src/make-openmeta-webp.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+import struct
+
+
+BASE = "base.webp"
+TIFF_OUTPUT = "openmeta-metadata.webp"
+PREFIXED_OUTPUT = "openmeta-prefixed-metadata.webp"
+EXIF_FLAG = 0x08
+XMP_FLAG = 0x04
+
+
+def read_chunks(data):
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
+        raise RuntimeError("base image is not a RIFF WebP file")
+
+    chunks = []
+    offset = 12
+    while offset < len(data):
+        if offset + 8 > len(data):
+            raise RuntimeError("truncated WebP chunk header")
+        fourcc = data[offset : offset + 4]
+        size = struct.unpack_from("<I", data, offset + 4)[0]
+        begin = offset + 8
+        end = begin + size
+        if end > len(data):
+            raise RuntimeError("truncated WebP chunk payload")
+        chunks.append((fourcc, data[begin:end]))
+        offset = end + (size & 1)
+    return chunks
+
+
+def write_chunk(fourcc, payload):
+    chunk = fourcc + struct.pack("<I", len(payload)) + payload
+    if len(payload) & 1:
+        chunk += b"\x00"
+    return chunk
+
+
+def make_tiff():
+    make = b"OpenMetaCamera\x00"
+    ifd0_size = 2 + 3 * 12 + 4
+    make_offset = 8 + ifd0_size
+    padded_make_size = (len(make) + 1) & ~1
+    exif_ifd_offset = make_offset + padded_make_size
+    exif_ifd_size = 2 + 12 + 4
+    aperture_offset = exif_ifd_offset + exif_ifd_size
+    tiff = bytearray(b"II")
+    tiff += struct.pack("<H", 42)
+    tiff += struct.pack("<I", 8)
+    tiff += struct.pack("<H", 3)
+    tiff += struct.pack("<HHII", 0x010F, 2, len(make), make_offset)
+    tiff += struct.pack("<HHI", 0x0112, 3, 1)
+    tiff += struct.pack("<H", 6) + b"\x00\x00"
+    tiff += struct.pack("<HHII", 0x8769, 4, 1, exif_ifd_offset)
+    tiff += struct.pack("<I", 0)
+    tiff += make + b"\x00" * (padded_make_size - len(make))
+    tiff += struct.pack("<H", 1)
+    tiff += struct.pack("<HHII", 0x9202, 5, 1, aperture_offset)
+    tiff += struct.pack("<I", 0)
+    tiff += struct.pack("<II", 12, 5)
+    return bytes(tiff)
+
+
+def make_xmp():
+    return (
+        b"<x:xmpmeta xmlns:x='adobe:ns:meta/'>"
+        b"<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>"
+        b"<rdf:Description xmlns:xmp='http://ns.adobe.com/xap/1.0/' "
+        b"xmlns:exif='http://ns.adobe.com/exif/1.0/' "
+        b"xmlns:xmpMM='http://ns.adobe.com/xap/1.0/mm/' "
+        b"xmlns:stEvt='http://ns.adobe.com/xap/1.0/sType/ResourceEvent#' "
+        b"xmp:CreatorTool='OpenMeta WebP pilot' xmp:Rating='4' "
+        b"exif:ApertureValue='99/10' xmpMM:DocumentID='test:document'>"
+        b"<xmpMM:History><rdf:Seq><rdf:li rdf:parseType='Resource'>"
+        b"<stEvt:action>saved</stEvt:action>"
+        b"</rdf:li></rdf:Seq></xmpMM:History>"
+        b"</rdf:Description>"
+        b"</rdf:RDF></x:xmpmeta>"
+    )
+
+
+def write_metadata_webp(output, base_chunks, exif):
+    vp8x = bytes((EXIF_FLAG | XMP_FLAG, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    chunks = write_chunk(b"VP8X", vp8x)
+    for chunk_type, payload in base_chunks:
+        if chunk_type not in (b"VP8X", b"EXIF", b"XMP "):
+            chunks += write_chunk(chunk_type, payload)
+    chunks += write_chunk(b"EXIF", exif)
+    chunks += write_chunk(b"XMP ", make_xmp())
+
+    body = b"WEBP" + chunks
+    with open(output, "wb") as output_file:
+        output_file.write(b"RIFF" + struct.pack("<I", len(body)) + body)
+
+
+with open(BASE, "rb") as input_file:
+    base_chunks = read_chunks(input_file.read())
+
+tiff = make_tiff()
+write_metadata_webp(TIFF_OUTPUT, base_chunks, tiff)
+write_metadata_webp(PREFIXED_OUTPUT, base_chunks, b"Exif\x00\x00" + tiff)


### PR DESCRIPTION
### Description

## Summary

This PR adds experimental, optional integration with [OpenMeta](https://github.com/ssh4net/OpenMeta) and uses it to decode WebP EXIF and XMP metadata.

The integration is disabled by default and can be enabled with:

```cmake
-DUSE_OPENMETA=ON
```

OpenMeta 0.4.118 or newer is required.

## Motivation

OpenImageIO currently implements metadata parsing separately in individual image plugins. OpenMeta provides a format-aware metadata decoder with a format-independent output model, including richer EXIF and structured XMP support.

WebP is used as the initial integration because its existing reader only decodes EXIF metadata and does not currently expose XMP properties.

## Implementation

The integration introduces two layers:

- A C++20 bridge linked to OpenMeta, with a small C-compatible boundary.
- A C++17 OpenImageIO facade that adapts Filesystem::IOProxy and converts decoded values into typed ImageSpec attributes.

This keeps OpenMeta's C++20 types and ABI requirements out of OpenImageIO's C++17 interfaces.

When OpenMeta is enabled, the WebP reader uses it as the sole EXIF/XMP metadata decoder. The legacy WebP EXIF path remains unchanged in builds without OpenMeta.

Metadata projection uses the following precedence:

1. Native typed metadata receives convenient OIIO/EXIF names.
2. Non-conflicting XMP properties receive flat host names.
3. Structured or colliding XMP properties receive canonical names.

For example, a typed EXIF aperture remains available as Exif:ApertureValue, while an XMP property with the same semantic meaning is preserved under its canonical namespace-qualified name.

## Build and packaging

- Supports static and shared OpenImageIO builds.
- Supports embedded static plugins and exported static dependency closure.
- Installs the runtime bridge for shared builds.
- Discovers Highway before OpenMeta to avoid partial Highway target exports introduced through OpenMeta's DNG SDK/JPEG XL dependencies (OpenMeta can be built with a richer configuration when the minimal implementation does not require such libs)
- Keeps USE_OPENMETA disabled by default.

## Tests

Added:

- Unit coverage for the bridge contract, random-access decoding, snapshot serialization, typed value conversion, and resource-limit diagnostics.
- A focused webp-openmeta regression test.
- WebP fixtures containing both raw TIFF and Exif\0\0-prefixed EXIF chunks.
- Coverage for typed EXIF/XMP collisions.
- Coverage for xmpMM:DocumentID and structured XMP history.
- Expected output checks for both EXIF payload variants.

## Scope

This PR only changes WebP metadata reading. WebP pixel decoding and metadata writing are unchanged.

The bridge is intended to allow additional image plugins to adopt OpenMeta incrementally after the WebP integration has established suitable behavior, compatibility, and performance.

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: Codex Sol 5.6 extraHigh and Astra extraHigh`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
