### PR TITLE
docs: strip quote-box styling from indented supplementary content

### DIFF
--- a/src/doc/.gitignore
+++ b/src/doc/.gitignore
@@ -8,4 +8,6 @@
 /openimageio.ind
 _markdown_openimageio/
 _minted-openimageio/
-_static/
+_static/*
+!_static/css/
+!_static/css/custom.css

--- a/src/doc/_static/css/custom.css
+++ b/src/doc/_static/css/custom.css
@@ -1,0 +1,12 @@
+/* Our Markdown source uses ">" blockquotes purely to indent supplementary
+ * material (result-as-parameter variants, examples, usage synopses) under a
+ * function or command description -- not as actual quoted text. Furo's
+ * default blockquote style adds a shaded background and left border, which
+ * makes that material look like a quotation. Strip the quote decoration but
+ * keep the indentation. */
+blockquote {
+    background: transparent;
+    border-left: none;
+    margin: 0;
+    padding: 0 0 0 1.5rem;
+}

--- a/src/doc/conf.py
+++ b/src/doc/conf.py
@@ -115,6 +115,7 @@ html_theme = 'furo'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = ['css/custom.css']
 
 
 # Breathe options


### PR DESCRIPTION
This has bugged me for a long time, and now it's finally fixed!

Furo's default blockquote style adds a shaded background and left border. Markdown docs use ">" blockquotes purely to indent supplementary material (result-as-parameter variants, examples, usage synopses), not as actual quotations, so this made them look quoted. Custom stylesheet keeps the indentation but drops the quote styling.

Assisted-by: Claude Code / Sonnet 5
